### PR TITLE
Improve Codex worker diagnostics

### DIFF
--- a/docs/agents/codex-issue-worker.md
+++ b/docs/agents/codex-issue-worker.md
@@ -77,7 +77,9 @@ process deliberately after inspecting it.
 `launchd` requires absolute paths, so the worker generates its local plist at
 installation time. The checked-in files contain no user or repository path;
 the generated plist uses the current checkout path and is stored under your
-`~/Library/LaunchAgents` directory.
+`~/Library/LaunchAgents` directory. It also captures the current shell `PATH`,
+so Homebrew-installed tools such as `gh`, `codex`, and `pnpm` remain available
+to the scheduled job. Re-run installation after changing your tool locations.
 
 ```bash
 scripts/codex-issue-worker install-launchd
@@ -88,6 +90,11 @@ Unload the job to stop polling completely:
 ```bash
 scripts/codex-issue-worker uninstall-launchd
 ```
+
+`status` includes the latest local `run` or `continue` outcome. On failure, it
+prints the first lines of `.codex-issue-worker/last-run.err.log`; the complete
+per-run error is kept there rather than being mixed only into launchd's shared
+stderr log.
 
 Prefer `disable` as the normal kill switch, since the worker verifies it before
 each action. Loading the job is an additional "this laptop only" gate.

--- a/scripts/codex-issue-worker
+++ b/scripts/codex-issue-worker
@@ -11,10 +11,13 @@ readonly CONFIG_FILE="$STATE_DIR/config.sh"
 readonly ENABLED_FILE="$STATE_DIR/enabled"
 readonly LOCK_DIR="$STATE_DIR/run.lock"
 readonly USAGE_FILE="$STATE_DIR/token-usage.tsv"
+readonly LAST_RUN_FILE="$STATE_DIR/last-run.tsv"
+readonly LAST_RUN_ERROR_FILE="$STATE_DIR/last-run.err.log"
 readonly BUDGET_APPROVAL_DIR="$STATE_DIR/budget-approvals"
 readonly WORKTREE_BASE_DIR="$STATE_DIR/worktree-bases"
 readonly EXAMPLE_CONFIG="$SCRIPT_DIR/codex-issue-worker.config.example"
 readonly LAUNCHD_LABEL="com.alundgren.irudd-piploy.codex-issue-worker"
+WORKER_RUN_COMMAND=""
 
 usage() {
   cat <<'EOF'
@@ -101,8 +104,49 @@ with_lock() {
   if ! mkdir "$LOCK_DIR" 2>/dev/null; then
     die "another worker run is active ($LOCK_DIR exists)"
   fi
-  trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT HUP INT TERM
+
+  WORKER_RUN_COMMAND="$1"
+  record_run_state "running" "" "$WORKER_RUN_COMMAND"
+  : >"$LAST_RUN_ERROR_FILE"
+
+  # Keep the complete stderr from this invocation alongside its final state.
+  # launchd otherwise only exposes an accumulating shared log, which makes a
+  # transient failure difficult to associate with a particular scheduled run.
+  exec 3>&2
+  exec 2>"$LAST_RUN_ERROR_FILE"
+  trap 'finish_locked_run "$?" "$WORKER_RUN_COMMAND"' EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
   "$@"
+}
+
+record_run_state() {
+  local outcome="$1"
+  local exit_code="$2"
+  local command_name="$3"
+  printf '%s\t%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$outcome" "$exit_code" "$command_name" >"$LAST_RUN_FILE"
+}
+
+finish_locked_run() {
+  local exit_code="$1"
+  local command_name="$2"
+
+  trap - EXIT HUP INT TERM
+  exec 2>&3
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+
+  if [ "$exit_code" -eq 0 ]; then
+    record_run_state "completed" "$exit_code" "$command_name"
+  else
+    if [ ! -s "$LAST_RUN_ERROR_FILE" ]; then
+      printf 'Worker exited with status %s without writing an error message.\n' "$exit_code" >"$LAST_RUN_ERROR_FILE"
+    fi
+    record_run_state "failed" "$exit_code" "$command_name"
+    cat "$LAST_RUN_ERROR_FILE" >&2
+  fi
+
+  exec 3>&-
 }
 
 claimed_issue() {
@@ -198,6 +242,18 @@ status() {
     echo "launchd job: not installed"
   fi
 
+  if [ -f "$LAST_RUN_FILE" ]; then
+    local last_run_timestamp last_run_outcome last_run_exit_code last_run_command
+    IFS=$'\t' read -r last_run_timestamp last_run_outcome last_run_exit_code last_run_command <"$LAST_RUN_FILE"
+    echo "last run: $last_run_outcome ($last_run_command at $last_run_timestamp${last_run_exit_code:+, exit $last_run_exit_code})"
+    if [ "$last_run_outcome" = "failed" ] && [ -s "$LAST_RUN_ERROR_FILE" ]; then
+      echo "last run error:"
+      sed -n '1,8{s/^/  /;p;}' "$LAST_RUN_ERROR_FILE"
+    fi
+  else
+    echo "last run: no local record"
+  fi
+
   local active_issue
   active_issue="$(claimed_issue)"
   if [ -n "$active_issue" ]; then
@@ -213,12 +269,13 @@ install_launchd() {
   require_command launchctl
   require_command plutil
 
-  local plist temporary domain program_path output_path error_path
+  local plist temporary domain program_path output_path error_path launchd_path
   plist="$(launchd_plist)"
   domain="gui/$(id -u)"
   program_path="$REPO_ROOT/scripts/codex-issue-worker"
   output_path="$STATE_DIR/launchd.out.log"
   error_path="$STATE_DIR/launchd.err.log"
+  launchd_path="$PATH"
   temporary="$(mktemp "$STATE_DIR/$LAUNCHD_LABEL.XXXXXX")"
 
   {
@@ -236,6 +293,11 @@ install_launchd() {
   </array>
   <key>WorkingDirectory</key>
   <string>$(printf '%s' "$REPO_ROOT" | xml_escape)</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>$(printf '%s' "$launchd_path" | xml_escape)</string>
+  </dict>
   <key>StartInterval</key>
   <integer>600</integer>
   <key>ProcessType</key>


### PR DESCRIPTION
## Summary

- Capture the interactive PATH in the generated launchd plist so scheduled runs can find Homebrew-installed gh, codex, and pnpm.
- Persist each worker run's outcome and stderr, and display it from status.
- Document reinstallation after tool-path changes.

## Root cause

launchd started with only the macOS system PATH, so the installed worker could not find gh and exited immediately. A GitHub TLS timeout also left no concise local record to distinguish a transient API failure from a stuck worker.

## Validation

- bash -n scripts/codex-issue-worker
- Isolated success and failure-path worker runs, including lock cleanup and persisted state/error checks
- Generated plist inspection confirming EnvironmentVariables.PATH
- git diff --check
