### PR TITLE
Add the tag-triggered GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm lint
+
+      - run: pnpm test
+
+      - run: pnpm build
+
+      - name: Create release and attach the bundle
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${{ github.ref_name }}" dist/piploy.cjs --title "${{ github.ref_name }}" --generate-notes

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@11.1.2",
   "engines": {
     "node": ">=24"
   },

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,9 @@
 declare const __PIPLOY_VERSION__: string;
 
-/** The package version plus the build's short git commit hash. */
+/**
+ * The release tag (e.g. `v1.2.3`) when built at a tagged commit — matching
+ * `tag_name` in the GitHub Releases API exactly, for self-update's
+ * comparison — otherwise the package version plus the build's short git
+ * commit hash, for local/dev builds.
+ */
 export const piployVersion = __PIPLOY_VERSION__;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,10 +9,25 @@ const packageJsonPath = fileURLToPath(
 const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
   version: string;
 };
+
+function releaseTagAtHead(): string | undefined {
+  try {
+    return execFileSync("git", ["describe", "--tags", "--exact-match"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+// Self-update (#8, #29) compares a release's `tag_name` against this constant
+// verbatim, so a build made at a tagged commit must carry the tag itself —
+// not the package version — or every poll would see a spurious update.
 const gitCommit = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
   encoding: "utf8",
 }).trim();
-const version = `${packageJson.version}+${gitCommit}`;
+const version = releaseTagAtHead() ?? `${packageJson.version}+${gitCommit}`;
 
 export default defineConfig({
   entry: { piploy: "src/cli.ts" },


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` — the repo's first CI. On push of a `v*` tag it installs, lints, tests, and builds, then runs `gh release create "$GITHUB_REF_NAME" dist/piploy.cjs --title "$GITHUB_REF_NAME" --generate-notes` to create the release and attach the bundle in one step, landing it at the `releases/latest/download/piploy.cjs` URL `self-update` depends on.
- Fixes a real bug surfaced while implementing this: `tsup.config.ts`'s injected version constant was `packageVersion+gitCommit` unconditionally, which could never equal a release's `tag_name` — self-update's comparison (decided in #8) would have seen a mismatch on every poll and redeployed hourly forever. Now the constant is the tag itself verbatim when built at a tagged commit, falling back to `version+commit` for untagged/dev builds.
- Adds a `packageManager` field to `package.json` so `pnpm/action-setup` in CI picks the same pnpm version used locally.

Resolves [#16](https://github.com/alundgren/Irudd.Piploy/issues/16), a ticket on the [wayfinder map for the TypeScript port](https://github.com/alundgren/Irudd.Piploy/issues/1).

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] `pnpm build` produces `dist/piploy.cjs`
- [x] Verified locally that an untagged build emits `0.1.0+<commit>` and a build at a local test tag emits the tag verbatim
- [ ] First real tag push will confirm the release workflow end-to-end (asset upload, `latest` alias) on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)