### PR TITLE
Raise Codex issue usage guard

### DIFF
--- a/docs/agents/codex-issue-worker.md
+++ b/docs/agents/codex-issue-worker.md
@@ -19,12 +19,15 @@ job is loaded. It is **disabled by default**.
   requires human review. The worker never merges.
 - It records token totals from Codex's JSON completion events. It will not make
   a follow-up run after the pre-turn guard, and it will not automatically create
-  a PR after the total meets the budget.
+  a PR after the total meets the budget. These are cumulative-usage circuit
+  breakers, not context-window limits, and the worker never enables or requests
+  context compaction.
 
 The final point is an operational guard, not a hard mid-turn cutoff: Codex
 reports token usage when a turn completes. A single run can therefore cross the
 budget before the controller can stop it. Keep the pre-turn threshold below the
-budget and begin with small, tightly scoped issues.
+budget and begin with small, tightly scoped issues. The default guard is 2m
+tokens and the default budget-review threshold is 2.5m tokens per issue.
 
 When the guard stops a held issue, inspect the worktree and recorded usage. To
 authorize exactly one additional Codex run, use:

--- a/scripts/codex-issue-worker.config.example
+++ b/scripts/codex-issue-worker.config.example
@@ -10,11 +10,12 @@ CLAIMED_LABEL="codex:claimed"
 REVIEW_LABEL="codex:needs-review"
 BUDGET_REVIEW_LABEL="codex:budget-review"
 
-# Codex reports usage only after a turn ends. The pre-turn guard prevents a
-# follow-up run once this issue has accumulated 170k tokens. The 200k budget
-# prevents automatic verification/PR creation after a run crosses the limit.
-PRETURN_TOKEN_GUARD=170000
-TOKEN_BUDGET=200000
+# Cumulative-usage circuit breaker only. This does not compact or otherwise
+# constrain Codex's context window. Codex reports usage after a turn ends, so
+# the 2m guard prevents a follow-up run and the 2.5m threshold requires review
+# before the worker verifies or opens a PR after a costly run.
+PRETURN_TOKEN_GUARD=2000000
+TOKEN_BUDGET=2500000
 
 # Required by this repository's CLAUDE.md. Keep this an explicit, trusted local
 # command; this configuration file is not read from an issue.


### PR DESCRIPTION
## Summary

Updates the local Codex issue-worker defaults to treat token values as a cumulative-usage circuit breaker, not as a context-window budget.

- Raises the per-issue pre-turn review guard to 2,000,000 tokens.
- Raises the per-issue budget-review threshold to 2,500,000 tokens.
- Documents that the worker never enables or requests context compaction.

## Validation

- `pnpm test`
- `git diff --check`
