### PR TITLE
Refresh origin main before worker runs

### DIFF
--- a/docs/agents/codex-issue-worker.md
+++ b/docs/agents/codex-issue-worker.md
@@ -14,7 +14,9 @@ job is loaded. It is **disabled by default**.
   close, or merge anything. The controller rejects a run that makes a commit
   or changes the controller's own files.
 - Work happens in `.codex-issue-worker/worktrees/issue-<n>`, not in the main
-  checkout.
+  checkout. Before the worker claims a new issue, it fetches `origin/main` and
+  creates that worktree from the refreshed remote ref. Continuing a held issue
+  reuses its existing worktree.
 - The configured checks run after Codex returns. If they fail, the controller
   captures the output and may give Codex one bounded repair run (configured by
   `MAX_VERIFICATION_REPAIR_RUNS`, default `1`), then re-runs the checks. The

--- a/scripts/codex-issue-worker
+++ b/scripts/codex-issue-worker
@@ -309,6 +309,12 @@ claim_issue() {
   comment "$issue_number" "Claimed by the local Codex worker. It will create a reviewable change and will not merge it."
 }
 
+refresh_origin_main() {
+  echo "Refreshing origin/main."
+  git -C "$REPO_ROOT" fetch origin main
+  git -C "$REPO_ROOT" rev-parse --verify --quiet origin/main >/dev/null
+}
+
 create_worktree() {
   local issue_number="$1"
   local branch_name="codex/issue-$issue_number"
@@ -318,7 +324,7 @@ create_worktree() {
   git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$branch_name" && die "branch already exists: $branch_name"
 
   mkdir -p "$STATE_DIR/worktrees"
-  git -C "$REPO_ROOT" worktree add -b "$branch_name" "$worktree" HEAD >/dev/null
+  git -C "$REPO_ROOT" worktree add -b "$branch_name" "$worktree" origin/main >/dev/null
   mkdir -p "$WORKTREE_BASE_DIR"
   git -C "$worktree" rev-parse HEAD >"$WORKTREE_BASE_DIR/issue-$issue_number"
   echo "$worktree"
@@ -546,6 +552,7 @@ run() {
     return
   fi
 
+  refresh_origin_main
   claim_issue "$issue_number"
   local prior_tokens
   prior_tokens="$(issue_token_total "$issue_number")"


### PR DESCRIPTION
## What changed

Before claiming a new eligible issue, the local Codex worker now fetches `origin/main` and creates the isolated issue worktree from that refreshed ref.

## Why

The worker previously created its issue branch from the local checkout's `HEAD`, which could be behind the remote main branch.

## Behavior

- New issue worktrees are based on freshly fetched `origin/main`.
- A held issue resumed with `continue` keeps its existing isolated worktree.
- The refresh happens before the issue is claimed, so a failed fetch does not claim or lock an issue.

## Validation

- `bash -n scripts/codex-issue-worker`
- Simulated `origin/main` fetch-and-verify flow
- `pnpm test`