### PR TITLE
Harden pnpm and Docker image supply chains

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Enforce dependency vulnerability policy
+        run: pnpm audit --audit-level high
+
+      - name: Generate dependency SBOM
+        run: pnpm sbom --sbom-format cyclonedx > piploy.cdx.json
+
       - run: pnpm lint
 
       - run: pnpm test
@@ -34,4 +40,4 @@ jobs:
       - name: Create release and attach the bundle
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${{ github.ref_name }}" dist/piploy.cjs --title "${{ github.ref_name }}" --generate-notes
+        run: gh release create "${{ github.ref_name }}" dist/piploy.cjs piploy.cdx.json --title "${{ github.ref_name }}" --generate-notes

--- a/Irudd.Piploy.App/DockerfileImagePolicy.cs
+++ b/Irudd.Piploy.App/DockerfileImagePolicy.cs
@@ -1,0 +1,105 @@
+using System.Text.RegularExpressions;
+
+namespace Irudd.Piploy.App;
+
+public static partial class DockerfileImagePolicy
+{
+    public static void Validate(string dockerfilePath)
+    {
+        var stages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var stageCount = 0;
+
+        foreach (var instruction in ReadInstructions(File.ReadAllText(dockerfilePath)))
+        {
+            var parts = Whitespace().Split(instruction, 2);
+            if (parts[0].Equals("FROM", StringComparison.OrdinalIgnoreCase))
+            {
+                if (parts.Length != 2)
+                    throw new InvalidOperationException("Dockerfile FROM instruction has no resolvable image reference.");
+                ValidateFrom(parts[1], stages, stageCount);
+                var alias = FromAlias().Match(parts[1]);
+                if (alias.Success)
+                    stages.Add(alias.Groups[1].Value);
+                stageCount++;
+            }
+            else if (parts.Length == 2 && parts[0].Equals("COPY", StringComparison.OrdinalIgnoreCase))
+            {
+                var source = CopyFrom().Match(parts[1]);
+                if (source.Success)
+                {
+                    var reference = source.Groups.Cast<Group>().Skip(1).First(group => group.Success).Value;
+                    ValidateReference(reference, stages, stageCount, "COPY --from");
+                }
+            }
+        }
+    }
+
+    private static void ValidateFrom(string arguments, HashSet<string> stages, int stageCount)
+    {
+        var match = FromImage().Match(arguments);
+        if (!match.Success)
+            throw new InvalidOperationException("Dockerfile FROM instruction has an unresolved or invalid image reference.");
+
+        ValidateReference(match.Groups[1].Value, stages, stageCount, "FROM");
+    }
+
+    private static void ValidateReference(string reference, HashSet<string> stages, int stageCount, string instruction)
+    {
+        reference = reference.Trim('"', '\'');
+        if (reference.Equals("scratch", StringComparison.OrdinalIgnoreCase) ||
+            stages.Contains(reference) ||
+            (int.TryParse(reference, out var index) && index >= 0 && index < stageCount))
+            return;
+
+        if (reference.Contains('$'))
+            throw new InvalidOperationException($"Dockerfile {instruction} uses dynamic external image reference '{reference}'.");
+
+        var digest = DigestReference().Match(reference);
+        if (!digest.Success)
+            throw new InvalidOperationException($"Dockerfile {instruction} external image '{reference}' must use an immutable sha256 digest.");
+
+        var name = digest.Groups[1].Value;
+        var isOfficialImage = !name.Contains('/') || name.StartsWith("docker.io/library/", StringComparison.Ordinal);
+        var isMicrosoftDotnet = name.StartsWith("mcr.microsoft.com/dotnet/", StringComparison.Ordinal);
+        if (!isOfficialImage && !isMicrosoftDotnet)
+            throw new InvalidOperationException($"Dockerfile {instruction} external image '{reference}' is not from an approved registry namespace.");
+    }
+
+    private static IEnumerable<string> ReadInstructions(string dockerfile)
+    {
+        var logicalLine = "";
+        using var reader = new StringReader(dockerfile);
+        while (reader.ReadLine() is { } line)
+        {
+            var trimmed = line.Trim();
+            if (logicalLine.Length == 0 && (trimmed.Length == 0 || trimmed.StartsWith('#')))
+                continue;
+
+            var continued = trimmed.EndsWith('\\');
+            logicalLine += (logicalLine.Length == 0 ? "" : " ") + (continued ? trimmed[..^1] : trimmed);
+            if (!continued)
+            {
+                yield return logicalLine.Trim();
+                logicalLine = "";
+            }
+        }
+
+        if (logicalLine.Length != 0)
+            yield return logicalLine.Trim();
+    }
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex Whitespace();
+
+    [GeneratedRegex("(?:^|\\s)--from(?:=|\\s+)(?:\"([^\"]+)\"|'([^']+)'|([^\\s]+))", RegexOptions.IgnoreCase)]
+    private static partial Regex CopyFrom();
+
+    [GeneratedRegex(@"^(?:--[^\s]+\s+)*([^\s]+)(?:\s+[Aa][Ss]\s+([A-Za-z0-9_.-]+))?\s*$")]
+    private static partial Regex FromImage();
+
+    [GeneratedRegex(@"\s+[Aa][Ss]\s+([A-Za-z0-9_.-]+)\s*$")]
+    private static partial Regex FromAlias();
+
+    [GeneratedRegex(@"^(.+?)(?::[^/@]+)?@sha256:([0-9a-f]{64})$")]
+    private static partial Regex DigestReference();
+}

--- a/Irudd.Piploy.App/PiployDockerService.cs
+++ b/Irudd.Piploy.App/PiployDockerService.cs
@@ -24,7 +24,15 @@ public class PiployDockerService(IOptions<PiploySettings> settings, PiployDocker
 
     public async Task<(bool WasCreated, string ImageId)> EnsureImageExists(PiploySettings.Application application, GitCommit commit, CancellationToken cancellationToken)
     {
-        
+        var (repoRelativeDockerContextDirectory, dockerfilename) = GetDockerfilePathFromSetting(application.DockerfilePath);
+        var absoluteRepoDirectory = application.GetRepoDirectory(Settings);
+        var absoluteDockerContextDirectory = Path.Combine(absoluteRepoDirectory, repoRelativeDockerContextDirectory);
+        var absoluteDockerfilePath = Path.Combine(absoluteDockerContextDirectory, dockerfilename);
+        if (!File.Exists(absoluteDockerfilePath))
+            throw new Exception($"Dockerfile '{application.DockerfilePath ?? "Dockerfile"}' does not exist. Expected location: '{absoluteDockerfilePath}'");
+
+        DockerfileImagePolicy.Validate(absoluteDockerfilePath);
+
         using var docker = new DockerClientConfiguration().CreateClient();
 
         var commitVersionTag = GetImageVersionTagCommit(application.Name, commit);
@@ -35,14 +43,6 @@ public class PiployDockerService(IOptions<PiploySettings> settings, PiployDocker
             return (false, existingImage.ID);
 
         //TODO: Check if already correct version
-
-        var (repoRelativeDockerContextDirectory, dockerfilename) = GetDockerfilePathFromSetting(application.DockerfilePath);
-        var absoluteRepoDirectory = application.GetRepoDirectory(Settings);
-        var absoluteDockerContextDirectory = Path.Combine(absoluteRepoDirectory, repoRelativeDockerContextDirectory);
-
-        var absoluteDockerfilePath = Path.Combine(absoluteDockerContextDirectory, dockerfilename);
-        if (!File.Exists(absoluteDockerfilePath))
-            throw new Exception($"Dockerfile '{application.DockerfilePath} does not exist. Expected location: '{absoluteDockerfilePath}'");
 
         using var tarFile = new MemoryStream();
         await TarFile.CreateFromDirectoryAsync(absoluteDockerContextDirectory, tarFile, false, cancellationToken: cancellationToken);
@@ -208,8 +208,9 @@ public class PiployDockerService(IOptions<PiploySettings> settings, PiployDocker
     public static string TestMarkerLabelName => $"{Piploy}_isCreatedByTest";
     public static string ImageCommitLabelName => $"{Piploy}_gitTipCommit";
 
-    public static (string ContextDirectory, string Dockerfilename) GetDockerfilePathFromSetting(string dockerPathSetting)
+    public static (string ContextDirectory, string Dockerfilename) GetDockerfilePathFromSetting(string? dockerPathSetting)
     {
+        dockerPathSetting = string.IsNullOrWhiteSpace(dockerPathSetting) ? "Dockerfile" : dockerPathSetting;
         //Normalize to format <path>/<filename> where path is repeating segments like <name>/
         var d = dockerPathSetting.Replace(@"\", "/").Trim();
         d = d.StartsWith("/") ? d.Substring(1) : d;

--- a/Irudd.Piploy.App/PiploySettings.cs
+++ b/Irudd.Piploy.App/PiploySettings.cs
@@ -44,8 +44,7 @@ public class PiploySettings
         //  Example with custom name of the file
         //  "api/DockerApiFile" or "/DockerApiFile"
         /// </summary>
-        [Required]
-        public string DockerfilePath { get; set; } = null!;
+        public string? DockerfilePath { get; set; }
 
         /// <summary>
         /// Same format as docker run -p <hostport>:<containerport>
@@ -90,4 +89,3 @@ public class PiploySettings
         }
     }
 }
-

--- a/Irudd.Piploy.Test/DockerTests.cs
+++ b/Irudd.Piploy.Test/DockerTests.cs
@@ -72,12 +72,47 @@ public class DockerTests(ITestOutputHelper output) : TestBase(output), IAsyncLif
     [InlineData(@"a b/c d/file name", "a b/c d", "file name")]
     [InlineData(@"/a b/c d/file name", "a b/c d", "file name")]
     [InlineData(@"/a b/c d\file name", "a b/c d", "file name")]
-    public void DockerPathSetting(string setting, string expectedContextDirectory, string expectedDockerfilename)
+    [InlineData(null, "", "Dockerfile")]
+    public void DockerPathSetting(string? setting, string expectedContextDirectory, string expectedDockerfilename)
     {
         var (contextDirectory, dockerFilename) = PiployDockerService.GetDockerfilePathFromSetting(setting);
 
         Assert.Equal(expectedContextDirectory, contextDirectory);
         Assert.Equal(expectedDockerfilename, dockerFilename);
+    }
+
+    [Theory]
+    [InlineData("FROM node:current-slim@sha256:deae974a69e140f44f434ab29cb519fb5f8fe250fd364b8ca446bd0761acdc6a")]
+    [InlineData("FROM docker.io/library/nginx@sha256:5a88c9c45479443d7be2eadc894b4ed0a9801bae03d97a5760ae13b5c2005942")]
+    [InlineData("FROM mcr.microsoft.com/dotnet/core/sdk:3.1@sha256:150d074697d1cda38a0c2185fe43895d84b5745841e9d15c5adba29604a6e4cb AS build\nCOPY --from=build /out /out")]
+    [InlineData("FROM scratch AS empty\nCOPY --from=empty /out /out")]
+    public void DockerfilePolicyAcceptsApprovedImmutableImages(string dockerfile) => ValidateDockerfile(dockerfile);
+
+    [Theory]
+    [InlineData("FROM nginx:latest")]
+    [InlineData("FROM somebody/nginx@sha256:5a88c9c45479443d7be2eadc894b4ed0a9801bae03d97a5760ae13b5c2005942")]
+    [InlineData("FROM ghcr.io/example/image@sha256:5a88c9c45479443d7be2eadc894b4ed0a9801bae03d97a5760ae13b5c2005942")]
+    [InlineData("ARG IMAGE=node\nFROM ${IMAGE}@sha256:deae974a69e140f44f434ab29cb519fb5f8fe250fd364b8ca446bd0761acdc6a")]
+    [InlineData("FROM scratch\nCOPY --from=nginx:latest /out /out")]
+    [InlineData("FROM scratch\nCOPY --from=mcr.microsoft.com/other/image@sha256:150d074697d1cda38a0c2185fe43895d84b5745841e9d15c5adba29604a6e4cb /out /out")]
+    public void DockerfilePolicyRejectsMutableUntrustedOrDynamicImages(string dockerfile)
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() => ValidateDockerfile(dockerfile));
+        Assert.Contains("Dockerfile", exception.Message);
+    }
+
+    private static void ValidateDockerfile(string contents)
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, contents);
+            DockerfileImagePolicy.Validate(path);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     public async Task InitializeAsync()

--- a/Irudd.Piploy.Test/Utilities/FakeGitRepository.cs
+++ b/Irudd.Piploy.Test/Utilities/FakeGitRepository.cs
@@ -34,7 +34,7 @@ public class FakeGitRepository(string directory)
             var fullDirectory = Path.Combine(directory, directoryName);
             Directory.CreateDirectory(fullDirectory);
 
-            AddAndStageTextFile(repo, "Dockerfile", @"FROM nginx:mainline-alpine
+            AddAndStageTextFile(repo, "Dockerfile", @"FROM nginx:mainline-alpine@sha256:5a88c9c45479443d7be2eadc894b4ed0a9801bae03d97a5760ae13b5c2005942
 RUN rm /etc/nginx/conf.d/*
 ADD hello.conf /etc/nginx/conf.d/
 ADD index.html /usr/share/nginx/html/", overrideDirectory: fullDirectory);

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,8 @@
 allowBuilds:
   esbuild: true
+minimumReleaseAge: 11520
+minimumReleaseAgeStrict: true
+minimumReleaseAgeIgnoreMissingTime: false
+trustPolicy: no-downgrade
+trustLockfile: false
+blockExoticSubdeps: true


### PR DESCRIPTION
## Summary

Implements #20 by hardening Piploy’s package resolution and application Dockerfile image policy.

- Enforces pnpm release-age, trust, and dependency-build controls; adds CI auditing and CycloneDX SBOM release artifacts.
- Rejects mutable, dynamic, and untrusted external Docker image references before Docker is invoked.
- Allows only digest-pinned Docker Official Images and `mcr.microsoft.com/dotnet/*`; supports the default repository-root Dockerfile path.

## Validation

- `pnpm lint`
- `pnpm test`
- `git diff --check`

The C# test suite was not run because the .NET SDK is unavailable in this environment.