### PR TITLE
Document dotnet-to-TypeScript migration status in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,22 @@ The five canonical triage roles, each label string equal to its name. See `docs/
 
 Single-context — `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.
 
+## Dotnet-to-TypeScript migration in progress
+
+`Irudd.Piploy.App` (C#) is legacy but still the code actually running on the
+Pi — it is not dead code. `src/` (TypeScript) is the port target and is
+incomplete; e.g. there is no Docker module yet. Deleting `Irudd.Piploy.App`
+is the last step of the port, tracked by
+[issue #17](https://github.com/alundgren/Irudd.Piploy/issues/17), and won't
+happen until then.
+
+Before changing behavior around git, Docker, config, or deploy — in either
+codebase — check [issue #1](https://github.com/alundgren/Irudd.Piploy/issues/1)
+(the wayfinder map) for the port's current state and decisions. A change
+scoped only against its own issue text can easily land in the wrong
+codebase, or in one but not both, and get silently dropped when the dotnet
+project is deleted.
+
 ## TypeScript verification
 
 Run `pnpm lint` and `pnpm test` before considering TypeScript changes complete.


### PR DESCRIPTION
## Summary
- Investigating why #20/PR #39 hardened Docker image validation in the legacy C# app (`Irudd.Piploy.App`) instead of the not-yet-built TS `docker.ts` module surfaced that nothing in the repo flags the dotnet app as live-but-legacy during the port, or points agents at the wayfinder map (#1) before touching git/Docker/config/deploy behavior.
- Adds a short section to `CLAUDE.md` explaining that `Irudd.Piploy.App` still runs on the Pi, `src/` is the incomplete port target, deletion is gated on #17, and cross-cutting behavior changes should be checked against #1 first.

## Test plan
- Docs-only change; no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)