### PR TITLE
Wire CLI commands to daemon

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,15 @@
 import { Command } from "commander";
 
-import { notImplementedMessage } from "./commands.js";
+import {
+  createCommandDeps,
+  poll,
+  serviceStart,
+  serviceStop,
+  status,
+  wipeAll,
+} from "./commands.js";
+import { createLogger } from "./logger.js";
+import { loadSettings, resolveConfigPath } from "./settings.js";
 import { piployVersion } from "./version.js";
 
 const commandNames = [
@@ -11,13 +20,21 @@ const commandNames = [
   "wipeall",
 ] as const;
 
-function registerStubCommand(
+function registerCommand(
   program: Command,
   commandName: (typeof commandNames)[number],
 ): void {
-  program.command(commandName).action(() => {
-    console.error(notImplementedMessage(commandName));
-    process.exitCode = 1;
+  program.command(commandName).action(async () => {
+    const settings = loadSettings(resolveConfigPath());
+    const deps = createCommandDeps(settings, createLogger(settings));
+    const actions = {
+      status,
+      "service-start": serviceStart,
+      "service-stop": serviceStop,
+      poll,
+      wipeall: wipeAll,
+    } as const;
+    await actions[commandName](deps);
   });
 }
 
@@ -26,10 +43,10 @@ export function createProgram(): Command {
 
   program.name("piploy").version(piployVersion);
   for (const commandName of commandNames) {
-    registerStubCommand(program, commandName);
+    registerCommand(program, commandName);
   }
 
   return program;
 }
 
-createProgram().parse();
+void createProgram().parseAsync();

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,3 +1,146 @@
-export function notImplementedMessage(command: string): string {
-  return `${command}: not implemented`;
+import { rmSync } from "node:fs";
+
+import {
+  createDaemonDeps,
+  requestDaemon,
+  startDaemon,
+  type Daemon,
+  type DaemonRequest,
+  type DaemonResponse,
+  type DaemonStatus,
+} from "./daemon.js";
+import { createDockerService } from "./docker.js";
+import type { Logger } from "./logger.js";
+import type { PiploySettings } from "./settings.js";
+import { piployVersion } from "./version.js";
+
+export interface CommandDeps {
+  requestDaemon(request: DaemonRequest): Promise<DaemonResponse | undefined>;
+  computeStatusInline(): Promise<DaemonStatus>;
+  pollInline(): Promise<void>;
+  wipeAll(): Promise<void>;
+  startDaemon(): Promise<Daemon>;
+}
+
+/** Wires CLI commands to the one real daemon, orchestration, and Docker adapters. */
+export function createCommandDeps(
+  settings: PiploySettings,
+  logger: Logger,
+): CommandDeps {
+  const daemonDeps = createDaemonDeps(settings, logger);
+  return {
+    requestDaemon,
+    computeStatusInline: daemonDeps.getStatus,
+    pollInline: daemonDeps.poll,
+    async wipeAll() {
+      try {
+        await createDockerService(settings, logger).cleanupAll();
+      } finally {
+        rmSync(settings.RootDirectory, { recursive: true, force: true });
+      }
+    },
+    startDaemon: () => startDaemon(settings, logger),
+  };
+}
+
+function commandFailed(message: string): void {
+  console.error(message);
+  process.exitCode = 1;
+}
+
+function printStatus(status: DaemonStatus, daemonReachable: boolean): void {
+  console.log(`Piploy version: ${piployVersion}`);
+  console.log(
+    `Background service: ${daemonReachable ? "running" : "not running"}`,
+  );
+  for (const application of status.applications) {
+    console.log(`\n${application.application}`);
+    console.log(
+      `  Running latest version: ${application.isRunningLatestVersion ? "yes" : "no"}`,
+    );
+    console.log(
+      `  Latest local commit: ${application.git?.local.hash ?? "none"}`,
+    );
+    console.log(
+      `  Latest remote commit: ${application.git?.remote.hash ?? "none"}`,
+    );
+    console.log(
+      `  Latest image hash: ${application.docker.latestImageHash ?? "none"}`,
+    );
+    console.log(
+      `  Running container hash: ${application.docker.runningContainerHash ?? "none"}`,
+    );
+  }
+}
+
+/** Prints daemon status, falling back to local git/Docker state only when unreachable. */
+export async function status(deps: CommandDeps): Promise<void> {
+  const response = await deps.requestDaemon({ command: "status" });
+  if (response === undefined) {
+    printStatus(await deps.computeStatusInline(), false);
+    return;
+  }
+  if (!response.ok) {
+    commandFailed(`Daemon status request failed: ${response.reason}`);
+    return;
+  }
+  if (!("status" in response)) {
+    commandFailed("Daemon status request returned no status");
+    return;
+  }
+  printStatus(response.status, true);
+}
+
+/** Requests an immediate daemon poll, or reconciles inline when no daemon is running. */
+export async function poll(deps: CommandDeps): Promise<void> {
+  const response = await deps.requestDaemon({ command: "poll" });
+  if (response === undefined) {
+    await deps.pollInline();
+    console.log("Poll completed.");
+    return;
+  }
+  if (!response.ok) {
+    commandFailed(`Daemon poll request failed: ${response.reason}`);
+    return;
+  }
+  console.log("Poll completed.");
+}
+
+/** Asks the running daemon to stop without falling back to a local action. */
+export async function serviceStop(deps: CommandDeps): Promise<void> {
+  const response = await deps.requestDaemon({ command: "stop" });
+  if (response === undefined) {
+    commandFailed("No Piploy daemon is reachable.");
+    return;
+  }
+  if (!response.ok) {
+    commandFailed(`Daemon stop request failed: ${response.reason}`);
+    return;
+  }
+  console.log("Piploy daemon stopped.");
+}
+
+/** Cleans up all Piploy Docker resources and removes the configured root directory. */
+export async function wipeAll(deps: CommandDeps): Promise<void> {
+  await deps.wipeAll();
+  console.log("Removed all Piploy containers, images, and files.");
+}
+
+/** Starts the foreground daemon and lets SIGINT/SIGTERM stop it cleanly. */
+export async function serviceStart(deps: CommandDeps): Promise<void> {
+  const daemon = await deps.startDaemon();
+  let stopping = false;
+  const stop = () => {
+    if (stopping) return;
+    stopping = true;
+    void daemon
+      .stop()
+      .then(() => process.exit(0))
+      .catch((error: unknown) => {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exitCode = 1;
+      });
+  };
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -18,7 +18,8 @@ const defaultQueueCapacity = 1000;
 const defaultPollIntervalMinutes = 60;
 const socketProbeTimeoutMilliseconds = 750;
 
-export type DaemonRequest = { command: "status" } | { command: "poll" };
+export type DaemonRequest =
+  { command: "status" } | { command: "poll" } | { command: "stop" };
 
 export type DaemonResponse =
   | { ok: true; status: DaemonStatus }
@@ -58,7 +59,8 @@ interface QueuedRequest {
   respond(response: DaemonResponse): void;
 }
 
-function defaultSocketPath(): string {
+/** Resolves the daemon socket alongside the active Piploy configuration. */
+export function defaultSocketPath(): string {
   return path.join(path.dirname(resolveConfigPath()), "piploy.sock");
 }
 
@@ -71,7 +73,9 @@ function parseRequest(value: unknown): DaemonRequest | undefined {
     typeof value !== "object" ||
     value === null ||
     !("command" in value) ||
-    (value.command !== "status" && value.command !== "poll")
+    (value.command !== "status" &&
+      value.command !== "poll" &&
+      value.command !== "stop")
   ) {
     return undefined;
   }
@@ -166,6 +170,59 @@ function close(server: net.Server): Promise<void> {
   });
 }
 
+/**
+ * Sends one request to the local daemon. A connection attempt doubles as the
+ * liveness probe: only establishing the socket connection is time-boxed.
+ */
+export function requestDaemon(
+  request: DaemonRequest,
+  socketPath: string = defaultSocketPath(),
+): Promise<DaemonResponse | undefined> {
+  return new Promise((resolve) => {
+    const client = net.createConnection(socketPath);
+    let settled = false;
+    let connected = false;
+    let received = "";
+
+    const finish = (response: DaemonResponse | undefined) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      client.destroy();
+      resolve(response);
+    };
+
+    const timeout = setTimeout(
+      () => finish(undefined),
+      socketProbeTimeoutMilliseconds,
+    );
+
+    client.once("connect", () => {
+      connected = true;
+      clearTimeout(timeout);
+      client.write(JSON.stringify(request) + "\n");
+    });
+    client.on("data", (chunk: Buffer) => {
+      received += chunk.toString("utf8");
+      const newline = received.indexOf("\n");
+      if (newline === -1) return;
+      try {
+        finish(JSON.parse(received.slice(0, newline)) as DaemonResponse);
+      } catch {
+        finish(undefined);
+      }
+    });
+    client.once("end", () => {
+      if (!settled) finish(undefined);
+    });
+    client.once("error", () => {
+      // A failed connection is an unreachable daemon. A later socket failure
+      // before a response is equally unusable to the caller.
+      if (!connected || !settled) finish(undefined);
+    });
+  });
+}
+
 /** Starts the local socket server, serial worker, and periodic poll feeder. */
 export async function startDaemon(
   settings: PiploySettings,
@@ -190,11 +247,24 @@ export async function startDaemon(
   const sockets = new Set<net.Socket>();
   let workerRunning = false;
   let stopping = false;
+  let shutdownPromise: Promise<void> | undefined;
+
+  function shutdown(): Promise<void> {
+    if (shutdownPromise) return shutdownPromise;
+    stopping = true;
+    clearInterval(timer);
+    for (const socket of sockets) socket.destroy();
+    shutdownPromise = close(server);
+    return shutdownPromise;
+  }
 
   async function runRequest(request: DaemonRequest): Promise<DaemonResponse> {
     try {
       if (request.command === "status") {
         return { ok: true, status: await deps.getStatus() };
+      }
+      if (request.command === "stop") {
+        return { ok: true };
       }
       await deps.poll();
       return { ok: true };
@@ -209,7 +279,19 @@ export async function startDaemon(
       while (!stopping) {
         const queued = queue.shift();
         if (!queued) return;
-        queued.respond(await runRequest(queued.request));
+        const response = await runRequest(queued.request);
+        queued.respond(response);
+        if (queued.request.command === "stop" && response.ok) {
+          stopping = true;
+          // Let socket.end() flush its acknowledgement before closing all
+          // active sockets and exiting the service process.
+          setImmediate(() => {
+            void shutdown()
+              .then(() => process.exit(0))
+              .catch((error: unknown) => logError(logger, error));
+          });
+          return;
+        }
       }
     } finally {
       workerRunning = false;
@@ -296,11 +378,6 @@ export async function startDaemon(
 
   return {
     socketPath,
-    async stop(): Promise<void> {
-      stopping = true;
-      clearInterval(timer);
-      for (const socket of sockets) socket.destroy();
-      await close(server);
-    },
+    stop: shutdown,
   };
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -6,4 +6,7 @@ declare const __PIPLOY_VERSION__: string;
  * comparison — otherwise the package version plus the build's short git
  * commit hash, for local/dev builds.
  */
-export const piployVersion = __PIPLOY_VERSION__;
+export const piployVersion =
+  typeof __PIPLOY_VERSION__ === "undefined"
+    ? "development"
+    : __PIPLOY_VERSION__;

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -1,9 +1,155 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { notImplementedMessage } from "../../src/commands.js";
+import {
+  poll,
+  serviceStart,
+  serviceStop,
+  status,
+  wipeAll,
+  type CommandDeps,
+} from "../../src/commands.js";
+import type { DaemonStatus } from "../../src/daemon.js";
 
-describe("notImplementedMessage", () => {
-  it("identifies the command as an unavailable stub", () => {
-    expect(notImplementedMessage("status")).toBe("status: not implemented");
+const daemonStatus: DaemonStatus = {
+  applications: [
+    {
+      application: "app",
+      git: null,
+      docker: {},
+      isRunningLatestVersion: false,
+    },
+  ],
+};
+
+function createDeps(): CommandDeps {
+  return {
+    requestDaemon: vi.fn(),
+    computeStatusInline: vi.fn(async () => daemonStatus),
+    pollInline: vi.fn(),
+    wipeAll: vi.fn(),
+    startDaemon: vi.fn(async () => ({
+      socketPath: "/tmp/piploy.sock",
+      stop: vi.fn(),
+    })),
+  };
+}
+
+describe("commands", () => {
+  afterEach(() => {
+    process.exitCode = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it("uses daemon status when the daemon is reachable", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => ({
+      ok: true as const,
+      status: daemonStatus,
+    }));
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await status(deps);
+
+    expect(deps.requestDaemon).toHaveBeenCalledWith({ command: "status" });
+    expect(deps.computeStatusInline).not.toHaveBeenCalled();
+    expect(output).toHaveBeenCalledWith("Background service: running");
+  });
+
+  it("computes status inline only when no daemon is reachable", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => undefined);
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await status(deps);
+
+    expect(deps.computeStatusInline).toHaveBeenCalledOnce();
+    expect(output).toHaveBeenCalledWith("Background service: not running");
+  });
+
+  it("reports a failed daemon status request without an inline fallback", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => ({
+      ok: false as const,
+      reason: "busy" as const,
+    }));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await status(deps);
+
+    expect(deps.computeStatusInline).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith("Daemon status request failed: busy");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("delegates poll to a reachable daemon", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => ({ ok: true as const }));
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await poll(deps);
+
+    expect(deps.requestDaemon).toHaveBeenCalledWith({ command: "poll" });
+    expect(deps.pollInline).not.toHaveBeenCalled();
+  });
+
+  it("runs poll inline only when no daemon is reachable", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => undefined);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await poll(deps);
+
+    expect(deps.pollInline).toHaveBeenCalledOnce();
+  });
+
+  it("reports a failed daemon poll request without an inline fallback", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => ({
+      ok: false as const,
+      reason: "failed" as const,
+    }));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await poll(deps);
+
+    expect(deps.pollInline).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith("Daemon poll request failed: failed");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("stops a reachable daemon and reports when none is reachable", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true as const })
+      .mockResolvedValueOnce(undefined);
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await serviceStop(deps);
+    await serviceStop(deps);
+
+    expect(deps.requestDaemon).toHaveBeenCalledWith({ command: "stop" });
+    expect(output).toHaveBeenCalledWith("Piploy daemon stopped.");
+    expect(error).toHaveBeenCalledWith("No Piploy daemon is reachable.");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("wipes without contacting the daemon", async () => {
+    const deps = createDeps();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await wipeAll(deps);
+
+    expect(deps.wipeAll).toHaveBeenCalledOnce();
+    expect(deps.requestDaemon).not.toHaveBeenCalled();
+  });
+
+  it("starts the daemon", async () => {
+    const deps = createDeps();
+
+    await serviceStart(deps);
+
+    expect(deps.startDaemon).toHaveBeenCalledOnce();
   });
 });

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -3,9 +3,10 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  requestDaemon,
   startDaemon,
   type Daemon,
   type DaemonDeps,
@@ -86,7 +87,7 @@ describe("daemon", () => {
 
     expect((await stat(daemon.socketPath)).mode & 0o777).toBe(0o600);
     await expect(
-      sendRequest(daemon.socketPath, { command: "status" }),
+      requestDaemon({ command: "status" }, daemon.socketPath),
     ).resolves.toEqual({
       ok: true,
       status: {
@@ -143,10 +144,30 @@ describe("daemon", () => {
     });
 
     await expect(
-      sendRequest(daemon.socketPath, { command: "stop" }),
+      sendRequest(daemon.socketPath, { command: "bogus" }),
     ).resolves.toEqual({
       ok: false,
       reason: "invalid-request",
     });
+  });
+
+  it("acknowledges stop requests before shutting down the daemon", async () => {
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+      return undefined as never;
+    }) as typeof process.exit);
+    const daemon = await start({
+      poll: async () => {},
+      getStatus: async () => ({ applications: [] }),
+    });
+
+    await expect(
+      sendRequest(daemon.socketPath, { command: "stop" }),
+    ).resolves.toEqual({ ok: true });
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0));
+    await expect(
+      requestDaemon({ command: "status" }, daemon.socketPath),
+    ).resolves.toBeUndefined();
+
+    exit.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

- replace CLI stubs with daemon-backed status, service lifecycle, polling, and wipeall commands
- add the stop socket request and a bounded daemon client/probe
- cover daemon and inline command paths with unit tests

Closes #30

## User impact

Operators can use all documented Piploy CLI commands; status and poll remain useful when the foreground daemon is not running.

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm build`