### PR TITLE
Enable mattpocock-skills plugin in cloud environments

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "mattpocock-skills@claude-plugins-official": true
+  }
+}


### PR DESCRIPTION
## Summary
- Add checked-in `.claude/settings.json` declaring `enabledPlugins["mattpocock-skills@claude-plugins-official"]: true`
- Mirrors the user's global `~/.claude/settings.json` enablement, so cloud/background agents (which don't see the user's global config) also get the plugin's skills

## Test plan
- [ ] Confirm a cloud/background Claude Code session for this repo lists the `mattpocock-skills:*` skills (e.g. `diagnosing-bugs`, `tdd`, `code-review`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)