### PR TITLE
Record the volume model and the one-container Application rule

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,44 @@
+# Piploy
+
+Piploy keeps a set of applications running on a single Raspberry Pi. It clones
+each application's Git repository, builds it into a Docker image, runs it as a
+container, and re-checks on a timer that reality still matches the
+configuration.
+
+## Language
+
+**Application**:
+One Git repository that Piploy turns into exactly one running container. An
+Application is never a group of containers — two containers means two
+Applications.
+_Avoid_: Service, app, stack, deployment
+
+**Poll**:
+One pass in which Piploy brings every Application's repository, image, and
+container back in line with the configuration. Polling is Piploy's only
+trigger; nothing pushes work to it.
+_Avoid_: Sync, deploy, tick, reconcile loop
+
+**Application data**:
+State an Application writes and expects to outlive its own container. Piploy
+never deletes Application data.
+_Avoid_: State, storage, persistent data
+
+**Volume**:
+A named directory Piploy creates and mounts into an Application's container to
+hold that Application's data. A Volume names the data, not a location — Piploy
+owns where it lives.
+_Avoid_: Mount, bind mount, Docker volume
+
+**Root directory**:
+Where Piploy keeps everything it can rebuild from nothing: clones and logs.
+Safe to delete.
+_Avoid_: Working directory, workspace
+
+**Data directory**:
+Where Piploy keeps everything it cannot rebuild: Application data. Distinct
+from the root directory precisely because it is never deleted.
+
+**Bundle**:
+The single deployed file that is both the daemon and the command line client.
+_Avoid_: Binary, executable, artifact

--- a/docs/adr/0005-application-state-and-volume-model.md
+++ b/docs/adr/0005-application-state-and-volume-model.md
@@ -1,0 +1,42 @@
+# Application state and the volume model
+
+Piploy needed persistent storage so an Application like `life` — a SQLite-backed
+planner — can survive having its container replaced on every deploy. An
+Application declares Volumes as bare names (`"sqlite:/app/data"`), never host
+paths, and Piploy resolves each to a directory it creates itself under a data
+directory derived next to `piploy.json` — the same rule that already locates
+`piploy.sock`. Application data therefore lives outside `RootDirectory`, so
+`wipeall` never deletes it and instead reports the paths it preserved.
+
+## Considered options
+
+- **Docker named volumes**, which is what `life`'s Compose file uses. Rejected:
+  portability and volume drivers are worth nothing on one Pi that never moves,
+  and they make the single irreplaceable thing in the system impossible to
+  `rsync` or open with `sqlite3` without digging through `/var/lib/docker`.
+- **Bind mounts under `RootDirectory`**, as a sibling of each Application's
+  `repo/`. Rejected: that is exactly the tree `wipeall` hands to a recursive
+  forced delete.
+- **Absolute host paths in configuration**, e.g. `"/mnt/photos:/app/photos"`.
+  Rejected: configuration that can name any path can hand a container `/etc`,
+  Piploy's own bundle and configuration, or `/var/run/docker.sock` — which is
+  root on the host. An external disk is served by symlinking the data directory
+  instead. This is addable later without invalidating existing configuration.
+- **An explicit `DataDirectory` setting.** Rejected: the location is derivable
+  from a rule the codebase already has, and `RootDirectory` is free-form enough
+  that deriving from *it* would place data somewhere surprising.
+
+## Consequences
+
+- Piploy only ever mounts directories it created. It cannot be configured into
+  mounting anything else.
+- All Application data sits under one directory, so backup is a single `rsync`.
+- "Piploy never deletes Application data" holds without an asterisk. A `wipeall`
+  followed by a poll therefore yields a fresh container attached to the
+  *existing* database — wipe-and-retry is no longer a way to exercise an
+  Application's first-run path.
+- `PIPLOY_CONFIG` relocates Application data as well as the socket, which gives
+  integration runs their own data root for free.
+- Files in a Volume are owned by whatever user the container runs as. An
+  Application whose Dockerfile sets no `USER` writes root-owned files that the
+  service user cannot read without `sudo`.

--- a/docs/adr/0006-an-application-is-one-container.md
+++ b/docs/adr/0006-an-application-is-one-container.md
@@ -1,0 +1,40 @@
+# An Application is exactly one container
+
+Deploying `life` raised the first real demand for a second container: the app
+talks to Ollama, and its Compose file runs the two side by side. Piploy keeps
+its existing shape instead — an Application is one Git repository that becomes
+one container — and Ollama runs natively on the Pi under its own systemd unit,
+reached over the Docker bridge. Piploy gains no concept of multi-container
+applications, service discovery, dependency ordering, or health gating, and
+contains no reference to Ollama.
+
+## Considered options
+
+- **`Application` gains a `Containers: []` array.** Rejected: that is Compose
+  re-implemented in JSON, and every Compose feature then becomes a plausible
+  request. Compose itself was already ruled out during the port for a separate
+  reason — it is a CLI plugin with no daemon API.
+- **A new `Service` / `Dependency` noun** that Piploy understands as either
+  containerised or host-native, wiring the URL into dependent Applications.
+  Rejected: routing through the host erases the distinction the noun exists to
+  model, so it would earn nothing. Both modes reduce to whether a second
+  ordinary Application entry exists.
+- **Running Ollama as a second Application** built from `life`'s own
+  `docker/ollama/Dockerfile`. Possible under this decision, but rejected in
+  favour of native: it requires amending
+  [ADR-0004](0004-supply-chain-controls.md), because `ollama/ollama` is a
+  third-party Docker Hub publisher that no digest pin can make compliant.
+  Native Ollama keeps ADR-0004 untouched, and gains `Restart=always` under
+  systemd.
+
+## Consequences
+
+- Applications reach host-native dependencies through the Docker bridge
+  gateway, configured as a literal address in an environment variable. Piploy
+  does not resolve, inject, or validate it.
+- Piploy cannot express startup ordering. An Application that depends on
+  something else must tolerate it being unavailable at boot.
+- The generic features this drove — Volumes and environment variables — carry
+  no knowledge of what they are used for, so they serve any future Application.
+- Reversing this means adding a container-grouping concept from scratch. The
+  cost is deliberate: it is what keeps Piploy from drifting into Compose.


### PR DESCRIPTION
Docs only — no code changes. Output of a `/grill-with-docs` session on extending Piploy to deploy apps like [`alundgren/life`](https://github.com/alundgren/life): a SQLite-backed planner that needs a persistent volume and talks to Ollama.

## What changed

- **`CONTEXT.md`** (new) — the repo had no glossary. Seven terms, defining **Application**, **Application data**, and the **root directory** / **data directory** split that ADR-0005 depends on.
- **`docs/adr/0005-application-state-and-volume-model.md`** — how persistent storage works.
- **`docs/adr/0006-an-application-is-one-container.md`** — why Piploy isn't growing multi-container support.

## The decisions

**ADR-0005.** An Application declares Volumes as bare names (`"sqlite:/app/data"`), **never host paths**. Piploy resolves each to a directory it creates itself, under a data directory derived next to `piploy.json` — the same rule that already locates `piploy.sock` in `src/daemon.ts:66`. Data therefore lives outside `RootDirectory`, so `wipeall`'s `rmSync` never reaches it.

Rejected, with reasons recorded: Docker named volumes (what `life`'s Compose file uses — unbackupable without digging through `/var/lib/docker`), bind mounts under `RootDirectory` (directly in `wipeall`'s blast radius), absolute host paths in config (lets configuration hand a container `/etc` or `/var/run/docker.sock`), and an explicit `DataDirectory` setting (derivable from a rule that already exists).

**ADR-0006.** An Application stays one repository and one container. Ollama runs **natively on the Pi** under its own systemd unit, reached over the Docker bridge, rather than as a second container. Piploy gains no service discovery, dependency ordering, or health gating, and never mentions Ollama.

This is what keeps [ADR-0004](https://github.com/alundgren/Irudd.Piploy/blob/main/docs/adr/0004-supply-chain-controls.md) untouched: `ollama/ollama` is a third-party Docker Hub publisher, so no digest pin can make it compliant, and containerising Ollama would have required amending the base-image policy.

## For the reviewer

- **ADR-0006 is arguably scope creep.** The session agreed to one ADR. The one-container rule turned out to be the most consequential decision made and had no home other than a chat log — it's hard to reverse, a future reader will ask "why can't I run a sidecar?", and three alternatives were genuinely weighed. It's a standalone file if you'd rather drop it.
- **Compose stays ruled out**, consistent with the port's original scope note in #1 — this decision reaffirms it rather than reopening it.
- No behaviour changes, so `pnpm lint` / `pnpm test` are unaffected. The implementation follows in #63 and #64.

## Follow-ups

- #63 — Add `Volumes` and `EnvironmentVariables` to an Application
- #64 — Recreate containers when `piploy.json` changes, and poll on daemon startup (filed as a **bug**: editing `PortMappings` is already a silent no-op today, and every self-update already costs up to an hour of no reconciliation)
- [alundgren/life#63](https://github.com/alundgren/life/issues/63) — document the native Ollama setup on the Pi

🤖 Generated with [Claude Code](https://claude.com/claude-code)