### PR TITLE
Reconcile containers when configuration changes

### DIFF
--- a/docs/adr/0002-module-seams-and-test-split.md
+++ b/docs/adr/0002-module-seams-and-test-split.md
@@ -3,7 +3,7 @@
 ## Decision
 
 `dockerPlan.ts` contains the pure Docker decision policy. Given image or
-container state and a Git commit, `planImage` and `planContainer` select
+container state, a Git commit, and a runtime-configuration hash, `planImage` and `planContainer` select
 `reuse`, `build`, `start`, or `recreate`; unit tests exercise these functions
 with plain values. `docker.ts` is the I/O adapter around dockerode and applies
 that policy while also handling cleanup.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -384,6 +384,7 @@ export async function startDaemon(
     () => void runTimerTick(),
     pollIntervalMinutes * 60_000,
   );
+  enqueue({ command: "poll" }, "timer");
   logger.info(`Daemon listening at ${socketPath}`);
 
   return {

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import Dockerode from "dockerode";
 
 import {
+  getContainerConfigHash,
   getDockerfilePathFromSetting,
   planContainer,
   planImage,
@@ -17,6 +18,7 @@ import { getApplicationRepoDirectory } from "./settings.js";
 const piploy = "piploy";
 const imageAppLabelName = `${piploy}_appName`;
 const imageCommitLabelName = `${piploy}_gitTipCommit`;
+const containerConfigLabelName = `${piploy}_configHash`;
 const testMarkerLabelName = `${piploy}_isCreatedByTest`;
 
 export interface GitCommit {
@@ -107,6 +109,7 @@ function asDockerContainer(
     id: container.Id,
     state: container.State,
     gitTipCommit: container.Labels[imageCommitLabelName],
+    configHash: container.Labels[containerConfigLabelName],
   };
 }
 
@@ -246,9 +249,13 @@ export function createDockerService(
   ): Promise<EnsureContainerResult> {
     const containerName = getContainerName(application);
     const existingContainer = await findContainer(containerName);
+    const configHash = getContainerConfigHash({
+      portMappings: application.PortMappings,
+    });
     const containerPlan = planContainer(
       existingContainer ? asDockerContainer(existingContainer) : undefined,
       commit.hash,
+      configHash,
     );
 
     if (containerPlan.action === "reuse") {
@@ -289,6 +296,7 @@ export function createDockerService(
       name: containerName,
       ExposedPorts: exposedPorts,
       HostConfig: { PortBindings: portBindings, AutoRemove: true },
+      Labels: { [containerConfigLabelName]: configHash },
     });
     try {
       logger.info(`Starting container ${containerName}`);

--- a/src/dockerPlan.ts
+++ b/src/dockerPlan.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export interface DockerImage {
   id: string;
 }
@@ -6,6 +8,16 @@ export interface DockerContainer {
   id: string;
   state: string;
   gitTipCommit?: string;
+  configHash?: string;
+}
+
+export interface ContainerConfiguration {
+  environmentVariables?: readonly string[];
+  volumes?: readonly string[];
+  portMappings?: readonly {
+    hostPort: number;
+    containerPort: number;
+  }[];
 }
 
 export type ImagePlan =
@@ -38,12 +50,16 @@ export function planImage(existingImage?: DockerImage): ImagePlan {
 export function planContainer(
   existingContainer: DockerContainer | undefined,
   gitTipCommit: string,
+  configHash: string,
 ): ContainerPlan {
   if (!existingContainer) {
     return { action: "recreate" };
   }
 
-  if (existingContainer.gitTipCommit === gitTipCommit) {
+  if (
+    existingContainer.gitTipCommit === gitTipCommit &&
+    existingContainer.configHash === configHash
+  ) {
     if (existingContainer.state === "running") {
       return { action: "reuse", containerId: existingContainer.id };
     }
@@ -53,6 +69,28 @@ export function planContainer(
   }
 
   return { action: "recreate", existingContainerId: existingContainer.id };
+}
+
+/**
+ * Produces a stable identity for the settings which affect a container at
+ * runtime. Arrays are sorted because their configuration order is not
+ * meaningful to Docker.
+ */
+export function getContainerConfigHash(
+  configuration: ContainerConfiguration,
+): string {
+  const normalized = {
+    environmentVariables: [
+      ...(configuration.environmentVariables ?? []),
+    ].sort(),
+    volumes: [...(configuration.volumes ?? [])].sort(),
+    portMappings: [...(configuration.portMappings ?? [])].sort(
+      (left, right) =>
+        left.hostPort - right.hostPort ||
+        left.containerPort - right.containerPort,
+    ),
+  };
+  return createHash("sha256").update(JSON.stringify(normalized)).digest("hex");
 }
 
 /** Converts the config setting into a Docker build context and its Dockerfile. */

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -115,7 +115,7 @@ describe("daemon", () => {
       {
         poll: async () => {
           polls += 1;
-          if (polls === 1) await firstPoll;
+          if (polls === 2) await firstPoll;
         },
         getStatus: async () => ({ applications: [] }),
         attemptSelfUpdate: async () => "up-to-date",
@@ -137,7 +137,7 @@ describe("daemon", () => {
     releaseFirstPoll!();
     await expect(first).resolves.toEqual({ ok: true });
     await expect(second).resolves.toEqual({ ok: true });
-    expect(polls).toBe(2);
+    expect(polls).toBe(3);
   });
 
   it("rejects malformed requests", async () => {
@@ -205,9 +205,27 @@ describe("daemon", () => {
       });
       daemons.push(daemon);
 
+      await vi.advanceTimersByTimeAsync(0);
+      events.length = 0;
       await vi.advanceTimersByTimeAsync(60_000);
 
       expect(events).toEqual(expectedEvents);
     },
   );
+
+  it("enqueues a poll immediately on startup without self-updating", async () => {
+    const events: string[] = [];
+    await start({
+      attemptSelfUpdate: async () => {
+        events.push("update");
+        return "up-to-date";
+      },
+      poll: async () => {
+        events.push("poll");
+      },
+      getStatus: async () => ({ applications: [] }),
+    });
+
+    await vi.waitFor(() => expect(events).toEqual(["poll"]));
+  });
 });

--- a/test/unit/dockerPlan.test.ts
+++ b/test/unit/dockerPlan.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  getContainerConfigHash,
   getDockerfilePathFromSetting,
   planContainer,
   planImage,
@@ -23,6 +24,8 @@ describe("planImage", () => {
 });
 
 describe("planContainer", () => {
+  const configHash = getContainerConfigHash({});
+
   it.each([
     [undefined, { action: "recreate" }],
     [
@@ -36,15 +39,21 @@ describe("planContainer", () => {
   ] as const)(
     "recreates when the current container is not usable",
     (container, expected) => {
-      expect(planContainer(container, "commit")).toEqual(expected);
+      expect(planContainer(container, "commit", configHash)).toEqual(expected);
     },
   );
 
   it("reuses a running container at the requested commit", () => {
     expect(
       planContainer(
-        { id: "container", state: "running", gitTipCommit: "commit" },
+        {
+          id: "container",
+          state: "running",
+          gitTipCommit: "commit",
+          configHash,
+        },
         "commit",
+        configHash,
       ),
     ).toEqual({ action: "reuse", containerId: "container" });
   });
@@ -52,10 +61,57 @@ describe("planContainer", () => {
   it("starts an exited container at the requested commit", () => {
     expect(
       planContainer(
-        { id: "container", state: "exited", gitTipCommit: "commit" },
+        {
+          id: "container",
+          state: "exited",
+          gitTipCommit: "commit",
+          configHash,
+        },
         "commit",
+        configHash,
       ),
     ).toEqual({ action: "start", containerId: "container" });
+  });
+
+  it("recreates a container when its runtime configuration changes", () => {
+    expect(
+      planContainer(
+        {
+          id: "container",
+          state: "running",
+          gitTipCommit: "commit",
+          configHash: getContainerConfigHash({
+            portMappings: [{ hostPort: 8080, containerPort: 80 }],
+          }),
+        },
+        "commit",
+        getContainerConfigHash({
+          portMappings: [{ hostPort: 9090, containerPort: 80 }],
+        }),
+      ),
+    ).toEqual({ action: "recreate", existingContainerId: "container" });
+  });
+
+  it("hashes equivalent runtime configurations identically", () => {
+    expect(
+      getContainerConfigHash({
+        environmentVariables: ["B=two", "A=one"],
+        volumes: ["cache:/cache", "data:/data"],
+        portMappings: [
+          { hostPort: 9090, containerPort: 90 },
+          { hostPort: 8080, containerPort: 80 },
+        ],
+      }),
+    ).toBe(
+      getContainerConfigHash({
+        environmentVariables: ["A=one", "B=two"],
+        volumes: ["data:/data", "cache:/cache"],
+        portMappings: [
+          { hostPort: 8080, containerPort: 80 },
+          { hostPort: 9090, containerPort: 90 },
+        ],
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
## What changed

- Store a stable hash of each container runtime configuration in a Docker label and recreate containers when it changes.
- Enqueue the first daemon poll immediately after startup, without changing the self-update timer behavior.
- Add focused unit coverage for configuration drift, stable configuration ordering, and startup polling.

## Why

Previously Piploy only compared a container's Git commit, so changing `piploy.json` port mappings was ignored until a new application commit happened. A newly started daemon also waited an entire poll interval before reconciling.

## Impact

After restarting Piploy to load configuration changes, the next reconciliation now replaces only containers whose runtime configuration changed. Startup begins reconciliation right away.

## Validation

- `pnpm lint`
- `pnpm test`