### PR TITLE
Implement orchestrator and status modules

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,0 +1,81 @@
+import { createDockerService } from "./docker.js";
+import { ensureLocalRepository, getLatestCommit } from "./git.js";
+import type { Logger } from "./logger.js";
+import type { Application, PiploySettings } from "./settings.js";
+
+export interface OrchestratorDeps {
+  ensureLocalRepository(application: Application): Promise<void>;
+  getLatestCommit(application: Application): Promise<{ hash: string }>;
+  ensureImageExists(
+    application: Application,
+    commit: { hash: string },
+  ): Promise<void>;
+  ensureContainerRunning(
+    application: Application,
+    commit: { hash: string },
+  ): Promise<void>;
+  cleanupInactive(applications: Application[]): Promise<void>;
+}
+
+export interface Orchestrator {
+  poll(): Promise<void>;
+}
+
+function logError(logger: Logger, error: unknown): void {
+  logger.error(error instanceof Error ? error.message : String(error));
+}
+
+/** Wires the one real git and Docker adapter into the orchestrator's narrow seam. */
+export function createOrchestratorDeps(
+  settings: PiploySettings,
+  logger: Logger,
+): OrchestratorDeps {
+  const docker = createDockerService(settings, logger);
+
+  return {
+    ensureLocalRepository: (application) =>
+      ensureLocalRepository(settings, application, logger),
+    getLatestCommit: (application) => getLatestCommit(settings, application),
+    async ensureImageExists(application, commit) {
+      await docker.ensureImageExists(application, commit);
+    },
+    async ensureContainerRunning(application, commit) {
+      await docker.ensureContainerRunning(application, commit);
+    },
+    cleanupInactive: (applications) => docker.cleanupInactive(applications),
+  };
+}
+
+export function createOrchestrator(
+  settings: PiploySettings,
+  logger: Logger,
+  deps: OrchestratorDeps = createOrchestratorDeps(settings, logger),
+): Orchestrator {
+  async function poll(): Promise<void> {
+    const pollLogger = logger.child({ operation: "poll" });
+    pollLogger.info("Polling applications");
+
+    try {
+      for (const application of settings.Applications) {
+        const applicationLogger = pollLogger.child({
+          application: application.Name,
+        });
+        applicationLogger.info(`Polling application: ${application.Name}`);
+
+        try {
+          await deps.ensureLocalRepository(application);
+          const commit = await deps.getLatestCommit(application);
+          await deps.ensureImageExists(application, commit);
+          await deps.ensureContainerRunning(application, commit);
+        } catch (error) {
+          logError(applicationLogger, error);
+        }
+      }
+    } finally {
+      pollLogger.info("Cleaning up unused images");
+      await deps.cleanupInactive(settings.Applications);
+    }
+  }
+
+  return { poll };
+}

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,0 +1,14 @@
+import type { DockerStatus } from "./docker.js";
+import type { GitCommitStatus } from "./git.js";
+
+/** Whether the running container was built from the remote repository tip. */
+export function isRunningLatestVersion(
+  commitStatus: GitCommitStatus | null,
+  dockerStatus: DockerStatus,
+): boolean {
+  return (
+    commitStatus !== null &&
+    dockerStatus.runningContainerHash !== undefined &&
+    commitStatus.remote.hash === dockerStatus.runningContainerHash
+  );
+}

--- a/test/unit/orchestrator.test.ts
+++ b/test/unit/orchestrator.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createOrchestrator,
+  type OrchestratorDeps,
+} from "../../src/orchestrator.js";
+import type { Logger } from "../../src/logger.js";
+import type { Application, PiploySettings } from "../../src/settings.js";
+
+const applications: Application[] = [
+  {
+    Name: "first",
+    GitRepositoryUrl: "https://example.test/first.git",
+    DockerfilePath: "Dockerfile",
+  },
+  {
+    Name: "second",
+    GitRepositoryUrl: "https://example.test/second.git",
+    DockerfilePath: "Dockerfile",
+  },
+];
+
+const settings: PiploySettings = {
+  RootDirectory: "/tmp/piploy",
+  Applications: applications,
+};
+
+function createLogger(): Logger {
+  const logger: Logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => logger,
+  };
+  return logger;
+}
+
+function createDeps(): OrchestratorDeps {
+  return {
+    ensureLocalRepository: vi.fn(),
+    getLatestCommit: vi.fn(async () => ({ hash: "abc123" })),
+    ensureImageExists: vi.fn(),
+    ensureContainerRunning: vi.fn(),
+    cleanupInactive: vi.fn(),
+  };
+}
+
+describe("orchestrator", () => {
+  it("reconciles each application in order, then cleans up inactive images", async () => {
+    const calls: string[] = [];
+    const deps = createDeps();
+    deps.ensureLocalRepository = vi.fn(async (application) => {
+      calls.push(`repository:${application.Name}`);
+    });
+    deps.getLatestCommit = vi.fn(async (application) => {
+      calls.push(`commit:${application.Name}`);
+      return { hash: application.Name };
+    });
+    deps.ensureImageExists = vi.fn(async (application, commit) => {
+      calls.push(`image:${application.Name}:${commit.hash}`);
+    });
+    deps.ensureContainerRunning = vi.fn(async (application, commit) => {
+      calls.push(`container:${application.Name}:${commit.hash}`);
+    });
+    deps.cleanupInactive = vi.fn(
+      async (configuredApplications: Application[]) => {
+        calls.push(
+          `cleanup:${configuredApplications.map(({ Name }) => Name).join(",")}`,
+        );
+      },
+    );
+
+    await createOrchestrator(settings, createLogger(), deps).poll();
+
+    expect(calls).toEqual([
+      "repository:first",
+      "commit:first",
+      "image:first:first",
+      "container:first:first",
+      "repository:second",
+      "commit:second",
+      "image:second:second",
+      "container:second:second",
+      "cleanup:first,second",
+    ]);
+  });
+
+  it("isolates an application failure and continues to the next application", async () => {
+    const deps = createDeps();
+    const errors: string[] = [];
+    const logger = createLogger();
+    logger.error = (message) => errors.push(message);
+    deps.ensureImageExists = vi.fn(async (application) => {
+      if (application.Name === "first") throw new Error("build failed");
+    });
+
+    await createOrchestrator(settings, logger, deps).poll();
+
+    expect(deps.ensureContainerRunning).toHaveBeenCalledTimes(1);
+    expect(deps.ensureContainerRunning).toHaveBeenCalledWith(applications[1], {
+      hash: "abc123",
+    });
+    expect(deps.cleanupInactive).toHaveBeenCalledWith(applications);
+    expect(errors).toEqual(["build failed"]);
+  });
+});

--- a/test/unit/status.test.ts
+++ b/test/unit/status.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { isRunningLatestVersion } from "../../src/status.js";
+
+const commitStatus = {
+  local: {
+    hash: "local",
+    date: new Date("2026-01-01T00:00:00Z"),
+    message: "local commit",
+  },
+  remote: {
+    hash: "remote",
+    date: new Date("2026-01-02T00:00:00Z"),
+    message: "remote commit",
+  },
+};
+
+describe("isRunningLatestVersion", () => {
+  it("returns true when the running container matches the remote tip", () => {
+    expect(
+      isRunningLatestVersion(commitStatus, {
+        latestImageHash: "remote",
+        runningContainerHash: "remote",
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    [null, { runningContainerHash: "remote" }],
+    [commitStatus, { latestImageHash: "remote" }],
+    [commitStatus, { runningContainerHash: "local" }],
+  ])(
+    "returns false when the repository or running container is not current",
+    (gitStatus, dockerStatus) => {
+      expect(isRunningLatestVersion(gitStatus, dockerStatus)).toBe(false);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- add the poll orchestrator with real git/Docker wiring and a narrow test seam
- isolate failures per application while always cleaning up inactive images
- add the pure running-latest-version status comparison and unit coverage

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm build`

Closes #27