### PR TITLE
Document shared-agent Git workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,38 @@ around git, Docker, configuration, or deployment, check
 [issue #1](https://github.com/alundgren/Irudd.Piploy/issues/1) and the
 relevant ADRs for the project's settled decisions.
 
+## Shared-agent Git workflow
+
+### Start new work from the remote main branch
+
+Before starting any new implementation work, refresh the remote tracking ref:
+
+```sh
+git fetch origin main
+```
+
+Treat the freshly fetched `origin/main` as the source of truth. Do not assume a
+local `main` branch is current, and do not use `git pull` as a substitute for
+this check. Create new work from `origin/main`:
+
+```sh
+git switch --create <agent>/<topic> origin/main
+```
+
+Use an agent identifier such as `claude`, `codex`, or a human username, with a
+short, descriptive topic. Before reusing an existing branch, fetch first and
+confirm that the branch is the intended one; otherwise create a new branch.
+
+### Keep agent work isolated
+
+- Work only in your assigned worktree and on your own `<agent>/<topic>` branch.
+- Do not commit, reset, rebase, force-push, or delete another agent's branch.
+- If your worktree has uncommitted changes or commits that must be preserved,
+  stop and ask for direction before rebasing, resetting, or changing branches.
+- Before opening a pull request, fetch `origin/main` again and verify the diff
+  is scoped to the intended work. Target the pull request at `main` unless the
+  task specifies another base branch.
+
 ## TypeScript verification
 
 Run `pnpm lint` and `pnpm test` before considering TypeScript changes complete.


### PR DESCRIPTION
## What changed

Adds shared-agent Git guidance to `CLAUDE.md`.

## Why

Agents could begin work from stale local `main` checkouts, causing avoidable rework and merge conflicts after remote changes landed.

## Impact

Agents now fetch `origin/main` before starting work, create agent-neutral `<agent>/<topic>` branches from that ref, and avoid rewriting or interfering with another agent's worktree or branch.

## Validation

- `git diff --check`
- Documentation-only change; TypeScript checks are not applicable.