### PR TITLE
Agent configuration and research findings for the TypeScript port

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent instructions
+
+This repo's agent configuration lives in [CLAUDE.md](./CLAUDE.md). Read that file — it is the single source of truth regardless of which agent tool you are.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# Irudd.Piploy
+
+Registers a git repo + docker commands to run a service, and makes sure they are always running. Runs as a background daemon on a Raspberry Pi.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live as GitHub issues in `alundgren/Irudd.Piploy`, managed with the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical triage roles, each label string equal to its name. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/research/arm64-packaging.md
+++ b/docs/research/arm64-packaging.md
@@ -1,0 +1,196 @@
+# Shipping a TypeScript daemon to linux-arm64 (Raspberry Pi)
+
+Research for [issue #6](https://github.com/alundgren/Irudd.Piploy/issues/6). Dev box is macOS/arm64, target is a Raspberry Pi running 64-bit Raspberry Pi OS under systemd, package manager is pnpm.
+
+There was no existing convention for research notes in this repo, so this file starts `docs/research/`.
+
+All claims below are cited to the source that owns them. Numbers marked **(measured)** were obtained by downloading the actual release artifacts on 2026-08-02; everything else is a documented claim, not a measurement.
+
+---
+
+## Recommendation
+
+**Bundle to one JS file with esbuild/tsup, install Node on the Pi, and ship `piploy.js` + a systemd unit. Treat Node SEA as an upgrade you can take later without redoing any work.**
+
+The reason this is the right shape rather than a cop-out: **a SEA takes a single bundled JS file as its `main`.** Node's SEA config is `{ "main": "/path/to/bundled/script.js", "output": ... }`, and the docs are explicit that by default only built-in modules can be resolved at runtime, so the entry must already be bundled ([Node.js SEA docs](https://nodejs.org/api/single-executable-applications.html)). So the bundler step is not an alternative to SEA — it is step one of SEA. Doing it first costs nothing and buys a decision you can defer until the git/Docker library question (below) is settled.
+
+Concretely:
+
+1. `tsup`/`esbuild` → `dist/piploy.cjs`, one file, CommonJS.
+2. `scp dist/piploy.cjs pi:/home/<user>/Piploy/`, `systemctl restart piploy`.
+3. Unit's `ExecStart` becomes `/usr/bin/node /home/<user>/Piploy/piploy.cjs service-start`.
+4. If and when the single-binary workflow is missed, add `node --build-sea sea-config.json` pointing `main` at the same `dist/piploy.cjs`. Nothing else changes.
+
+**What this gives up:** one extra thing installed on the Pi (Node), and the artifact is not `chmod +x`-able on its own. **What it buys:** the deploy artifact is ~1 MB instead of ~150 MB, stack traces are real, you can `node --inspect` on the Pi, and the packaging decision stops blocking on the native-module question.
+
+**Bun and Deno are not recommended**, not because their compile story is worse — Bun's is actually the best of the three — but because they swap the runtime out from under a daemon whose whole job is talking to Unix sockets and child processes. That is a compatibility surface you would be paying for forever to save one `apt install`. Detail in the per-option sections.
+
+---
+
+## The native-module question, answered both ways
+
+This is the load-bearing unknown, so take it first.
+
+### Fact 1: the libraries most likely to be picked are pure JS
+
+Checked directly against the npm registry (`npm view <pkg> dependencies gypfile`) on 2026-08-02:
+
+| Package | Native? | Evidence |
+|---|---|---|
+| `dockerode` 5.0.1 | **No** | No `gypfile`. Deps are `docker-modem`, `@grpc/grpc-js`, `protobufjs`, `tar-fs`, `@balena/dockerignore`. `@grpc/grpc-js` self-describes as "gRPC Library for Node - **pure JS** implementation". |
+| `simple-git` 3.36.0 | **No** | Deps are all JS helpers; it shells out to the `git` binary. |
+| `isomorphic-git` 1.40.0 | **No** | Pure JS deps (`pako`, `sha.js`, `crc-32`, …). |
+| `nodegit` 0.27.0 | **Yes** | Depends on `nan`, `node-gyp`, `node-pre-gyp`. |
+
+So the native-module risk is concentrated almost entirely in one choice: `nodegit`. If the parallel git/Docker research lands on `dockerode` + (`simple-git` or `isomorphic-git`), **this whole section is moot** and every packaging option below stays open.
+
+### Fact 2: ABI stability does not save you across architectures
+
+Node-API guarantees that an addon compiled for one Node major version runs on later majors "without recompilation" ([Node-API docs](https://nodejs.org/api/n-api.html)). That stability is **across Node versions only**. The same docs point at `node-pre-gyp`/`prebuild`/`prebuildify` precisely because a separate binary is still needed per OS and per architecture. A `.node` file built on your Mac is `darwin/arm64` and will not load on the Pi.
+
+### Fact 3: pnpm can fetch foreign-arch binaries without a Pi
+
+`supportedArchitectures` lets you "specify architectures for which you'd like to install optional dependencies, even if they don't match the architecture of the system running the install", with `os`, `cpu` and `libc` keys ([pnpm dependency-resolution settings](https://pnpm.io/settings/dependency-resolution)). So:
+
+```yaml
+supportedArchitectures:
+  os: [linux, current]
+  cpu: [arm64, current]
+  libc: [glibc]
+```
+
+This works for packages that ship **prebuilt** arm64 binaries as optional deps. It does **not** work for packages that compile in a `postinstall` (`nodegit` does), because there is no arm64 toolchain on the Mac.
+
+### If the libraries are pure JS
+
+- **Cross-compilation is a non-problem for every option.** JS is architecture-neutral; the only per-arch thing is the runtime, and all three runtimes ship official linux-arm64 builds.
+- Node SEA cross-builds cleanly (see below), Bun and Deno cross-compile by design, and the bundler option has nothing to cross-compile at all.
+- **This is the world to plan for.** Pick on ergonomics, not on native-module contortions.
+
+### If the git or Docker library turns out to be native
+
+Ranked easiest to hardest:
+
+1. **Bundler + Node on the Pi — easiest.** Two escape hatches: ship `node_modules/<pkg>` alongside the bundle with an arm64 prebuild pulled via `supportedArchitectures`, or run `pnpm rebuild` on the Pi where the toolchain and the target arch are the same thing. Nothing about the packaging changes. Note that esbuild/tsup must then mark the native package `external` — you cannot bundle a `.node` into a JS file.
+2. **Container — also easy, structurally.** `docker buildx build --platform linux/arm64` builds the addon on (an emulation of) the target platform, so `postinstall` compilation works without a cross-toolchain. `node` official images publish `arm64v8` for both `bookworm` and `alpine` variants ([docker-library/official-images `library/node`](https://github.com/docker-library/official-images/blob/master/library/node)).
+3. **Node SEA — possible but manual.** Native addons are supported by declaring them in the `assets` field, then at runtime writing the asset to a temp file and calling `process.dlopen()` — the docs spell out exactly this dance ([Node.js SEA docs](https://nodejs.org/api/single-executable-applications.html)). You are hand-writing extraction code, and the addon must already be an arm64 `.node`. There is also a pointed caveat: *"if the single-executable application is produced by postject running on a Linux arm64 docker container, the produced ELF binary does not have the correct hash table to load the addons and will crash on `process.dlopen()`. Build the single-executable application on other platforms, or at least on a non-container Linux arm64 environment to work around this issue."* Building on macOS avoids that specific trap; building in an arm64 CI container walks straight into it.
+4. **Bun — plausible, with a live bug.** Bun "implements this interface from scratch, so **most** existing Node-API extensions work with Bun out of the box" ([Bun Node-API docs](https://bun.com/docs/api/node-api)) — "most" is doing work in that sentence. `bun build --compile` can embed `.node` files, but with a caveat: *"If you're using `@mapbox/node-pre-gyp` or similar tools, the `.node` file must be required directly or it won't bundle correctly"* ([Bun executables docs](https://bun.com/docs/bundler/executables)) — and `node-pre-gyp` is exactly what `nodegit` uses. There is also an open regression, [oven-sh/bun#26045](https://github.com/oven-sh/bun/issues/26045), where `--compile` with multiple NAPI modules mixes their exports. Additionally, nothing in Bun's docs states that a *foreign-architecture* `.node` is embedded correctly when cross-compiling; cross-compilation and native embedding are documented separately and I found no primary source that they compose.
+5. **Deno — most constrained.** `deno compile` gained FFI and Node native addon support in 2.3: *"Deno 2.3 extends `deno compile` to support programs that use Foreign Function Interface (FFI) and Node native add-ons"* ([Deno 2.3 release notes](https://deno.com/blog/v2.3)). But it requires a real `node_modules/` directory (`nodeModulesDir: "auto"|"manual"`) plus `--allow-ffi`, and Deno does not run npm lifecycle scripts by default for security reasons — which is how most native addons obtain their binding ([deno compile docs](https://docs.deno.com/runtime/reference/cli/compile/), [Node/npm compatibility](https://docs.deno.com/runtime/fundamentals/node/)).
+
+**Bottom line:** if a native module lands, options 1 and 2 barely notice and options 3–5 all become projects. That asymmetry is a real argument for the recommendation even before ergonomics are considered.
+
+---
+
+## Option 1: Node SEA
+
+**Status.** *"Stability: 1.1 - Active development"* ([Node.js SEA docs](https://nodejs.org/api/single-executable-applications.html)). Added in v19.7.0/v18.16.0; the one-step `node --build-sea <config>` flag landed in **v25.5.0**, replacing the older manual `npx postject` dance. Same doc lists CI coverage as Windows, macOS arm64, and *"Linux (all distributions supported by Node.js except Alpine and all architectures supported by Node.js except s390x)"* — so linux-arm64 is a regularly tested target.
+
+**Cross-compiling from macOS: yes, with one setting.** Two mechanics make it work:
+
+- The config takes an `executable` key — *"Optional, if not specified, uses the current Node.js binary"* — so you point it at a downloaded `node-vX-linux-arm64` binary instead of your Mac's.
+- Injection is done by [postject](https://github.com/nodejs/postject), which per its own README injects into *"Mach-O, PE, ELF"* and is built with Emscripten (CMake + Ninja + emsdk, output is `dist/main.js`). It is a WASM/JS tool, not a native host tool, so it manipulates an aarch64 ELF from a macOS host without needing a cross-toolchain.
+
+The documented constraint: *"When generating cross-platform SEAs (e.g., generating a SEA for `linux-x64` on `darwin-arm64`), `useCodeCache` and `useSnapshot` must be set to false to avoid generating incompatible executables. Since code cache and snapshots can only be loaded on the same platform where they are compiled, the generated executable might crash on startup."* Both default to `false` anyway, so the practical cost is that **you forfeit the startup optimisation that is SEA's main runtime advantage over plain `node script.js`**. If startup on the Pi ever matters, the fix is to run the SEA build *on the Pi* with `useCodeCache: true` — which is a strictly larger deploy pipeline.
+
+Also relevant: `useSnapshot` cannot be combined with `"mainFormat": "module"`, and with `useCodeCache: true` dynamic `import()` does not work. ESM is supported via `"mainFormat": "module"`, but `import.meta.resolve` is unavailable and `import()` can only load built-ins — another reason to bundle to CJS.
+
+**Disk (measured).** The SEA output is a copy of the Node binary with a blob appended. `node-v26.5.1-linux-arm64/bin/node` is **148,303,152 bytes (~141 MiB)**, `ELF 64-bit LSB executable, ARM aarch64 … not stripped, with debug_info`. So expect a ~141 MiB artifact over `scp` on every deploy. (For comparison, the whole `node-v26.5.1-linux-arm64` tarball is 31 MB compressed / 232 MB extracted, of which 62 MB is `include/` headers you would never ship.)
+
+**Startup.** Not measured on a Pi. Structurally it is the same V8 + same bundled script as plain Node, so with code cache disabled expect parity with `node piploy.js`, not an improvement.
+
+**Verdict.** The genuine spiritual successor to `dotnet publish --self-contained -p:PublishSingleFile=true`, and cross-building from the Mac works. Held back only by Stability 1.1 and a ~141 MiB artifact. **Adopt it second, once the library question is closed** — it slots onto the recommended bundle with no rework.
+
+## Option 2: `bun build --compile`
+
+**Cross-compilation: best in class.** *"Use the `--target` flag to compile your standalone executable for a different operating system, architecture, or version of Bun than the machine you're running `bun build` on."* `bun-linux-arm64` and `bun-linux-arm64-musl` are both listed targets ([Bun executables docs](https://bun.com/docs/bundler/executables)). So `bun build --compile --target=bun-linux-arm64 --minify --bytecode ./src/index.ts --outfile piploy` from macOS is a documented one-liner. No arch caveats apply on ARM (the AVX2/`-baseline` business is x64-only).
+
+**Startup.** `--bytecode` *"moves parsing overhead for large input files from runtime to bundle time"*, with a claimed 2x faster startup for a workload like `tsc` (same doc). Unlike SEA's code cache, nothing in the docs says `--bytecode` is incompatible with cross-compilation. For a daemon that starts once and runs forever, this is close to irrelevant anyway.
+
+**Disk (measured).** `bun-linux-aarch64` from release `bun-v1.3.14` is **91,801,560 bytes (~88 MiB)** — the smallest of the three single-binary options, and that is the floor your compiled artifact sits on.
+
+**Requirements.** *"Bun's glibc binaries require glibc 2.17 or newer"* and *"Kernel version 5.6 or higher is recommended; Bun runs on kernels as old as 3.10"* ([Bun installation docs](https://bun.com/docs/installation)). Raspberry Pi OS is Debian-based and the current release is on Debian Trixie ([Raspberry Pi OS docs](https://www.raspberrypi.com/documentation/computers/os.html)), far above both floors. 64-bit Pi OS covers Pi 3, 4 and 5.
+
+**What you give up.** The runtime. Bun's own compatibility table rates `node:net` *"🟢 Fully implemented"* (good — that is the Docker Unix socket path) but `node:child_process` only partially: *"Missing `proc.gid` `proc.uid`. `Stream` class not exported. IPC cannot send socket handles"* ([Bun Node.js API compatibility](https://bun.com/docs/runtime/nodejs-apis)). A deploy daemon that shells out to `git` and `docker` lives in `child_process`. None of the listed gaps are obviously fatal, but the list is a moving target and you would be validating it yourself on every upgrade.
+
+**Verdict.** Technically the smoothest cross-compile of the three, and the smallest binary. Rejected only on runtime risk: adopting Bun means every future Node-ecosystem library is a compatibility question. Reasonable to revisit if the daemon stays small and the deps stay boring.
+
+## Option 3: `deno compile`
+
+**Cross-compilation: officially supported.** *"Deno supports cross compiling to all targets regardless of the host platform"*, with `aarch64-unknown-linux-gnu` in the target list. Mechanically, `--target` downloads and caches a platform-specific `denort` (stripped runtime) binary, after which builds work offline ([deno compile docs](https://docs.deno.com/runtime/reference/cli/compile/)).
+
+**Disk (measured).** `denort-aarch64-unknown-linux-gnu` from `v2.9.4` unpacks to **108,766,096 bytes (~104 MiB)**. `--bundle` + `--minify` tree-shake your code but do not shrink that floor.
+
+**What you give up.** The npm interop is the weak point for this use case. Per the compile docs, non-statically-analyzable dynamic imports and computed worker URLs are dropped unless passed via `--include`, and CJS packages plus `.node` addons need special handling. Deno also does not run lifecycle scripts by default. `node:child_process` is "partially supported" with Deno 2.7 improvements noted, and `node:net` is partial (`fd` option unsupported) ([Node/npm compatibility](https://docs.deno.com/runtime/fundamentals/node/)).
+
+**Verdict.** No advantage over Bun for this project — bigger binary, more npm friction — and the same runtime-swap risk. Rejected.
+
+## Option 4: Bundler + Node on the Pi (recommended)
+
+**Cross-compilation: not applicable.** esbuild/tsup emit portable JavaScript. The only per-arch artifact is Node itself, and nodejs.org ships official `linux-arm64` builds for every current release (`node-v26.5.1-linux-arm64.tar.xz`, 31,021,640 bytes over the wire; **measured** 232 MB extracted, 153 MB of which is `bin/`).
+
+**Deploy shape.** Two artifacts instead of one — but only one of them changes per deploy, and it is ~1 MB rather than ~141 MiB. Installing Node is a one-time `tar -xJf` into `/usr/local` (or the distro package). The systemd unit in `README.md` needs `ExecStart=/usr/bin/node /home/<user>/Piploy/piploy.cjs service-start`; everything else in that unit is unchanged.
+
+**Startup and disk.** Identical runtime to Option 1, so identical startup, at ~150 MB resident on disk for Node — the same bytes Option 1 would ship on *every* deploy, paid once.
+
+**Debuggability.** This is the real win. `node --inspect`, `node --stack-trace-limit`, source maps that resolve, and the ability to `node -e` against your own bundle on the Pi when something misbehaves at 11pm. None of the compiled options give you that without rebuilding.
+
+**Verdict.** Recommended. Also the option that keeps every other option open.
+
+## Option 5: piploy in a container
+
+**Shape.** `docker buildx build --platform linux/arm64` from the Mac (buildx handles the cross-build; `node` official images publish `arm64v8` per [docker-library/official-images](https://github.com/docker-library/official-images/blob/master/library/node)), push or `docker save`/`scp`/`docker load`, then run with `-v /var/run/docker.sock:/var/run/docker.sock`.
+
+**The security cost is real and documented.** Docker's own post-install guide states flatly: *"The `docker` group grants root-level privileges to the user."* ([Docker post-install docs](https://docs.docker.com/engine/install/linux-postinstall/)), and the daemon-protection page makes the same point about daemon credentials: *"anyone with the keys can give any instructions to your Docker daemon, giving them root access to the machine hosting the daemon"* ([Protect the Docker daemon socket](https://docs.docker.com/engine/security/protect-access/)). Worth noting honestly: **piploy already needs this privilege**, container or not — it exists to drive Docker. Containerising does not add a new capability, it just relocates where the socket is mounted.
+
+**Bootstrapping.** Something must start the container and restart it on boot. systemd still does that (`ExecStart=/usr/bin/docker run --rm ...` or a `docker compose` unit), so systemd does not go away; you gain a layer rather than removing one.
+
+**Verdict.** Not the first move — it makes routine debugging harder (`docker logs` instead of `journalctl`, exec into a container to poke at a git checkout) for benefit you do not collect until self-deploy exists. But see below.
+
+---
+
+## Which options help the future "piploy redeploys itself" story
+
+Not in scope to build, but cheap to prefer.
+
+- **Container (Option 5) — clearly easiest.** Self-redeploy becomes "pull a new image tag and recreate the container", which is *literally the thing piploy already does for every other service*. No new mechanism at all. This is the strongest argument in Option 5's favour and the reason it should stay on the table as a phase 2.
+- **Bundler + Node (Option 4) — easy.** Replacing a `.js` file has no OS-level restriction; write the new file, `systemctl restart piploy`. The daemon can even stage the file and exit, letting `Restart=always` in the existing unit pick it up.
+- **Single-binary options (1–3) — mildly awkward.** Linux refuses to write to the file of a running executable (`ETXTBSY`), so self-replacement must be `rename()`-then-write, not overwrite-in-place. This is a well-known, solvable pattern, but it is code you have to get right, and the artifact being ~88–141 MiB makes the transfer itself a more serious operation.
+
+---
+
+## Summary table
+
+| | Cross-build from macOS | Artifact on the wire | Disk on Pi | If native module | Self-redeploy | Debuggability |
+|---|---|---|---|---|---|---|
+| **Bundler + Node** ✅ | N/A (portable JS) | ~1 MB | ~150 MB (once) | Easy (`pnpm rebuild` or arm64 prebuild) | Easy | Best |
+| **Node SEA** | Yes, `executable` + postject; no code cache | ~141 MiB (measured) | ~141 MiB | Manual `assets` + `process.dlopen()` | ETXTBSY dance | Poor |
+| **Bun compile** | Yes, `--target=bun-linux-arm64` | ~88 MiB floor (measured) | ~88 MiB | Docs unclear for foreign-arch `.node`; open bug #26045 | ETXTBSY dance | Poor |
+| **Deno compile** | Yes, all targets | ~104 MiB floor (measured) | ~104 MiB | Needs `node_modules` + `--allow-ffi`, no lifecycle scripts | ETXTBSY dance | Poor |
+| **Container** | Yes, buildx `--platform linux/arm64` | image layers | image + Node layer | Easiest (builds on target platform) | Easiest | Medium |
+
+## Open items this research could not close
+
+- **Startup time on actual Pi hardware was not measured** — no device available to this investigation. All three compiled options run the same class of JS engine; the only documented startup lever that survives cross-compilation is Bun's `--bytecode`. If startup ever matters, measure on the device rather than trusting any of this.
+- **Whether Bun correctly embeds a foreign-architecture `.node` when cross-compiling** is not addressed by any primary source I could find. Treat as unknown, not as "works".
+- The git/Docker library choice is being decided in parallel; if it lands on `nodegit`, re-read the "if native" section before committing to a packaging option.
+
+## Sources
+
+- [Node.js — Single Executable Applications](https://nodejs.org/api/single-executable-applications.html)
+- [Node.js — Node-API](https://nodejs.org/api/n-api.html)
+- [nodejs/postject README](https://github.com/nodejs/postject/blob/main/README.markdown)
+- [Node.js downloads index](https://nodejs.org/dist/index.json)
+- [Bun — Single-file executable](https://bun.com/docs/bundler/executables)
+- [Bun — Node-API](https://bun.com/docs/api/node-api)
+- [Bun — Node.js API compatibility](https://bun.com/docs/runtime/nodejs-apis)
+- [Bun — Installation / system requirements](https://bun.com/docs/installation)
+- [oven-sh/bun#26045 — `--compile` mixes multiple NAPI module exports](https://github.com/oven-sh/bun/issues/26045)
+- [Deno — `deno compile`](https://docs.deno.com/runtime/reference/cli/compile/)
+- [Deno — Node and npm compatibility](https://docs.deno.com/runtime/fundamentals/node/)
+- [Deno 2.3 release notes](https://deno.com/blog/v2.3)
+- [pnpm — dependency resolution settings (`supportedArchitectures`)](https://pnpm.io/settings/dependency-resolution)
+- [Docker — Linux post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/)
+- [Docker — Protect the Docker daemon socket](https://docs.docker.com/engine/security/protect-access/)
+- [docker-library/official-images — `library/node`](https://github.com/docker-library/official-images/blob/master/library/node)
+- [Raspberry Pi OS documentation](https://www.raspberrypi.com/documentation/computers/os.html)
+- npm registry metadata for `dockerode`, `simple-git`, `isomorphic-git`, `nodegit`, `@grpc/grpc-js` (via `npm view`, 2026-08-02)

--- a/docs/research/ts-docker-client.md
+++ b/docs/research/ts-docker-client.md
@@ -1,0 +1,382 @@
+# Which Docker client should the TypeScript port use?
+
+Research for [issue #5](https://github.com/alundgren/Irudd.Piploy/issues/5). Target: linux-arm64 Raspberry Pi, daemon over the
+local unix socket. Docker Compose is out of scope, so a daemon-API client is viable.
+
+All version-specific claims are as of 2026-08-02, against dockerode 5.0.1, docker-modem 5.0.7 and `@types/dockerode` 4.0.1.
+
+Claims marked **(verified)** were run end to end against a real daemon — Docker Engine **29.2.1, API 1.53 (minimum 1.44),
+`linux/arm64`** (colima on an M-series Mac). That daemon is the same OS/arch as the Pi, so the build, run and error-string
+behaviour below is observed on the target architecture, not inferred. It is *not* the Pi's actual daemon version — see
+"Open items".
+
+## Recommendation
+
+**Use `dockerode`.** It covers every operation `PiployDockerService` and `PiployDockerCleanupService` perform, I verified
+all of them end to end on linux/arm64, and it is the only maintained option in this space.
+
+**dockerode is pure JavaScript** — no `gypfile`, no build step of its own — **but its dependency tree pulls one native,
+optional addon.** `dockerode` → `docker-modem` → `ssh2` → optional `cpu-features` (+ `nan`), which has a `binding.gyp` and
+compiles at install time. It is declared in `ssh2`'s `optionalDependencies` and `ssh2` requires it inside a bare
+`try {} catch {}`, so a failed build is not an install failure and the library works without it — I confirmed this by
+deleting `node_modules/cpu-features` and successfully calling the daemon **(verified)**. So for the packaging decision:
+**treat dockerode as pure JS, with the caveat that a compile will be attempted on the Pi unless you suppress it.**
+This corrects `arm64-packaging.md`, which recorded dockerode as having no native dependency — true of the package itself,
+not of its transitive tree.
+
+The tradeoff, stated plainly: **dockerode's runtime is excellent and its types are third-party and wrong in three places
+that this port hits directly.** `@types/dockerode` is DefinitelyTyped, not shipped by the project (dockerode's own
+`package.json` has no `types` field). It rejects a multi-tag build, rejects a `Buffer` build context, and does not know
+about `docker.followProgress` at all — the exact method you need to read BuildKit output. All three work at runtime. You
+will be writing a small typed façade with a couple of `as any` escapes behind it. That is the whole cost, and it is
+cheap relative to hand-rolling the HTTP layer.
+
+The sharpest single finding: **`modem.followProgress` silently returns undecodable base64 protobuf when the build uses
+BuildKit.** Port `ProgressTracer` onto `docker.followProgress` instead. Details below — this is the one that would
+otherwise be discovered at 11pm on the Pi.
+
+## The operations that must be covered
+
+From `Irudd.Piploy.App/PiployDockerService.cs` and `PiployDockerCleanupService.cs`:
+
+| Docker.DotNet today | dockerode equivalent | Status |
+| --- | --- | --- |
+| `Images.BuildImageFromDockerfileAsync(params, tarStream, ...)` | `docker.buildImage(tarStreamOrBuffer, opts)` | Direct **(verified)** |
+| `ImageBuildParameters.Tags` (3 tags) | `opts.t = ['a:latest','a:g_…','a:v_…']` | Works at runtime; **types reject it** |
+| `ImageBuildParameters.Labels` | `opts.labels = { … }` | Direct **(verified)** |
+| `ImageBuildParameters.Dockerfile = "<bare name>"` | `opts.dockerfile = '<bare name>'` | Direct **(verified)** |
+| `ProgressTracer : IProgress<JSONMessage>` | `docker.followProgress(stream, onDone, onEvent)` | Direct, **not** `modem.followProgress` |
+| `Images.ListImagesAsync(Filters { reference })` | `docker.listImages({ filters: { reference: ['…'] } })` | Direct **(verified)** |
+| `Containers.ListContainersAsync(Filters { name })` | `docker.listContainers({ filters: { name: ['…'] } })` | Direct **(verified)** |
+| label filters for cleanup | `{ filters: { label: ['piploy_isCreatedByTest=true'] } }` | Direct **(verified)** |
+| `CreateContainerParameters` + `HostConfig.PortBindings`/`AutoRemove`, `ExposedPorts`, `Name` | `docker.createContainer({ Image, name, ExposedPorts, HostConfig: { PortBindings, AutoRemove } })` | Direct **(verified)** |
+| `Containers.StartContainerAsync` | `container.start()` | Direct **(verified)** |
+| `Containers.RemoveContainerAsync(Force = true)` | `container.remove({ force: true })` | Direct **(verified)** |
+| `Containers.StopContainerAsync` | `container.stop()` | Direct |
+| `Images.DeleteImageAsync(Force = true)` | `docker.getImage(idOrTag).remove({ force: true })` | Direct **(verified)** |
+| `Images.PruneImagesAsync(Filters { dangling })` | `docker.pruneImages({ filters: { dangling: ['true'] } })` | Direct **(verified)** |
+| `DockerApiException` → "port is already allocated" | thrown `Error` with `.statusCode` / `.json` / `.message` | Direct **(verified)** — see below |
+
+### Verified end-to-end
+
+One script built a real image from an in-memory tar with three tags and five labels, filtered it back out of the daemon,
+created and started a named container with a port binding and `AutoRemove`, provoked the port clash, force-removed, and
+pruned:
+
+```
+== tar built, bytes = 3072
+== build progress events = 47
+{"stream":"Step 1/9 : FROM alpine:3.20"}
+  ...
+{"stream":"Successfully tagged piploy/probeapp:latest\n"}
+{"stream":"Successfully tagged piploy/probeapp:g_abc123def456\n"}
+{"stream":"Successfully tagged piploy/probeapp:v_aaaa-bbbb-cccc\n"}
+== listImages reference filter => 1 sha256:6f701be03cb2
+   RepoTags: ["piploy/probeapp:g_abc123def456"]
+   Labels  : {"piploy_appName":"probeapp","piploy_buildDate":"…","piploy_gitTipCommit":"abc123def456",
+              "piploy_isCreatedByTest":"true","piploy_uniqueId":"aaaa-bbbb-cccc"}
+== listImages label filter => 2
+== container created+started f1b9b19a8837c16a8c4
+== listContainers name filter => 1 running ["/piploy_probeapp"]
+== force removed
+== prune dangling => {"ImagesDeleted":null,"SpaceReclaimed":0}
+```
+
+So the whole `PiployDockerService` shape maps over without contortion.
+
+## Building from a tar'd context — what replaces `TarFile.CreateFromDirectoryAsync`
+
+There are two routes, and **you probably do not need a tar library at all.**
+
+**Route A — let dockerode pack the directory.** `buildImage` accepts `{ context, src }` instead of a stream;
+`util.prepareBuildContext` then packs with the bundled `tar-fs`, applies `.dockerignore` via `@balena/dockerignore`, and
+gzips the result before sending. Verified with a nested context and a non-default Dockerfile name **(verified)**:
+
+```
+build ok, events 36 | COPY worked: true
+tags ["piploy/ctxsrc:1"]
+labels {"piploy_appName":"ctxsrc","piploy_isCreatedByTest":"true"}
+```
+
+This is strictly *more* than the C# does today — the dotnet version does not honour `.dockerignore` at all, since
+`TarFile.CreateFromDirectoryAsync` tars everything. **Sharp edge:** `src` is not optional despite reading like it should
+be. `lib/util.js` does `const entries = file.src.slice() || []` inside an `fs.readFile` callback, so omitting `src`
+throws a `TypeError` that is *not* routed into the returned promise — it crashes the process **(verified)**. Always pass
+`src: fs.readdirSync(context)`.
+
+**Route B — hand-build the tar.** If you want byte-level control (or to keep parity with today's "tar everything"
+behaviour), `tar-stream` is already in the tree as a transitive dependency of `tar-fs`, and `buildImage` accepts a raw
+`Buffer` or `Readable`: `docker-modem` passes `options.file` straight through and sets `Content-Type: application/tar`.
+Verified with a hand-rolled `tar.pack()` walk of the context directory **(verified)** — that is the direct equivalent of
+the C# `MemoryStream` + `TarFile` pair.
+
+Either way the `Dockerfile` handling is identical to C#: the tar's root is the build context, and `dockerfile` is the
+bare filename. The Engine API says the `Dockerfile` "is typically in the archive's root, but can be at a different path
+or have a different name by specifying the `dockerfile` parameter"
+([Engine API `/build`](https://docs.docker.com/reference/api/engine/version/v1.51/#tag/Image/operation/ImageBuild)).
+Verified with `dockerfile: 'Dockerfile.custom'` and a `COPY sub/x.txt` from a nested directory **(verified)**.
+
+**Recommendation: Route A.** No extra dependency, and you get `.dockerignore` for free.
+
+## Multiple tags on one build
+
+The API supports it — `t` is "A name and optional tag to apply to the image in the `name:tag` format. … You can provide
+several `t` parameters" (swagger `/build`). `docker-modem`'s `buildQuerystring` passes arrays through to
+`querystring.stringify`, which emits the repeated form; only non-array objects get `JSON.stringify`'d. Observed directly:
+
+```
+t=piploy%2Fa%3Alatest&t=piploy%2Fa%3Ag_abc&t=piploy%2Fa%3Av_guid&dockerfile=Dockerfile
+  &labels=%7B%22piploy_appName%22%3A%22a%22%2C%22piploy_gitTipCommit%22%3A%22abc%22%7D
+```
+
+All three tags landed on one image **(verified)** — the build log ends with three `Successfully tagged` lines.
+
+**But `@types/dockerode` declares `t?: string | undefined`.** `tsc --strict` on the exact call the port needs:
+
+```
+tcheck2.ts(6,27): error TS2769: No overload matches this call.
+    Type 'string[]' is not assignable to type 'string'.
+```
+
+This is the first of the three typing gaps. Runtime is fine; the type is wrong.
+
+## Streaming build progress — the BuildKit trap
+
+`ProgressTracer` today just serialises each `JSONMessage` into the logger. The naive TS port is
+`docker.modem.followProgress(stream, done, ev => logger.info(JSON.stringify(ev)))`, and against the **classic** builder
+that works exactly like the C# — `{"stream":"Step 1/9 : FROM alpine:3.20"}` and friends **(verified)**.
+
+Against **BuildKit** (`version: '2'`) it produces garbage. Same build, both callbacks, side by side **(verified)**:
+
+```
+== modem.followProgress -> 27 events
+[{"id":"moby.buildkit.trace","aux":"Cm8KR3NoYTI1NjoxMTk2OTZlNWQxMzk2MTM0MzBmYTEyNTM2ZmMyZDM3ZjllMmI5MmI2…"}, …]
+   contains BUILD-STEP-MARKER: false
+
+== docker.followProgress -> 11 events
+[{"stream":"[sha256:27a1f] [internal] load remote build context\n"},
+ {"stream":"CACHED: copy /context /\n"},
+ {"stream":"[sha256:60f80] [1/2] FROM docker.io/library/alpine:3.20@sha256:d9e853e8…\n"}, …]
+   contains BUILD-STEP-MARKER: true
+```
+
+`RUN echo BUILD-STEP-MARKER` is visible through one and invisible through the other. dockerode 5 added
+`lib/buildkit.js`, which decodes the `moby.buildkit.trace` `aux` field as a `moby.buildkit.v1.StatusResponse` protobuf
+and reformats it into `{ stream: … }` events — that is what `protobufjs` and `@grpc/proto-loader` are in the dependency
+list for. `Docker.prototype.followProgress` delegates to it; `Modem.prototype.followProgress` does not.
+
+**`@types/dockerode` 4.0.1 does not declare `Dockerode.followProgress`** — typing gap two:
+
+```
+tcheck.ts(18,5): error TS2339: Property 'followProgress' does not exist on type 'Dockerode'.
+```
+
+So the typed path leads you straight into the broken one. Worth an explicit comment in the port.
+
+**Why this matters even though the API still defaults to the classic builder.** `/build`'s `version` parameter defaults
+to `"1"`, described in the spec itself as "the first generation classic (deprecated) builder". Docker's deprecation page
+is blunter: "This release marks the beginning of the deprecation cycle of the classic ('legacy') builder for Linux
+images. No active development will happen on the classic builder (except for bugfixes)", and the CLI's warning reads
+"DEPRECATED: The legacy builder is deprecated and will be removed in a future release."
+([Deprecated Engine features](https://docs.docker.com/engine/deprecated/)). Piploy can stay on the default for now, but
+the removal is announced, so wire the progress path onto `docker.followProgress` from day one and the eventual flip to
+`version: '2'` is a one-line change. I verified BuildKit builds work through dockerode today, tags and labels included
+**(verified)**.
+
+## Server-side filters
+
+The API takes filters "encoded as JSON (a `map[string][]string`)" — array-of-strings, unlike Docker.DotNet's
+`map[string]map[string]bool`. `docker-modem` JSON-stringifies any non-array object in the query, so the plain object form
+is correct:
+
+```
+filters=%7B%22reference%22%3A%5B%22piploy%2Fa%3Ag_abc%22%5D%7D
+filters=%7B%22name%22%3A%5B%22piploy_a%22%5D%2C%22label%22%3A%5B%22piploy_isCreatedByTest%3Dtrue%22%5D%7D
+```
+
+`reference`, `name` and `label` are all in the documented filter lists for `/images/json` and `/containers/json`, and all
+three returned correctly **(verified)**. `@types/dockerode` gets this one right: `filters?: string | { [key: string]: string[] }`.
+
+Note for the cleanup port: `PiployDockerCleanupService.GetAllPiployImages` fetches *all* images and filters
+`piploy_appName` in memory. dockerode can push that to the daemon as `{ label: ['piploy_appName'] }` (key-only label
+filter is documented). Not required for parity, but it is free.
+
+## Recognising "port is already allocated"
+
+The string is stable and comes from the daemon, not the client. In moby,
+`daemon/libnetwork/portallocator/portallocator.go`:
+
+```go
+func (e alreadyAllocatedErr) Error() string {
+	return fmt.Sprintf("Bind for %s:%d failed: port is already allocated", e.ip, e.port)
+}
+```
+
+Provoked live, with two containers with distinct names binding the same host port **(verified)**:
+
+```
+statusCode: 500
+message   : "(HTTP code 500) server error - failed to set up container networking: driver failed programming external
+             connectivity on endpoint piploy_probe2_b (c0a7b667…): Bind for 0.0.0.0:18081 failed: port is already allocated "
+json      : {"message":"failed to set up container networking: … Bind for 0.0.0.0:18081 failed: port is already allocated"}
+/port is already allocated/ test -> true
+```
+
+The thrown value is a plain `Error` (not a subclass) with own enumerable keys `["reason","statusCode","json"]`. So
+`PiployException.CreatePortAlreadyInUse` ports as a substring test on `err.message`, exactly like the C#
+`ex.Message.Contains("port is already allocated")` — or, slightly better, on `err.json.message`, which is the daemon's
+text without dockerode's `(HTTP code 500) server error - ` prefix.
+
+One incidental finding worth guarding: the failure surfaces on **`start`**, not on `create`, and a *name* clash raises a
+different error first (`statusCode: 409`, "The container name … is already in use"). The C# already removes the existing
+container before creating, so the name clash should not occur — but do not collapse the two branches.
+
+## Volume mounts and other richer `docker run` options
+
+Not foreclosed. `HostConfig.Binds` works through dockerode and is correctly typed — a container run with
+`Binds: ['<hostdir>:/data:ro']` read the mounted file and printed `mounted-ok` **(verified)**. `HostConfig.Mounts`,
+`Env`, `RestartPolicy`, `Memory` and the rest of `HostConfig` are all in the same `ContainerCreateOptions` type. The
+daemon API is the full surface `docker run` itself uses, so anything `docker run` can do is reachable; the only thing
+genuinely out of reach is Compose, which is already out of scope.
+
+(A first attempt at this test failed with "No such file or directory" because the host path was under macOS `/var/folders`,
+which is not shared into the colima VM — a dev-environment artifact, not a dockerode or API limitation. Re-run from a
+shared path it worked.)
+
+## API version
+
+dockerode sends **no version prefix** unless you pass one: `docker-modem` only prepends `'/' + this.version` when
+`opts.version` is set. That works, but the spec says "Using the API without a version-prefix is deprecated and will be
+removed in a future release", and the deprecation page adds "API versions should be supplied to all API calls to ensure
+compatibility with future Engine versions."
+
+Pinning works and is cheap — `new Docker({ version: 'v1.44' })`. Observed against the arm64 daemon **(verified)**:
+
+```
+(no prefix)  -> ApiVersion 1.53 MinAPIVersion 1.44 Version 29.2.1 Arch arm64 linux
+v1.44        -> ApiVersion 1.53 MinAPIVersion 1.44 Version 29.2.1 Arch arm64 linux
+v1.53        -> ApiVersion 1.53 MinAPIVersion 1.44 Version 29.2.1 Arch arm64 linux
+v1.99        -> ERROR 400 "(HTTP code 400) unexpected - client version 1.99 is too new. Maximum supported API version is 1.53 "
+```
+
+Note the floor has moved twice: Docker's deprecation page records the minimum as 1.24 from v25.0, "permanently removed"
+below that in v26 — but the Engine 29.2.1 daemon I tested reports `MinAPIVersion 1.44`. So **pin low, not high**:
+everything piploy uses (`t`, `labels`, `filters`, `PortBindings`, `AutoRemove`, `dangling` prune) long predates 1.44.
+Confirm against the Pi before choosing the exact number — see "Open items".
+
+**Connection.** On the Pi this is a non-issue: `new Docker()` defaults to `/var/run/docker.sock`. On a macOS dev box it
+is a papercut — dockerode reads `DOCKER_HOST` but **does not read `docker context`**, so a colima/Rancher/Docker-Desktop
+setup with a non-default socket needs `DOCKER_HOST` or an explicit `socketPath`. I hit exactly this
+(`connect ENOENT /var/run/docker.sock`) before setting `DOCKER_HOST`. Worth a line in the integration-test setup.
+
+## Maintenance and typing quality — the honest picture
+
+**dockerode.** 4,932 stars, Apache-2.0, last push 2026-07-21, 25 open issues, v5.0.1 released 2026-06-24 and v5.0.0
+2026-04-23. So it is actively released, not coasting. The caveat is a real one: **one maintainer** (`apocas`, who also
+maintains `docker-modem`), and a chunk of recent commit traffic is dependabot. `engines: node >= 14.17`. The code is
+old-style JS — `var`, callbacks with a promise wrapper — which is exactly the "callback-flavoured" character the ticket
+suspected. It works; it is not pretty.
+
+**`@types/dockerode` 4.0.1** (2026-01-21) is DefinitelyTyped, maintained separately from the library, and lags it. Three
+gaps confirmed by `tsc --strict` against the calls this port actually makes:
+
+1. `t?: string` — rejects the multi-tag array that the port requires.
+2. `Dockerode.followProgress` is missing entirely — the BuildKit-decoding method.
+3. `buildImage` does not accept a `Buffer`: *"Argument of type 'Buffer<ArrayBuffer>' is not assignable to parameter of
+   type 'string | ImageBuildContext | ReadableStream'"*. Avoidable by passing a `Readable` (route A or a
+   `Readable.from(buf)`), which is better style anyway.
+
+None are blockers, all are one `as any` or a local `declare module` augmentation. But they are in the *load-bearing*
+calls, not the periphery, which is why the façade recommendation below is not optional decoration.
+
+## The alternatives, and why not
+
+**Hand-rolled HTTP over the unix socket.** Genuinely viable for this narrow a surface — Node's `http` takes `socketPath`
+directly, and piploy touches maybe eight endpoints. But it means owning the chunked NDJSON build-progress parser *and*
+the BuildKit protobuf decoding, which is the one thing dockerode does that is not trivial. Reject unless dockerode
+becomes unmaintained.
+
+**Generate a typed client from the official spec.** Attractive on paper — moby publishes `api/swagger.yaml` (currently
+Engine API 1.55) as a first-party artifact. It does not work with the current toolchain: the file declares
+`swagger: "2.0"`, and `openapi-typescript` 7.13.0 is "Convert OpenAPI **3.0 & 3.1** schemas to TypeScript", with OpenAPI
+2.x "supported with versions `5.x` and previous". So this is a conversion step plus a five-major-versions-old generator,
+and it still leaves you writing the streaming and error layers by hand. Reject.
+
+**`node-docker-api`** (1.1.22) and **`docker-cli-js`** (2.10.0) both last published 2023-06-01 and are dead. `node-docker-api`
+still depends on `docker-modem@^0.3.1` — five majors behind. Reject.
+
+**`testcontainers`** (12.0.4, actively maintained) is not a competitor: it *depends on* `dockerode@^5.0.0` and
+`@types/dockerode@^4.0.1`. Its existence is the strongest available evidence that dockerode 5 is the current, working
+choice — a heavily used library with real CI picked exactly this. It is also a good source of usage patterns, the same
+way `testcontainers-dotnet` is cited in `PiployDockerService.cs` today.
+
+## Suggested shape for the port
+
+A thin typed façade, so the `as any` escapes live in one file and no caller can reach the wrong `followProgress`:
+
+```ts
+import Docker from 'dockerode'
+import fs from 'node:fs'
+
+const docker = new Docker({ version: 'v1.44' }) // pin once the Pi's MinAPIVersion is known
+
+type BuildOpts = { context: string; dockerfile: string; tags: string[]; labels: Record<string, string> }
+
+export async function buildImage(o: BuildOpts, log: (line: string) => void) {
+  const stream = await docker.buildImage(
+    { context: o.context, src: fs.readdirSync(o.context) }, // src is NOT optional
+    { t: o.tags, labels: o.labels, dockerfile: o.dockerfile } as any, // @types says t: string
+  )
+  await new Promise<void>((resolve, reject) =>
+    // docker.followProgress, NOT modem.followProgress — the latter cannot decode BuildKit
+    (docker as any).followProgress(stream, (e: unknown) => (e ? reject(e) : resolve()),
+      (ev: { stream?: string }) => log(JSON.stringify(ev))),
+  )
+}
+
+export function isPortAlreadyInUse(err: unknown): boolean {
+  const m = (err as { json?: { message?: string }; message?: string })
+  return /port is already allocated/.test(m?.json?.message ?? m?.message ?? '')
+}
+```
+
+`EnsureImageExists` then becomes: `listImages({ filters: { reference: [commitTag] } })` → return if found, else
+`buildImage` → re-query. `EnsureContainerRunning` becomes: `listContainers({ filters: { name: [containerName] } })` →
+inspect label/state → `remove({ force: true })` → `createContainer` → `start()` inside a `try` that runs
+`isPortAlreadyInUse`. Same shape as the C# today.
+
+For packaging (issue #6): if you want to avoid the `cpu-features` compile attempt on the Pi, pnpm's
+`onlyBuiltDependencies` / `neverBuiltDependencies` can suppress it, and dockerode still works — proven above. Whether to
+bother is a judgement call for issue #8, but the option exists and costs nothing.
+
+## Open items this research could not close
+
+- **The Pi's actual daemon and API version are unknown** — [issue #2](https://github.com/alundgren/Irudd.Piploy/issues/2)
+  is still open and is a HITL task. Everything here was verified against Engine 29.2.1 / API 1.53 / min 1.44 on
+  linux/arm64, which is a good proxy but not the box. Read the Pi's `MinAPIVersion` before fixing the `version:` pin. If
+  the Pi runs an older Engine, nothing in the operation set is at risk — all of it predates API 1.24 — only the pin
+  number changes.
+- **Whether the classic builder is removed in any currently shipping Engine** is not established. The deprecation is
+  announced and "no active development" is stated, but I found no primary source naming a removal version. Treated as
+  "announced, not scheduled". The mitigation (use `docker.followProgress`) costs nothing either way.
+- **`cpu-features` was observed compiling successfully on darwin/arm64, not on linux/arm64.** It is optional and
+  dockerode demonstrably runs without it, so a failure is harmless — but I have not watched it build on a Pi, and cannot
+  say whether it succeeds there or merely fails quietly.
+- **Nothing was tested against a low-memory device.** Building images on a Pi is a Pi question, not a client question,
+  but it is the kind of thing that only shows up on the target.
+
+## Sources
+
+Primary sources only; every claim above traces to one of these.
+
+- `Irudd.Piploy.App/PiployDockerService.cs`, `PiployDockerCleanupService.cs` — this repo
+- [Docker Engine API reference](https://docs.docker.com/reference/api/engine/) and [`moby/moby` `api/swagger.yaml`](https://github.com/moby/moby/blob/master/api/swagger.yaml) (Engine API 1.55) — `/build`, `/images/json`, `/containers/json`, `/containers/create`, versioning preamble
+- [Docker — Deprecated Engine features](https://docs.docker.com/engine/deprecated/) — legacy builder, unversioned API requests, minimum API version
+- moby source: [`daemon/libnetwork/portallocator/portallocator.go`](https://github.com/moby/moby/blob/master/daemon/libnetwork/portallocator/portallocator.go) — the "port is already allocated" string
+- dockerode source: [`lib/docker.js`](https://github.com/apocas/dockerode/blob/master/lib/docker.js), [`lib/util.js`](https://github.com/apocas/dockerode/blob/master/lib/util.js), [`lib/buildkit.js`](https://github.com/apocas/dockerode/blob/master/lib/buildkit.js)
+- docker-modem source: [`lib/modem.js`](https://github.com/apocas/docker-modem/blob/master/lib/modem.js) (`dial`, `buildQuerystring`, `defaultOpts`), `lib/ssh.js`
+- [ssh2 README](https://github.com/mscdex/ssh2#readme) — `cpu-features` as an optional dependency; `lib/protocol/constants.js` for the `try/catch`
+- [`@types/dockerode`](https://www.npmjs.com/package/@types/dockerode) 4.0.1 (DefinitelyTyped) `index.d.ts`
+- [openapi-typescript](https://openapi-ts.dev/introduction) — OpenAPI 3.x only, 2.x on 5.x and earlier
+- npm registry metadata and GitHub repo metadata for `dockerode`, `docker-modem`, `@types/dockerode`, `node-docker-api`, `docker-cli-js`, `testcontainers`, `ssh2` (2026-08-02)
+- Direct experiments run with dockerode 5.0.1 on Node 26 against Docker Engine 29.2.1 / API 1.53 / linux-arm64 (build with 3 tags + 5 labels from both an in-memory `tar-stream` buffer and dockerode's `{context, src}` packer; classic vs BuildKit progress decoding; `reference`/`name`/`label` filters; create/start/force-remove with `PortBindings`, `ExposedPorts`, `AutoRemove`; provoked port clash; `Binds` volume mount; dangling prune; API-version pinning; `cpu-features` removal)

--- a/docs/research/ts-git-library.md
+++ b/docs/research/ts-git-library.md
@@ -1,0 +1,247 @@
+# Can an embedded TS git library replace LibGit2Sharp?
+
+Research for [issue #4](https://github.com/alundgren/Irudd.Piploy/issues/4). Target: linux-arm64, no `git` binary on the Pi.
+
+All version-specific claims are as of 2026-08-02, against isomorphic-git 1.40.0 and nodegit 0.27.0 / 0.28.0-alpha.38.
+
+## Recommendation
+
+**Use isomorphic-git.** It covers every operation `PiployGitService` performs, is pure JavaScript with no native
+build step, and I verified the whole pipeline end-to-end against this repo's own GitHub remote.
+
+The tradeoff, stated plainly: **isomorphic-git only speaks HTTP(S).** No SSH, no `file://`, no local paths.
+LibGit2Sharp today accepts all of them. If piploy only ever deploys from `https://` remotes, this costs nothing.
+If a Pi is ever expected to pull via a deploy key over SSH, isomorphic-git cannot do it and the answer changes to
+the git CLI. That is the whole decision.
+
+There is also a second, smaller cost: isomorphic-git has no `reset --hard`, so it has to be composed from two
+calls. I tested that the composition is exactly equivalent, including the index — details below. It is an honest
+equivalent, not a rough one.
+
+nodegit — the obvious LibGit2Sharp analogue — is ruled out, not on API grounds but on shipping grounds: it has
+never published a Node-ABI linux-arm64 prebuilt binary, so it would compile libgit2 from source on the Pi.
+
+## The operations that must be covered
+
+From `Irudd.Piploy.App/PiployGitService.cs` and `GitCommit.cs`:
+
+| LibGit2Sharp today | isomorphic-git equivalent | Status |
+| --- | --- | --- |
+| `Repository.Clone(url, dir)` | `git.clone({ fs, http, dir, url })` | Direct |
+| `Commands.Fetch(repo, remote, refspecs, ...)` | `git.fetch({ fs, http, dir, remote })` | Direct |
+| `repo.Head` (branch + tip) | `git.currentBranch()` + `git.resolveRef({ ref: 'HEAD' })` | Direct |
+| `repo.Head.RemoteName` | `git.getConfig({ path: 'branch.<name>.remote' })` | Direct |
+| `repo.Branches["origin/master"].Tip` | `git.resolveRef({ ref: 'refs/remotes/origin/master' })` | Direct |
+| `repo.Reset(ResetMode.Hard, tip)` | `git.writeRef(...)` + `git.checkout({ force: true })` | **Composed — see below** |
+| `commit.Sha` / `.Message` / `.Committer.When` | `git.readCommit()` → `oid`, `commit.message`, `commit.committer.{timestamp,timezoneOffset}` | Direct |
+| `Directory.Exists(repo/.git)` probe | `git.findRoot()`, or keep the plain directory check | Direct |
+
+`.git` directory detection can stay exactly as it is — it is a filesystem check, not a git operation.
+
+### Verified end-to-end
+
+Against `https://github.com/alundgren/Irudd.Piploy` itself, with isomorphic-git 1.40.0 on Node 26:
+
+```
+clone ok in 1142 ms
+currentBranch   master
+HEAD            c748f963374d263f290305380d3263bc83690adf
+branch.master.remote = origin
+remotes         [{"remote":"origin","url":"https://github.com/alundgren/Irudd.Piploy"}]
+fetch -> { defaultBranch: 'refs/heads/master',
+           fetchHead: 'c748f963374d263f290305380d3263bc83690adf',
+           desc: "branch 'master' of https://github.com/alundgren/Irudd.Piploy" }
+refs/remotes/origin/master = c748f963374d263f290305380d3263bc83690adf
+tip message     "Port already in use handling"
+```
+
+So clone, fetch, remote-tracking ref resolution, config read and commit read all work, and the shape maps onto
+`GetBranches` / `GetCommitStatus` without contortion.
+
+## The `reset --hard` gap, and whether the workaround is honest
+
+**The gap is real.** isomorphic-git has no `reset` command. The API directory
+([`src/api/`](https://github.com/isomorphic-git/isomorphic-git/tree/main/src/api)) contains `resetIndex.js` but no
+`reset.js`, and the [commands index](https://isomorphic-git.org/docs/en/alphabetic) lists `resetIndex` under
+plumbing with no porcelain `reset`. This is long-standing, not a recent regression:
+[issue #129 "git reset"](https://github.com/isomorphic-git/isomorphic-git/issues/129) was opened in April 2018 and
+closed without a `reset` command being added; the thread's answer is the manual ref-rewrite workaround. Eight
+years and 1.40.0 later there is still no `reset`.
+
+**The naive workaround does not work.** `checkout({ ref: 'master', force: true })` on its own is *not* a hard reset
+to the remote tip. If the local branch already exists, `_checkout` resolves the ref to the *local* branch and
+leaves the branch pointer where it was
+([`src/commands/checkout.js`](https://github.com/isomorphic-git/isomorphic-git/blob/main/src/commands/checkout.js) —
+the `GitRefManager.resolve({ ref })` path only falls back to `<remote>/<ref>` when the local ref does **not**
+resolve). I confirmed this: after `checkout({ ref: 'master', force: true })` with `origin/master` at commit B, HEAD
+was still at commit A. Anyone porting this by reaching for `checkout --force` alone will silently never deploy new
+commits.
+
+**The correct composition, and proof it is equivalent.** Two calls:
+
+```js
+await git.writeRef({ fs, dir, ref: `refs/heads/${branch}`, value: remoteTipOid, force: true })
+await git.checkout({ fs, dir, ref: branch, force: true })
+```
+
+I built two identical dirty working copies at commit A with `origin/master` at commit B, dirtied them in every way
+that distinguishes reset semantics — a modified tracked file, a modified file that B deletes, a deleted tracked
+file, a staged new file, and an untracked file — then ran `git reset --hard B` on one and the two-call composition
+on the other, and diffed the results:
+
+```
+--- head:   IDENTICAL   05765ef811346eff15a42d6c5e413a98767a2c2a
+--- branch: IDENTICAL   main
+--- status: IDENTICAL   ?? untracked.txt
+--- files:  IDENTICAL
+    ./added.txt  "new in B\n"
+    ./keep.txt  "v2\n"
+    ./sub/nested.txt  "n2\n"
+    ./untracked.txt  "untracked\n"
+```
+
+Identical on all four axes, including the index — the staged file was unstaged and removed by both, and the
+untracked file survived both. That last point matters and matches git's own definition: `git reset --hard` updates
+tracked content and the index, and per [git-reset(1)](https://git-scm.com/docs/git-reset), "Tracked files not in
+*<commit>* are removed so that the working tree matches *<commit>*. Update the index to match the new `HEAD`, so
+nothing will be staged." It does not sweep untracked files, and neither does the composition.
+
+This is corroborated by the source: in `_checkout`'s `analyze()`, case `'001'` (untracked, absent from the target
+commit) returns without an operation unless explicitly named in `filepaths`; case `'101'` (in index and workdir,
+absent from the commit) returns `delete`; and cases `'011'`/`'111'` return `update` when `force` is set instead of
+raising `CheckoutConflictError`.
+
+**Verdict: the workaround is genuinely equivalent for piploy's use.** The caveat is that it is two operations, not
+one, and therefore not atomic — a crash between `writeRef` and `checkout` leaves the branch pointer moved and the
+working tree stale. LibGit2Sharp's single `Reset` call has the same exposure in practice (it is not transactional
+either), and piploy's loop is idempotent — the next pass re-runs the checkout — so this is a note, not a blocker.
+Worth wrapping in one `resetHard()` helper so no caller can do half of it.
+
+## The transport constraint — the real cost
+
+isomorphic-git resolves a remote helper in
+[`src/managers/GitRemoteManager.js`](https://github.com/isomorphic-git/isomorphic-git/blob/main/src/managers/GitRemoteManager.js),
+whose entire table is:
+
+```js
+remoteHelpers.set('http', GitRemoteHTTP)
+remoteHelpers.set('https', GitRemoteHTTP)
+```
+
+Anything else throws `UnknownTransportError`; an unparseable URL throws `UrlParseError`. `GitRemoteHTTP` is the
+only helper in `src/managers/`. Observed directly:
+
+```
+UrlParseError          /tmp/.../work/upstream
+    -> Cannot parse remote URL: "/tmp/.../work/upstream"
+UnknownTransportError  file:///tmp/.../work/upstream
+    -> uses an unrecognized transport protocol: "file"
+UnknownTransportError  ssh://git@example.com/x/y.git
+    -> uses an unrecognized transport protocol: "ssh"
+UnknownTransportError  git@example.com:x/y.git
+    -> uses an unrecognized transport protocol: "ssh"
+```
+
+Two consequences worth deciding on before committing to this:
+
+1. **SSH remotes are impossible.** Not awkward — impossible. `git@github.com:...` and `ssh://` both throw. The
+   library will helpfully suggest an HTTPS translation of the URL, but it cannot use the key.
+2. **The existing test harness breaks.** `Irudd.Piploy.Test/Utilities/TestBase.cs` sets
+   `GitRepositoryUrl = remoteDirectory` — a plain local directory path — for both test applications, and
+   `FakeGitRepository` builds a real repo there. LibGit2Sharp clones that happily; isomorphic-git raises
+   `UrlParseError`. The TS port's test suite will need a different approach: serve the fixture repo over HTTP
+   locally (isomorphic-git's own test suite does this), or make the fixture setup do a filesystem copy plus
+   `git.init` rather than a clone. This is a known chunk of porting work, not a surprise to be discovered later.
+
+## Credentials
+
+**The dotnet version passes no credentials, and does not need to.** `PiployGitService.cs` calls
+`Repository.Clone(application.GitRepositoryUrl, repoDirectory)` and `Commands.Fetch(..., new FetchOptions { }, "")`
+with no `CredentialsProvider` anywhere; `PiploySettings.Application` (`PiploySettings.cs`) has exactly one git
+field, `GitRepositoryUrl`, with no username, token or key-path sibling. There is no credential handling in the
+codebase at all. So today piploy works only against **public repositories** — or, on a machine where libgit2 picks
+up ambient config, whatever that config provides. The target repo itself is public, which is consistent with this.
+
+If private repos are ever wanted, isomorphic-git's route is the
+[`onAuth`](https://isomorphic-git.org/docs/en/onAuth) callback, which returns `{ username, password }` (a Personal
+Access Token as the password) or raw `{ headers }`. It documents no SSH-key path — consistent with the
+HTTPS-only transport table. A `GitCredentials` block in `piploy.json`, or a token from the environment, would drop
+into `onAuth` cleanly. Worth noting that this would be a *new* capability, not a port of an existing one, and
+should be its own issue rather than smuggled into the port.
+
+## Why not nodegit
+
+nodegit is libgit2 bindings — the closest analogue to LibGit2Sharp, and API-wise it would map almost one-to-one,
+including a real `Reset.reset(repo, commit, Reset.TYPE.HARD)`. It fails on delivery:
+
+- **The stable release is nearly six years old.** `nodegit@0.27.0` was published 2020-07-28 (npm registry
+  metadata). The `next` tag is `0.28.0-alpha.38` (2026-04-23) — still alpha after years, though the repo is
+  actively committed to (most recent commits July 2026).
+- **No Node-ABI linux-arm64 prebuilt binary has ever been published.** I enumerated the full prebuild bucket
+  (`https://axonodegit.s3.amazonaws.com/nodegit/nodegit/`, the `binary.host` declared in nodegit's own
+  `package.json`): 3183 objects across all versions, 47 mentioning arm. Every `linux-arm64` artifact is an
+  **Electron** ABI build:
+
+  ```
+  nodegit-v0.28.0-alpha.36-electron-v38.4-linux-arm64.tar.gz
+  nodegit-v0.28.0-alpha.38-electron-v41.3-linux-arm64.tar.gz
+  ```
+
+  Count of `node-v*-linux-arm64` artifacts in the entire bucket: **0**. darwin-arm64 and win32-arm64 Node builds
+  exist; linux-arm64 Node builds do not.
+- **Therefore it compiles from source on the Pi.** `lifecycleScripts/install.js` invokes node-pre-gyp with
+  `--fallback-to-build`, so a missing prebuild is not an error — it silently becomes a full libgit2 + C++ addon
+  compile, needing a toolchain and Python on the target, taking a long time on a Pi, and re-triggering on every
+  Node major upgrade. That is strictly worse than the dotnet status quo, where LibGit2Sharp ships a native
+  linux-arm64 binary in the NuGet package.
+
+Also note `0.28.0-alpha.38` declares `engines: { node: '>= 20' }` — fine, but it is an alpha, so choosing nodegit
+means depending on an alpha to get any recent-Node support at all.
+
+## The fallback: simple-git / child_process
+
+Kept as the documented fallback, not the recommendation. simple-git 3.36.0 (2026-04-12) is pure JS with only
+four small runtime deps, and is behaviourally the most faithful option — it *is* git, so `file://`, local paths,
+SSH, credential helpers and `reset --hard` all just work. Its readme states the cost outright under System
+Dependencies: "Requires git to be installed and that it can be called using the command `git`."
+
+That forfeits the embedded property the ticket asks to preserve, and adds a provisioning requirement on the Pi
+(and on any container piploy itself runs in). Take this route only if SSH remotes turn out to be a requirement —
+in which case it is the *only* route, since isomorphic-git cannot do SSH at any price.
+
+## Suggested shape for the port
+
+```ts
+// one helper so no caller can perform half a reset
+async function resetHard(dir: string, oid: string, branch: string) {
+  await git.writeRef({ fs, dir, ref: `refs/heads/${branch}`, value: oid, force: true })
+  await git.checkout({ fs, dir, ref: branch, force: true })
+}
+```
+
+`EnsureLocalRepository` then becomes: probe `.git` → `clone` if absent; otherwise `fetch`, compare
+`resolveRef('HEAD')` against `resolveRef('refs/remotes/origin/<branch>')`, and call `resetHard` when they differ —
+the same shape as the C# today.
+
+Two implementation notes:
+
+- isomorphic-git needs an explicit HTTP client: `import http from 'isomorphic-git/http/node'`. It is a separate
+  export subpath, not bundled into the default import.
+- `commit.committer.timezoneOffset` is in **minutes and sign-inverted relative to ISO 8601** — a commit at
+  `+02:00` reports `timezoneOffset: -120` (observed; matches the JS `Date.getTimezoneOffset()` convention, not
+  git's). Get this backwards and `GitCommit.Date` is off by twice the offset. `commit.committer.timestamp` is
+  plain UTC epoch seconds and is the safe field to build from.
+
+## Sources
+
+Primary sources only; every claim above traces to one of these.
+
+- `Irudd.Piploy.App/PiployGitService.cs`, `GitCommit.cs`, `PiploySettings.cs`, `Irudd.Piploy.Test/Utilities/TestBase.cs` — this repo
+- [isomorphic-git command index](https://isomorphic-git.org/docs/en/alphabetic), [`clone`](https://isomorphic-git.org/docs/en/clone), [`fetch`](https://isomorphic-git.org/docs/en/fetch), [`onAuth`](https://isomorphic-git.org/docs/en/onAuth)
+- isomorphic-git source: [`src/api/`](https://github.com/isomorphic-git/isomorphic-git/tree/main/src/api), [`src/managers/GitRemoteManager.js`](https://github.com/isomorphic-git/isomorphic-git/blob/main/src/managers/GitRemoteManager.js), [`src/commands/checkout.js`](https://github.com/isomorphic-git/isomorphic-git/blob/main/src/commands/checkout.js), [`src/typedefs.js`](https://github.com/isomorphic-git/isomorphic-git/blob/main/src/typedefs.js)
+- [isomorphic-git issue #129 "git reset"](https://github.com/isomorphic-git/isomorphic-git/issues/129)
+- [git-reset(1)](https://git-scm.com/docs/git-reset)
+- npm registry metadata for `isomorphic-git`, `nodegit`, `simple-git`; nodegit prebuild bucket listing at `https://axonodegit.s3.amazonaws.com/nodegit/nodegit/`
+- nodegit source: [`lifecycleScripts/install.js`](https://github.com/nodegit/nodegit/blob/master/lifecycleScripts/install.js)
+- [simple-git readme](https://github.com/steveukx/git-js/blob/main/simple-git/readme.md)
+- Direct experiments run against isomorphic-git 1.40.0 on Node 26 / git 2.54.0 (transport table, reset equivalence, commit metadata, live clone+fetch of this repo)


### PR DESCRIPTION
Two things that accumulated while charting the TypeScript port: the agent configuration from skill init, and the findings for the three research tickets on [the map](https://github.com/alundgren/Irudd.Piploy/issues/1).

No production code changes — this is all Markdown.

## `45ad8ac` — agent configuration

`CLAUDE.md` as the single source of truth with `AGENTS.md` pointing at it, plus `docs/agents/` recording three repo-specific conventions: GitHub as the issue tracker (including how `/wayfinder` expresses maps, sub-issue tickets and native issue dependencies), the triage labels, and where the domain docs live.

## `9dc60bd` — research findings

One file per research ticket under `docs/research/`. Each carries the full findings with primary sources cited; the tickets carry the summaries. These exist as files rather than only as issue comments because [#7](https://github.com/alundgren/Irudd.Piploy/issues/7) has to weigh measured artifact sizes, a `postject`/ELF trap and a native-module analysis that no comment-length summary can carry.

| File | Ticket | Recommendation |
| --- | --- | --- |
| `ts-git-library.md` | [#4](https://github.com/alundgren/Irudd.Piploy/issues/4) | isomorphic-git |
| `ts-docker-client.md` | [#5](https://github.com/alundgren/Irudd.Piploy/issues/5) | dockerode 5.0.1 |
| `arm64-packaging.md` | [#6](https://github.com/alundgren/Irudd.Piploy/issues/6) | esbuild/tsup bundle + Node on the Pi, Node SEA as a later drop-in |

## What a reviewer should know

**The two documents disagree, deliberately.** `arm64-packaging.md` records dockerode as having no native dependency. `ts-docker-client.md` shows that is true of the package but not of its tree — `docker-modem → ssh2 → optional cpu-features` compiles at install, though it is optional and suppressible via pnpm's `neverBuiltDependencies`. I left both files as their authors wrote them rather than editing the earlier one after the fact, so whoever resolves [#7](https://github.com/alundgren/Irudd.Piploy/issues/7) sees the disagreement and its evidence instead of a silently patched claim. Native-module status weighs heavily in that decision, so it should not be quietly resolved here.

**Three findings are load-bearing enough to flag:**

- **isomorphic-git cannot do SSH at any price** — the remote-helper table is `http` and `https`, everything else throws. If a Pi ever needs a deploy key, the recommendation flips to the git CLI. Worth deciding explicitly rather than by default.
- **Two naive ports would silently look like they work.** `checkout({ force: true })` alone is not a hard reset to the remote tip, so piploy would never deploy new commits; and under BuildKit the typed `modem.followProgress` path yields undecodable protobuf while the untyped `docker.followProgress` decodes it.
- **The existing test harness breaks either way** — `TestBase.cs` uses a local directory path as `GitRepositoryUrl`, which isomorphic-git rejects. Relevant to [#11](https://github.com/alundgren/Irudd.Piploy/issues/11).

Gaps are recorded as unknown rather than papered over: startup time on real Pi hardware was never measured, and the Pi's actual Docker API version waits on [#2](https://github.com/alundgren/Irudd.Piploy/issues/2).

**Provenance:** written by research subagents. The first three ran concurrently in one working directory and raced each other's branches — the git-library findings were committed onto the packaging branch. This PR reconstructs the intended history off `master`; the content is unaffected. The Docker research was re-run in the foreground with git access withheld.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
