### PR TITLE
Open PRs for verified worker changes

### DIFF
--- a/docs/agents/codex-issue-worker.md
+++ b/docs/agents/codex-issue-worker.md
@@ -22,8 +22,10 @@ job is loaded. It is **disabled by default**.
   `MAX_VERIFICATION_REPAIR_RUNS`, default `1`), then re-runs the checks. The
   usual token guard applies before an automatic repair starts. A
   budget-approved `continue` remains exactly one Codex run and does not add a
-  repair attempt. A PR is opt-in and still requires human review. The worker
-  never merges.
+  repair attempt. A successfully verified implementation with repository
+  changes is committed, pushed, and opened as a PR before the worker applies
+  `codex:needs-review`; it still requires human review and the worker never
+  merges.
 - It records token totals from Codex's JSON completion events. It will not make
   a follow-up run after the pre-turn guard, and it will not automatically create
   a PR after the total meets the budget. These are cumulative-usage circuit
@@ -55,7 +57,7 @@ Run from the repository root:
 ```bash
 chmod +x scripts/codex-issue-worker
 scripts/codex-issue-worker init
-# Review .codex-issue-worker/config.sh. Keep AUTO_CREATE_PR=false initially.
+# Review .codex-issue-worker/config.sh.
 scripts/codex-issue-worker bootstrap-labels
 scripts/codex-issue-worker enable
 scripts/codex-issue-worker run --dry-run

--- a/scripts/codex-issue-worker
+++ b/scripts/codex-issue-worker
@@ -65,7 +65,6 @@ require_initialized() {
   : "${TOKEN_BUDGET:?missing TOKEN_BUDGET in $CONFIG_FILE}"
   : "${PRETURN_TOKEN_GUARD:?missing PRETURN_TOKEN_GUARD in $CONFIG_FILE}"
   : "${VERIFY_COMMAND:?missing VERIFY_COMMAND in $CONFIG_FILE}"
-  : "${AUTO_CREATE_PR:?missing AUTO_CREATE_PR in $CONFIG_FILE}"
   : "${MAX_VERIFICATION_REPAIR_RUNS:=1}"
 
   [[ "$MAX_VERIFICATION_REPAIR_RUNS" =~ ^[0-9]+$ ]] || die "MAX_VERIFICATION_REPAIR_RUNS must be a non-negative integer"
@@ -442,7 +441,7 @@ skipping repository checks, then rerun the required verification."
   fi
 }
 
-verify_and_maybe_open_pr() {
+verify_and_open_pr() {
   local issue_number="$1"
   local worktree="$2"
   local verification_log="$3"
@@ -475,12 +474,6 @@ verify_and_maybe_open_pr() {
   if git -C "$worktree" diff --quiet && [ -z "$(git -C "$worktree" ls-files --others --exclude-standard)" ]; then
     add_label "$issue_number" "$REVIEW_LABEL"
     comment "$issue_number" "Codex completed without a repository change. Review its final message and worktree at \`$worktree\`."
-    return 0
-  fi
-
-  if [ "$AUTO_CREATE_PR" != "true" ]; then
-    add_label "$issue_number" "$REVIEW_LABEL"
-    comment "$issue_number" "Codex completed and verification passed. Automatic PR creation is disabled; review the worktree at \`$worktree\`."
     return 0
   fi
 
@@ -522,7 +515,7 @@ run_and_verify() {
     fi
 
     verification_log="$worktree/.codex-issue-worker/verification-$(basename "$run_log" .jsonl).log"
-    if verify_and_maybe_open_pr "$issue_number" "$worktree" "$verification_log"; then
+    if verify_and_open_pr "$issue_number" "$worktree" "$verification_log"; then
       return
     else
       verification_status="$?"

--- a/scripts/codex-issue-worker.config.example
+++ b/scripts/codex-issue-worker.config.example
@@ -26,10 +26,5 @@ VERIFY_COMMAND="pnpm lint && pnpm test"
 # still stop a repair run that would require explicit human approval.
 MAX_VERIFICATION_REPAIR_RUNS=1
 
-# Leave false for the initial rollout. If changed to true, a successfully
-# verified run commits its worktree, pushes codex/issue-<n>, and creates a PR.
-# The worker never merges the PR and still blocks on this issue until release.
-AUTO_CREATE_PR=false
-
 # Optional. Empty means use your local Codex default.
 CODEX_MODEL=""


### PR DESCRIPTION
## Summary

The local issue worker now automatically commits, pushes, and opens a pull request for every successful, verified implementation that changes the repository. It applies `codex:needs-review` only after PR creation succeeds.

The obsolete `AUTO_CREATE_PR` rollout switch has been removed from the example configuration and the worker documentation now describes the required PR-before-review flow. The worker still never merges.

## Validation

- `zsh -n scripts/codex-issue-worker`
- `git diff --check`