### PR TITLE
Implement config loading and logging (settings.ts, logger.ts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "build": "tsup"
   },
   "dependencies": {
-    "commander": "^14.0.0"
+    "commander": "^14.0.0",
+    "pino": "^10.3.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       commander:
         specifier: ^14.0.0
         version: 14.0.3
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -294,6 +300,9 @@ packages:
 
   '@oxc-project/types@0.142.0':
     resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@rolldown/binding-android-arm64@1.2.1':
     resolution: {integrity: sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==}
@@ -665,6 +674,10 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1056,6 +1069,10 @@ packages:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1089,6 +1106,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
 
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
@@ -1128,13 +1155,26 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process-warning@5.1.0:
+    resolution: {integrity: sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  real-require@1.0.0:
+    resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1154,6 +1194,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -1170,6 +1214,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1177,6 +1224,10 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1203,6 +1254,10 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thread-stream@4.2.0:
+    resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
+    engines: {node: '>=20'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1383,6 +1438,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -1567,6 +1625,8 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.142.0': {}
+
+  '@pinojs/redact@0.4.0': {}
 
   '@rolldown/binding-android-arm64@1.2.1':
     optional: true
@@ -1870,6 +1930,8 @@ snapshots:
   argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
+
+  atomic-sleep@1.0.0: {}
 
   balanced-match@1.0.2: {}
 
@@ -2226,6 +2288,8 @@ snapshots:
 
   obug@2.1.4: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -2257,6 +2321,26 @@ snapshots:
 
   picomatch@4.0.5: {}
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.1.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.2.0
+
   pirates@4.0.7: {}
 
   pkg-types@1.3.1:
@@ -2281,9 +2365,17 @@ snapshots:
 
   prettier@3.9.6: {}
 
+  process-warning@5.1.0: {}
+
   punycode@2.3.1: {}
 
+  quick-format-unescaped@4.0.4: {}
+
   readdirp@4.1.2: {}
+
+  real-require@0.2.0: {}
+
+  real-require@1.0.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -2342,6 +2434,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
+  safe-stable-stringify@2.5.0: {}
+
   semver@7.8.5: {}
 
   shebang-command@2.0.0:
@@ -2352,9 +2446,15 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
+
+  split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
@@ -2383,6 +2483,10 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  thread-stream@4.2.0:
+    dependencies:
+      real-require: 1.0.0
 
   tinybench@2.9.0: {}
 
@@ -2512,3 +2616,5 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,113 @@
+import { appendFileSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
+import path from "node:path";
+
+import pino from "pino";
+
+import type { PiploySettings } from "./settings.js";
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface LogScope {
+  operation?: string;
+  application?: string;
+  gitRepository?: string;
+}
+
+export interface Logger {
+  debug(message: string): void;
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+  child(scope: LogScope): Logger;
+}
+
+const reservedKeys = new Set(["level", "time", "msg", "pid", "hostname"]);
+
+/**
+ * .NET's `CalendarWeekRule.FirstDay` + Monday-first week, matching the ported
+ * file's original rotation cadence exactly (not true ISO 8601, whose week 1
+ * can start in the prior year).
+ */
+export function calendarWeekOfYear(date: Date): number {
+  const year = date.getUTCFullYear();
+  const jan1 = Date.UTC(year, 0, 1);
+  const dayOfYear =
+    Math.floor((date.getTime() - jan1) / (24 * 60 * 60 * 1000)) + 1;
+  const jan1Iso = ((new Date(jan1).getUTCDay() + 6) % 7) + 1; // Mon=1..Sun=7
+  const daysInWeek1 = 8 - jan1Iso;
+  if (dayOfYear <= daysInWeek1) {
+    return 1;
+  }
+  return 1 + Math.ceil((dayOfYear - daysInWeek1) / 7);
+}
+
+function formatTimestamp(date: Date): string {
+  return date.toISOString().slice(0, 19).replace("T", " ");
+}
+
+function formatLine(parsed: Record<string, unknown>): string {
+  const scopeEntries = Object.entries(parsed).filter(
+    ([key]) => !reservedKeys.has(key),
+  );
+  const scopePrefix = `[${scopeEntries.map(([key, value]) => `${key}=${String(value)}`).join(", ")}]`;
+  const timestamp = formatTimestamp(new Date(parsed.time as number));
+  return `${timestamp} ${scopePrefix} ${String(parsed.msg)}`;
+}
+
+function getLogFolder(settings: PiploySettings): string {
+  return path.join(settings.RootDirectory, "logs");
+}
+
+function rotatingLogFilename(now: Date): string {
+  return `piploy-log-${now.getUTCFullYear()}-${calendarWeekOfYear(now)}.txt`;
+}
+
+function writeRotatingLogLine(logFolder: string, line: string): void {
+  const now = new Date();
+  const currentFilename = rotatingLogFilename(now);
+  for (const entry of readdirSync(logFolder, { withFileTypes: true })) {
+    if (
+      entry.isFile() &&
+      entry.name.startsWith("piploy-log-") &&
+      entry.name !== currentFilename
+    ) {
+      unlinkSync(path.join(logFolder, entry.name));
+    }
+  }
+  appendFileSync(path.join(logFolder, currentFilename), line + "\n");
+}
+
+function createTextStream(logFolder: string): pino.DestinationStream {
+  return {
+    write(rawLine: string) {
+      if (!rawLine.trim()) return;
+      const parsed = JSON.parse(rawLine) as Record<string, unknown>;
+      const line = formatLine(parsed);
+      process.stdout.write(line + "\n");
+      writeRotatingLogLine(logFolder, line);
+    },
+  };
+}
+
+function wrap(pinoLogger: pino.Logger): Logger {
+  return {
+    debug: (message) => pinoLogger.debug(message),
+    info: (message) => pinoLogger.info(message),
+    warn: (message) => pinoLogger.warn(message),
+    error: (message) => pinoLogger.error(message),
+    child: (scope) => wrap(pinoLogger.child(scope)),
+  };
+}
+
+export function createLogger(
+  settings: PiploySettings,
+  level: LogLevel = "info",
+): Logger {
+  const logFolder = getLogFolder(settings);
+  mkdirSync(logFolder, { recursive: true });
+  const pinoLogger = pino(
+    { level, base: undefined, timestamp: pino.stdTimeFunctions.epochTime },
+    createTextStream(logFolder),
+  );
+  return wrap(pinoLogger);
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { z } from "zod";
+
+const portMappingPattern = /^(\d+):(\d+)$/;
+
+const PortMappingSchema = z.string().transform((value, ctx) => {
+  const match = portMappingPattern.exec(value);
+  if (!match) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "Invalid port mappings. Must have the format <hostPort>:<containerPort>",
+    });
+    return z.NEVER;
+  }
+  return {
+    hostPort: Number(match[1]),
+    containerPort: Number(match[2]),
+  };
+});
+
+const ApplicationSchema = z.object({
+  Name: z.string().regex(/^[A-Za-z0-9_-]+$/),
+  GitRepositoryUrl: z.string(),
+  DockerfilePath: z.string(),
+  PortMappings: z.array(PortMappingSchema).optional(),
+});
+
+const PiploySettingsSchema = z.object({
+  RootDirectory: z.string(),
+  MinutesBetweenBackgroundPolls: z.number().optional(),
+  Applications: z.array(ApplicationSchema),
+  IsTestRun: z.boolean().optional(),
+});
+
+const ConfigFileSchema = z.object({
+  Piploy: PiploySettingsSchema,
+});
+
+export type PortMapping = { hostPort: number; containerPort: number };
+export type Application = z.infer<typeof ApplicationSchema>;
+export type PiploySettings = z.infer<typeof PiploySettingsSchema>;
+
+export function parseSettings(json: unknown): PiploySettings {
+  return ConfigFileSchema.parse(json).Piploy;
+}
+
+export function loadSettings(configPath: string): PiploySettings {
+  const raw = readFileSync(configPath, "utf8");
+  return parseSettings(JSON.parse(raw));
+}
+
+/** `piploy.json` resolves relative to the running bundle, not CWD, with a `PIPLOY_CONFIG` override (#8). */
+export function resolveConfigPath(
+  bundleDir: string = defaultBundleDirectory(),
+): string {
+  return process.env.PIPLOY_CONFIG ?? path.join(bundleDir, "piploy.json");
+}
+
+function defaultBundleDirectory(): string {
+  return path.dirname(fileURLToPath(import.meta.url));
+}
+
+export function getApplicationRootDirectory(
+  settings: PiploySettings,
+  application: Application,
+): string {
+  return path.join(settings.RootDirectory, application.Name);
+}
+
+export function getApplicationRepoDirectory(
+  settings: PiploySettings,
+  application: Application,
+): string {
+  return path.join(getApplicationRootDirectory(settings, application), "repo");
+}

--- a/test/unit/fixtures/piploy.valid.json
+++ b/test/unit/fixtures/piploy.valid.json
@@ -1,0 +1,15 @@
+{
+  "Piploy": {
+    "RootDirectory": "/home/irudd/Piploy/root",
+    "MinutesBetweenBackgroundPolls": 60,
+    "Applications": [
+      {
+        "Name": "app1",
+        "GitRepositoryUrl": "https://github.com/example/app1.git",
+        "DockerfilePath": "Dockerfile",
+        "PortMappings": ["8080:80"]
+      }
+    ],
+    "IsTestRun": false
+  }
+}

--- a/test/unit/fixtures/piploy.valid.json
+++ b/test/unit/fixtures/piploy.valid.json
@@ -1,6 +1,6 @@
 {
   "Piploy": {
-    "RootDirectory": "/home/irudd/Piploy/root",
+    "RootDirectory": "/opt/piploy/root",
     "MinutesBetweenBackgroundPolls": 60,
     "Applications": [
       {

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -27,7 +27,7 @@ describe("loadSettings", () => {
     const settings = loadSettings(path.join(fixturesDir, "piploy.valid.json"));
 
     expect(settings).toEqual({
-      RootDirectory: "/home/irudd/Piploy/root",
+      RootDirectory: "/opt/piploy/root",
       MinutesBetweenBackgroundPolls: 60,
       Applications: [
         {
@@ -125,16 +125,12 @@ describe("resolveConfigPath", () => {
 
   it("resolves piploy.json relative to the bundle directory by default", () => {
     delete process.env.PIPLOY_CONFIG;
-    expect(resolveConfigPath("/home/irudd/Piploy")).toBe(
-      "/home/irudd/Piploy/piploy.json",
-    );
+    expect(resolveConfigPath("/opt/piploy")).toBe("/opt/piploy/piploy.json");
   });
 
   it("prefers the PIPLOY_CONFIG override when set", () => {
     process.env.PIPLOY_CONFIG = "/etc/piploy/custom.json";
-    expect(resolveConfigPath("/home/irudd/Piploy")).toBe(
-      "/etc/piploy/custom.json",
-    );
+    expect(resolveConfigPath("/opt/piploy")).toBe("/etc/piploy/custom.json");
   });
 });
 
@@ -142,17 +138,17 @@ describe("application directories", () => {
   it("derives the per-application root and repo directories", () => {
     const settings = parseSettings({
       Piploy: {
-        RootDirectory: "/home/irudd/Piploy/root",
+        RootDirectory: "/opt/piploy/root",
         Applications: [validApplication],
       },
     });
     const application = settings.Applications[0]!;
 
     expect(getApplicationRootDirectory(settings, application)).toBe(
-      "/home/irudd/Piploy/root/app1",
+      "/opt/piploy/root/app1",
     );
     expect(getApplicationRepoDirectory(settings, application)).toBe(
-      "/home/irudd/Piploy/root/app1/repo",
+      "/opt/piploy/root/app1/repo",
     );
   });
 });

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -1,0 +1,158 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  getApplicationRepoDirectory,
+  getApplicationRootDirectory,
+  loadSettings,
+  parseSettings,
+  resolveConfigPath,
+} from "../../src/settings.js";
+
+const fixturesDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fixtures",
+);
+
+const validApplication = {
+  Name: "app1",
+  GitRepositoryUrl: "https://github.com/example/app1.git",
+  DockerfilePath: "Dockerfile",
+};
+
+describe("loadSettings", () => {
+  it("reads and validates a valid piploy.json fixture", () => {
+    const settings = loadSettings(path.join(fixturesDir, "piploy.valid.json"));
+
+    expect(settings).toEqual({
+      RootDirectory: "/home/irudd/Piploy/root",
+      MinutesBetweenBackgroundPolls: 60,
+      Applications: [
+        {
+          Name: "app1",
+          GitRepositoryUrl: "https://github.com/example/app1.git",
+          DockerfilePath: "Dockerfile",
+          PortMappings: [{ hostPort: 8080, containerPort: 80 }],
+        },
+      ],
+      IsTestRun: false,
+    });
+  });
+});
+
+describe("parseSettings", () => {
+  it("accepts a minimal valid config with no optional fields", () => {
+    const settings = parseSettings({
+      Piploy: {
+        RootDirectory: "/root",
+        Applications: [validApplication],
+      },
+    });
+
+    expect(settings.MinutesBetweenBackgroundPolls).toBeUndefined();
+    expect(settings.IsTestRun).toBeUndefined();
+    expect(settings.Applications[0]?.PortMappings).toBeUndefined();
+  });
+
+  it("rejects a config missing the Piploy wrapper key", () => {
+    expect(() =>
+      parseSettings({ RootDirectory: "/root", Applications: [] }),
+    ).toThrow();
+  });
+
+  it("rejects a config missing RootDirectory", () => {
+    expect(() =>
+      parseSettings({ Piploy: { Applications: [validApplication] } }),
+    ).toThrow();
+  });
+
+  it("rejects an application name with invalid characters", () => {
+    expect(() =>
+      parseSettings({
+        Piploy: {
+          RootDirectory: "/root",
+          Applications: [{ ...validApplication, Name: "app 1!" }],
+        },
+      }),
+    ).toThrow();
+  });
+
+  it.each(["8080", "8080:", ":80", "abc:80", "8080:80:90"])(
+    "rejects an invalid port mapping string %s",
+    (mapping) => {
+      expect(() =>
+        parseSettings({
+          Piploy: {
+            RootDirectory: "/root",
+            Applications: [{ ...validApplication, PortMappings: [mapping] }],
+          },
+        }),
+      ).toThrow(
+        "Invalid port mappings. Must have the format <hostPort>:<containerPort>",
+      );
+    },
+  );
+
+  it("parses port mappings into typed host/container pairs", () => {
+    const settings = parseSettings({
+      Piploy: {
+        RootDirectory: "/root",
+        Applications: [
+          { ...validApplication, PortMappings: ["8080:80", "9090:90"] },
+        ],
+      },
+    });
+
+    expect(settings.Applications[0]?.PortMappings).toEqual([
+      { hostPort: 8080, containerPort: 80 },
+      { hostPort: 9090, containerPort: 90 },
+    ]);
+  });
+});
+
+describe("resolveConfigPath", () => {
+  const originalEnv = process.env.PIPLOY_CONFIG;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.PIPLOY_CONFIG;
+    } else {
+      process.env.PIPLOY_CONFIG = originalEnv;
+    }
+  });
+
+  it("resolves piploy.json relative to the bundle directory by default", () => {
+    delete process.env.PIPLOY_CONFIG;
+    expect(resolveConfigPath("/home/irudd/Piploy")).toBe(
+      "/home/irudd/Piploy/piploy.json",
+    );
+  });
+
+  it("prefers the PIPLOY_CONFIG override when set", () => {
+    process.env.PIPLOY_CONFIG = "/etc/piploy/custom.json";
+    expect(resolveConfigPath("/home/irudd/Piploy")).toBe(
+      "/etc/piploy/custom.json",
+    );
+  });
+});
+
+describe("application directories", () => {
+  it("derives the per-application root and repo directories", () => {
+    const settings = parseSettings({
+      Piploy: {
+        RootDirectory: "/home/irudd/Piploy/root",
+        Applications: [validApplication],
+      },
+    });
+    const application = settings.Applications[0]!;
+
+    expect(getApplicationRootDirectory(settings, application)).toBe(
+      "/home/irudd/Piploy/root/app1",
+    );
+    expect(getApplicationRepoDirectory(settings, application)).toBe(
+      "/home/irudd/Piploy/root/app1/repo",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `src/settings.ts`: zod schema for `piploy.json`, byte-identical to the C# shape, `PortMappings` parsed eagerly, `resolveConfigPath()` implements #8's bundle-relative + `PIPLOY_CONFIG`-override resolution
- `src/logger.ts`: pino behind a small `Logger` interface, human-readable text output (not JSON) to stdout + a rotating file per ADR-0001, `child()` scopes replacing `BeginScope`, weekly rotation matching .NET's `CalendarWeekRule.FirstDay` cadence
- Along the way, wired the map's missing native dependency edges for issues #25–#30 and #17 (previously only declared as body text, not enforced), so the wayfinder frontier query is accurate again

Resolves #23.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] Manual smoke test of `logger.ts` against a real temp directory (both destinations, scope nesting, level filtering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)