### PR TITLE
Bundle Piploy runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "tsc --noEmit && eslint . && prettier --check \"*.{js,ts,json}\" \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "vitest --config vitest.unit.config.ts run",
     "test:integration": "vitest --config vitest.integration.config.ts run",
-    "build": "tsup"
+    "build": "tsup && node scripts/verifyBundle.mjs"
   },
   "dependencies": {
     "commander": "^14.0.0",

--- a/scripts/verifyBundle.mjs
+++ b/scripts/verifyBundle.mjs
@@ -1,0 +1,57 @@
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { builtinModules } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+
+const bundlePath = path.resolve("dist/piploy.cjs");
+const allowedModules = new Set(
+  builtinModules.flatMap((moduleName) => [moduleName, `node:${moduleName}`]),
+);
+const requiredModules = [
+  ...readFileSync(bundlePath, "utf8").matchAll(/\brequire\((["'])([^"']+)\1\)/g),
+].map((match) => match[2]);
+const externalModules = [
+  ...new Set(
+    requiredModules.filter(
+      (moduleName) => moduleName !== undefined && !allowedModules.has(moduleName),
+    ),
+  ),
+];
+
+if (externalModules.length > 0) {
+  throw new Error(
+    `Bundle has external runtime requires: ${externalModules.join(", ")}`,
+  );
+}
+
+const temporaryDirectory = mkdtempSync(path.join(os.tmpdir(), "piploy-bundle-"));
+
+try {
+  const deployedBundlePath = path.join(temporaryDirectory, "piploy.cjs");
+  cpSync(bundlePath, deployedBundlePath);
+  writeFileSync(
+    path.join(temporaryDirectory, "piploy.json"),
+    JSON.stringify({
+      Piploy: {
+        RootDirectory: path.join(temporaryDirectory, "root"),
+        Applications: [],
+      },
+    }),
+  );
+
+  for (const args of [["--version"], ["status"]]) {
+    const result = spawnSync(process.execPath, [deployedBundlePath, ...args], {
+      encoding: "utf8",
+      timeout: 10_000,
+    });
+    if (result.error || result.status !== 0) {
+      throw new Error(
+        `Clean-install check failed for '${args.join(" ")}': ${result.error?.message ?? result.stderr}`,
+      );
+    }
+  }
+} finally {
+  rmSync(temporaryDirectory, { recursive: true, force: true });
+}

--- a/src/optionalTransportDependencyStub.cjs
+++ b/src/optionalTransportDependencyStub.cjs
@@ -1,0 +1,5 @@
+/* global module */
+
+// docker-modem loads SSH support unconditionally, but Piploy only uses the
+// Docker daemon's Unix socket and never selects that transport.
+module.exports = {};

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,6 +9,9 @@ const packageJsonPath = fileURLToPath(
 const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
   version: string;
 };
+const optionalTransportDependencyStubPath = fileURLToPath(
+  new URL("./src/optionalTransportDependencyStub.cjs", import.meta.url),
+);
 
 function releaseTagAtHead(): string | undefined {
   try {
@@ -37,6 +40,22 @@ export default defineConfig({
   sourcemap: true,
   outDir: "dist",
   clean: true,
+  // Piploy ships only this bundle. Keep every runtime dependency in it rather
+  // than relying on a node_modules directory beside the deployed artifact.
+  noExternal: [/^(commander|dockerode|isomorphic-git|pino|zod)(\/.*)?$/],
+  esbuildPlugins: [
+    {
+      name: "stub-unreachable-docker-ssh-transport",
+      setup(build) {
+        // docker-modem eagerly loads ssh2 and cpu-features even though Piploy
+        // connects only through Docker's local Unix socket. These native
+        // optional dependencies are intentionally unavailable on the Pi.
+        build.onResolve({ filter: /^(ssh2|cpu-features)$/ }, () => ({
+          path: optionalTransportDependencyStubPath,
+        }));
+      },
+    },
+  ],
   define: {
     __PIPLOY_VERSION__: JSON.stringify(version),
   },


### PR DESCRIPTION
## Summary

- bundle Piploy's runtime dependencies into `dist/piploy.cjs`
- replace Docker's unused SSH-only optional native modules with a bundled inert shim
- verify each build has only Node builtin requires and runs from a clean directory with only `piploy.cjs` and `piploy.json`

## Why

`tsup` externalized production dependencies, so the release asset crashed on a clean Pi install with `MODULE_NOT_FOUND`. Docker's SSH transport is unreachable because Piploy always uses the local Docker Unix socket, but its modules are loaded eagerly during bundling.

Closes #55.

## Validation

- `pnpm build`
- `pnpm lint`
- `pnpm test`
- `pnpm test:integration`