### PR TITLE
Implement self-update

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 import { Command } from "commander";
 
 import { notImplementedMessage } from "./commands.js";
+import type { Logger } from "./logger.js";
+import { attemptSelfUpdate } from "./selfUpdate.js";
 import { piployVersion } from "./version.js";
 
 const commandNames = [
@@ -21,10 +23,27 @@ function registerStubCommand(
   });
 }
 
+function createConsoleLogger(): Logger {
+  const logger: Logger = {
+    debug: (message) => console.debug(message),
+    info: (message) => console.log(message),
+    warn: (message) => console.warn(message),
+    error: (message) => console.error(message),
+    child: () => logger,
+  };
+  return logger;
+}
+
 export function createProgram(): Command {
   const program = new Command();
 
   program.name("piploy").version(piployVersion);
+  program.command("self-update").action(async () => {
+    const result = await attemptSelfUpdate(createConsoleLogger());
+    if (result === "failed") {
+      process.exitCode = 1;
+    }
+  });
   for (const commandName of commandNames) {
     registerStubCommand(program, commandName);
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -7,6 +7,7 @@ import { getCommitStatus, type GitCommitStatus } from "./git.js";
 import type { Logger } from "./logger.js";
 import { createOrchestrator } from "./orchestrator.js";
 import { decideQueueAdmission, type QueueSource } from "./queuePolicy.js";
+import { attemptSelfUpdate, type SelfUpdateResult } from "./selfUpdate.js";
 import {
   resolveConfigPath,
   type Application,
@@ -39,6 +40,7 @@ export interface DaemonStatus {
 export interface DaemonDeps {
   poll(): Promise<void>;
   getStatus(): Promise<DaemonStatus>;
+  attemptSelfUpdate(): Promise<SelfUpdateResult>;
 }
 
 export interface DaemonOptions {
@@ -111,6 +113,7 @@ export function createDaemonDeps(
         settings.Applications.map(getApplicationStatus),
       ),
     }),
+    attemptSelfUpdate: () => attemptSelfUpdate(logger),
   };
 }
 
@@ -288,8 +291,15 @@ export async function startDaemon(
   chmodSync(socketPath, 0o600);
   server.on("error", (error) => logError(logger, error));
 
+  async function runTimerTick(): Promise<void> {
+    const updateResult = await deps.attemptSelfUpdate();
+    if (updateResult !== "updated") {
+      enqueue({ command: "poll" }, "timer");
+    }
+  }
+
   const timer = setInterval(
-    () => enqueue({ command: "poll" }, "timer"),
+    () => void runTimerTick(),
     pollIntervalMinutes * 60_000,
   );
   logger.info(`Daemon listening at ${socketPath}`);

--- a/src/selfUpdate.ts
+++ b/src/selfUpdate.ts
@@ -1,0 +1,127 @@
+import { mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { Logger } from "./logger.js";
+import { resolveBundleDirectory } from "./settings.js";
+import { piployVersion } from "./version.js";
+
+const releaseApiUrl =
+  "https://api.github.com/repos/alundgren/Irudd.Piploy/releases/latest";
+const bundleFilename = "piploy.cjs";
+
+export type SelfUpdateResult = "updated" | "up-to-date" | "failed";
+
+export interface LatestRelease {
+  tag: string;
+  downloadUrl: string;
+}
+
+interface ReleaseResponse {
+  tag_name?: unknown;
+  assets?: unknown;
+}
+
+interface ReleaseAsset {
+  name?: unknown;
+  browser_download_url?: unknown;
+}
+
+/** Optional locations make the real HTTP/file-system flow integration-testable. */
+export interface SelfUpdateOptions {
+  bundleDirectory?: string;
+  latestReleaseUrl?: string;
+}
+
+/** A release tag differs from a tagged production build exactly when it should install. */
+export function shouldSelfUpdate(
+  runningVersion: string,
+  latestTag: string,
+): boolean {
+  return runningVersion !== latestTag;
+}
+
+function latestReleaseFrom(value: unknown): LatestRelease {
+  const release = value as ReleaseResponse;
+  if (typeof release.tag_name !== "string" || !Array.isArray(release.assets)) {
+    throw new Error("Latest release response is missing release metadata");
+  }
+  const asset = (release.assets as ReleaseAsset[]).find(
+    (candidate) => candidate.name === bundleFilename,
+  );
+  if (!asset || typeof asset.browser_download_url !== "string") {
+    throw new Error(`Latest release has no ${bundleFilename} asset`);
+  }
+  return { tag: release.tag_name, downloadUrl: asset.browser_download_url };
+}
+
+export async function checkLatestRelease(
+  latestUrl: string = releaseApiUrl,
+): Promise<LatestRelease> {
+  const response = await fetch(latestUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Latest release check failed: ${response.status} ${response.statusText}`,
+    );
+  }
+  return latestReleaseFrom(await response.json());
+}
+
+async function downloadAndSwap(
+  downloadUrl: string,
+  bundleDirectory: string,
+): Promise<void> {
+  const response = await fetch(downloadUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Piploy release download failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const temporaryDirectory = await mkdtemp(
+    path.join(bundleDirectory, ".piploy-update-"),
+  );
+  const temporaryBundle = path.join(temporaryDirectory, bundleFilename);
+  const bundlePath = path.join(bundleDirectory, bundleFilename);
+  const previousBundlePath = `${bundlePath}.prev`;
+  try {
+    await writeFile(
+      temporaryBundle,
+      new Uint8Array(await response.arrayBuffer()),
+    );
+    await rename(bundlePath, previousBundlePath);
+    await rename(temporaryBundle, bundlePath);
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Checks GitHub for a release, atomically swaps in its bundle when needed, and
+ * never lets an update failure interrupt the caller's normal work.
+ */
+export async function attemptSelfUpdate(
+  logger: Logger,
+  options: SelfUpdateOptions = {},
+): Promise<SelfUpdateResult> {
+  try {
+    logger.info("Checking for a Piploy update");
+    const release = await checkLatestRelease(options.latestReleaseUrl);
+    if (!shouldSelfUpdate(piployVersion, release.tag)) {
+      logger.info(`Piploy is up to date (${piployVersion})`);
+      return "up-to-date";
+    }
+
+    logger.info(`Installing Piploy update ${release.tag}`);
+    await downloadAndSwap(
+      release.downloadUrl,
+      options.bundleDirectory ?? resolveBundleDirectory(),
+    );
+    logger.info(`Installed Piploy update ${release.tag}; restarting`);
+    process.exit(0);
+    return "updated";
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    logger.error(`Self-update failed: ${detail}`);
+    return "failed";
+  }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { z } from "zod";
 
@@ -55,13 +54,14 @@ export function loadSettings(configPath: string): PiploySettings {
 
 /** `piploy.json` resolves relative to the running bundle, not CWD, with a `PIPLOY_CONFIG` override (#8). */
 export function resolveConfigPath(
-  bundleDir: string = defaultBundleDirectory(),
+  bundleDir: string = resolveBundleDirectory(),
 ): string {
   return process.env.PIPLOY_CONFIG ?? path.join(bundleDir, "piploy.json");
 }
 
-function defaultBundleDirectory(): string {
-  return path.dirname(fileURLToPath(import.meta.url));
+/** The directory containing the running Piploy bundle. */
+export function resolveBundleDirectory(): string {
+  return path.dirname(process.argv[1] ?? process.cwd());
 }
 
 export function getApplicationRootDirectory(

--- a/test/integration/selfUpdate.test.ts
+++ b/test/integration/selfUpdate.test.ts
@@ -1,0 +1,85 @@
+import { createServer, type Server } from "node:http";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { attemptSelfUpdate } from "../../src/selfUpdate.js";
+import { createSilentLogger } from "./helpers/testLogger.js";
+
+describe("self-update", () => {
+  let server: Server;
+  let releaseApiUrl: string;
+  let bundleDirectory: string;
+
+  beforeEach(async () => {
+    server = createServer((request, response) => {
+      const origin = `http://${request.headers.host}`;
+      if (request.url === "/repos/alundgren/Irudd.Piploy/releases/latest") {
+        response.setHeader("content-type", "application/json");
+        response.end(
+          JSON.stringify({
+            tag_name: "v99.0.0",
+            assets: [
+              {
+                name: "piploy.cjs",
+                browser_download_url: `${origin}/assets/piploy.cjs`,
+              },
+            ],
+          }),
+        );
+        return;
+      }
+      if (request.url === "/assets/piploy.cjs") {
+        response.end("new Piploy bundle");
+        return;
+      }
+      response.statusCode = 404;
+      response.end();
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Fixture server did not bind to a TCP port");
+    }
+    releaseApiUrl = `http://127.0.0.1:${address.port}/repos/alundgren/Irudd.Piploy/releases/latest`;
+    bundleDirectory = await mkdtemp(path.join(os.tmpdir(), "piploy-update-"));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+    await rm(bundleDirectory, { recursive: true, force: true });
+  });
+
+  it("downloads a release from a real HTTP server and swaps only the bundle", async () => {
+    const bundlePath = path.join(bundleDirectory, "piploy.cjs");
+    const configPath = path.join(bundleDirectory, "piploy.json");
+    await writeFile(bundlePath, "old Piploy bundle");
+    await writeFile(configPath, '{"Piploy":{}}');
+    const exit = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+
+    await expect(
+      attemptSelfUpdate(createSilentLogger(), {
+        bundleDirectory,
+        latestReleaseUrl: releaseApiUrl,
+      }),
+    ).resolves.toBe("updated");
+
+    expect(exit).toHaveBeenCalledWith(0);
+    await expect(readFile(bundlePath, "utf8")).resolves.toBe(
+      "new Piploy bundle",
+    );
+    await expect(readFile(`${bundlePath}.prev`, "utf8")).resolves.toBe(
+      "old Piploy bundle",
+    );
+    await expect(readFile(configPath, "utf8")).resolves.toBe('{"Piploy":{}}');
+  });
+});

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -3,7 +3,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   startDaemon,
@@ -49,6 +49,7 @@ describe("daemon", () => {
 
   afterEach(async () => {
     await Promise.all(daemons.splice(0).map((daemon) => daemon.stop()));
+    vi.useRealTimers();
   });
 
   async function start(
@@ -82,6 +83,7 @@ describe("daemon", () => {
           },
         ],
       }),
+      attemptSelfUpdate: async () => "up-to-date",
     });
 
     expect((await stat(daemon.socketPath)).mode & 0o777).toBe(0o600);
@@ -115,6 +117,7 @@ describe("daemon", () => {
           if (polls === 1) await firstPoll;
         },
         getStatus: async () => ({ applications: [] }),
+        attemptSelfUpdate: async () => "up-to-date",
       },
       1,
     );
@@ -140,6 +143,7 @@ describe("daemon", () => {
     const daemon = await start({
       poll: async () => {},
       getStatus: async () => ({ applications: [] }),
+      attemptSelfUpdate: async () => "up-to-date",
     });
 
     await expect(
@@ -149,4 +153,39 @@ describe("daemon", () => {
       reason: "invalid-request",
     });
   });
+
+  it.each([
+    ["up-to-date", ["update", "poll"]],
+    ["failed", ["update", "poll"]],
+    ["updated", ["update"]],
+  ] as const)(
+    "runs self-update before polling on a timer tick when it is %s",
+    async (updateResult, expectedEvents) => {
+      vi.useFakeTimers();
+      const events: string[] = [];
+      const socketPath = path.join(
+        await mkdtemp(path.join(os.tmpdir(), "piploy-")),
+        "piploy.sock",
+      );
+      const daemon = await startDaemon(settings, createLogger(), {
+        socketPath,
+        pollIntervalMinutes: 1,
+        deps: {
+          attemptSelfUpdate: async () => {
+            events.push("update");
+            return updateResult;
+          },
+          poll: async () => {
+            events.push("poll");
+          },
+          getStatus: async () => ({ applications: [] }),
+        },
+      });
+      daemons.push(daemon);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(events).toEqual(expectedEvents);
+    },
+  );
 });

--- a/test/unit/selfUpdate.test.ts
+++ b/test/unit/selfUpdate.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldSelfUpdate } from "../../src/selfUpdate.js";
+
+describe("shouldSelfUpdate", () => {
+  it("updates exactly when the release tag differs from the running version", () => {
+    expect(shouldSelfUpdate("v1.2.3", "v1.2.3")).toBe(false);
+    expect(shouldSelfUpdate("v1.2.3", "v1.2.4")).toBe(true);
+    expect(shouldSelfUpdate("0.1.0+abc123", "v0.1.0")).toBe(true);
+  });
+});

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -8,6 +8,7 @@ import {
   getApplicationRootDirectory,
   loadSettings,
   parseSettings,
+  resolveBundleDirectory,
   resolveConfigPath,
 } from "../../src/settings.js";
 
@@ -131,6 +132,14 @@ describe("resolveConfigPath", () => {
   it("prefers the PIPLOY_CONFIG override when set", () => {
     process.env.PIPLOY_CONFIG = "/etc/piploy/custom.json";
     expect(resolveConfigPath("/opt/piploy")).toBe("/etc/piploy/custom.json");
+  });
+});
+
+describe("resolveBundleDirectory", () => {
+  it("uses the directory containing the invoked bundle", () => {
+    expect(resolveBundleDirectory()).toBe(
+      path.dirname(process.argv[1] ?? process.cwd()),
+    );
   });
 });
 

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  define: {
+    __PIPLOY_VERSION__: JSON.stringify("test"),
+  },
   test: {
     include: ["test/integration/**/*.test.ts"],
     fileParallelism: false,

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  define: {
+    __PIPLOY_VERSION__: JSON.stringify("test"),
+  },
   test: {
     include: ["test/unit/**/*.test.ts"],
     exclude: ["test/integration/**"],


### PR DESCRIPTION
Closes #29

## What changed

- Added `selfUpdate.ts` to check GitHub's latest release, download `piploy.cjs` to a same-filesystem temporary location, retain the previous bundle as `piploy.cjs.prev`, and restart after a successful swap.
- Runs self-update before application polling on daemon timer ticks, while preserving fail-open polling when no update is available or an update check fails.
- Added the standalone `piploy self-update` command, which reports through the console and exits non-zero on failure without touching application configuration or `RootDirectory`.
- Exposed bundle-directory resolution through settings and supplied the build-time version constant to both Vitest suites.

## Why

Tagged releases were published but the Pi never consumed them automatically. Piploy can now reconcile its own bundle against the latest release without requiring an SSH deployment.

## Validation

- `pnpm lint`
- `pnpm test` — 44 passed
- `pnpm test:integration` — 10 passed, including real local HTTP download and filesystem swap coverage
- `pnpm build`