### PR TITLE
Add application volumes and environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ These steps install Piploy on a new Pi. They assume the service user is
    ├── piploy.cjs       # deployed bundle
    ├── piploy.cjs.prev  # rollback copy, created after the first self-update
    ├── piploy.json      # configuration; deployments never overwrite it
-   └── root/             # application repositories and logs
+   ├── root/             # application repositories and logs
+   └── data/             # persistent application data; Piploy never deletes it
    ```
 
 4. Create `/etc/systemd/system/piploy.service`:
@@ -90,7 +91,7 @@ reach it. Another user gets the offline fallback described under `status`.
 | `poll` | Runs one reconciliation now instead of waiting for the poll timer. |
 | `service-start` | Runs the daemon in the foreground. This is what systemd invokes; do not run it by hand while the service is up. |
 | `service-stop` | Asks the running daemon to shut down. |
-| `wipeall` | Removes all Piploy containers and images and deletes the root directory. Destructive. |
+| `wipeall` | Removes all Piploy containers and images and deletes the root directory. Application data is preserved and its paths are printed. |
 | `self-update` | Checks GitHub for a newer release and installs it. |
 | `--version` | Prints the running bundle's version. |
 | `--help` | Lists the commands. |

--- a/docs/adr/0001-config-validation-and-logging.md
+++ b/docs/adr/0001-config-validation-and-logging.md
@@ -11,8 +11,15 @@ letters, numbers, underscores, and hyphens. Port mappings are validated as
 `<hostPort>:<containerPort>` and converted to typed port pairs while the
 configuration is parsed. Volumes are validated as
 `<name>:/container/path` and likewise converted to typed names and container
-paths; host paths and `..` are rejected. Environment variables are passed to
-Docker verbatim, without interpolation.
+paths; host paths, `..`, the container root, a second colon — which Docker
+would read as mount options — and two Volumes of one Application sharing a
+container path are all rejected. Environment variables are passed to Docker
+verbatim, without interpolation.
+
+`RootDirectory` is rejected when it overlaps the data directory in either
+direction, because `wipeall` deletes `RootDirectory` recursively and
+Application data must survive it (see
+[ADR-0005](0005-application-state-and-volume-model.md)).
 
 The daemon reads and validates configuration once at startup. Restart Piploy
 after changing `piploy.json`.

--- a/docs/adr/0001-config-validation-and-logging.md
+++ b/docs/adr/0001-config-validation-and-logging.md
@@ -5,10 +5,14 @@
 `piploy.json` is Piploy's supported configuration contract. It contains a
 top-level `Piploy` object with `RootDirectory`, `Applications`, optional
 `MinutesBetweenBackgroundPolls`, and optional `IsTestRun`. Each application
-has `Name`, `GitRepositoryUrl`, `DockerfilePath`, and optional `PortMappings`.
-Names may contain letters, numbers, underscores, and hyphens. Port mappings
-are validated as `<hostPort>:<containerPort>` and converted to typed port
-pairs while the configuration is parsed.
+has `Name`, `GitRepositoryUrl`, `DockerfilePath`, optional `PortMappings`,
+optional `Volumes`, and optional `EnvironmentVariables`. Names may contain
+letters, numbers, underscores, and hyphens. Port mappings are validated as
+`<hostPort>:<containerPort>` and converted to typed port pairs while the
+configuration is parsed. Volumes are validated as
+`<name>:/container/path` and likewise converted to typed names and container
+paths; host paths and `..` are rejected. Environment variables are passed to
+Docker verbatim, without interpolation.
 
 The daemon reads and validates configuration once at startup. Restart Piploy
 after changing `piploy.json`.

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -12,6 +12,7 @@ import {
 import { createDockerService } from "./docker.js";
 import type { Logger } from "./logger.js";
 import type { PiploySettings } from "./settings.js";
+import { getApplicationDataDirectory } from "./settings.js";
 import { piployVersion } from "./version.js";
 
 export interface CommandDeps {
@@ -19,6 +20,7 @@ export interface CommandDeps {
   computeStatusInline(): Promise<DaemonStatus>;
   pollInline(): Promise<void>;
   wipeAll(): Promise<void>;
+  getPreservedApplicationDataDirectories(): string[];
   startDaemon(): Promise<Daemon>;
 }
 
@@ -39,6 +41,10 @@ export function createCommandDeps(
         rmSync(settings.RootDirectory, { recursive: true, force: true });
       }
     },
+    getPreservedApplicationDataDirectories: () =>
+      settings.Applications.filter(
+        (application) => (application.Volumes?.length ?? 0) > 0,
+      ).map(getApplicationDataDirectory),
     startDaemon: () => startDaemon(settings, logger),
   };
 }
@@ -124,6 +130,9 @@ export async function serviceStop(deps: CommandDeps): Promise<void> {
 export async function wipeAll(deps: CommandDeps): Promise<void> {
   await deps.wipeAll();
   console.log("Removed all Piploy containers, images, and files.");
+  for (const directory of deps.getPreservedApplicationDataDirectories()) {
+    console.log(`Preserved application data: ${directory}`);
+  }
 }
 
 /** Starts the foreground daemon and lets SIGINT/SIGTERM stop it cleanly. */

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 
 import Dockerode from "dockerode";
@@ -12,7 +12,7 @@ import {
 } from "./dockerPlan.js";
 import type { Logger } from "./logger.js";
 import type { Application, PiploySettings } from "./settings.js";
-import { getApplicationRepoDirectory } from "./settings.js";
+import { getApplicationRepoDirectory, getVolumeDirectory } from "./settings.js";
 
 const piploy = "piploy";
 const imageAppLabelName = `${piploy}_appName`;
@@ -283,12 +283,26 @@ export function createDockerService(
       exposedPorts[port] = {};
     }
 
+    const binds = (application.Volumes ?? []).map((volume) => {
+      const volumeDirectory = getVolumeDirectory(application, volume);
+      mkdirSync(volumeDirectory, { recursive: true });
+      return `${volumeDirectory}:${volume.containerPath}`;
+    });
+    const environment = Object.entries(
+      application.EnvironmentVariables ?? {},
+    ).map(([name, value]) => `${name}=${value}`);
+
     logger.info(`Creating container ${containerName}`);
     const createdContainer = await docker.createContainer({
       Image: getImageVersionTagCommit(application.Name, commit),
       name: containerName,
+      Env: environment,
       ExposedPorts: exposedPorts,
-      HostConfig: { PortBindings: portBindings, AutoRemove: true },
+      HostConfig: {
+        PortBindings: portBindings,
+        Binds: binds,
+        AutoRemove: true,
+      },
     });
     try {
       logger.info(`Starting container ${containerName}`);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { z } from "zod";
 
 const portMappingPattern = /^(\d+):(\d+)$/;
+const volumePattern = /^([A-Za-z0-9_-]+):(\/.*)$/;
 
 const PortMappingSchema = z.string().transform((value, ctx) => {
   const match = portMappingPattern.exec(value);
@@ -21,11 +22,26 @@ const PortMappingSchema = z.string().transform((value, ctx) => {
   };
 });
 
+const VolumeSchema = z.string().transform((value, ctx) => {
+  const match = volumePattern.exec(value);
+  if (!match || value.includes("..")) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "Invalid volumes. Must have the format <name>:/container/path; host paths and '..' are not allowed",
+    });
+    return z.NEVER;
+  }
+  return { name: match[1]!, containerPath: match[2]! };
+});
+
 const ApplicationSchema = z.object({
   Name: z.string().regex(/^[A-Za-z0-9_-]+$/),
   GitRepositoryUrl: z.string(),
   DockerfilePath: z.string(),
   PortMappings: z.array(PortMappingSchema).optional(),
+  Volumes: z.array(VolumeSchema).optional(),
+  EnvironmentVariables: z.record(z.string(), z.string()).optional(),
 });
 
 const PiploySettingsSchema = z.object({
@@ -40,6 +56,7 @@ const ConfigFileSchema = z.object({
 });
 
 export type PortMapping = { hostPort: number; containerPort: number };
+export type Volume = { name: string; containerPath: string };
 export type Application = z.infer<typeof ApplicationSchema>;
 export type PiploySettings = z.infer<typeof PiploySettingsSchema>;
 
@@ -62,6 +79,24 @@ export function resolveConfigPath(
 /** The directory containing the running Piploy bundle. */
 export function resolveBundleDirectory(): string {
   return path.dirname(process.argv[1] ?? process.cwd());
+}
+
+/** The directory where Piploy keeps Application data that must outlive containers. */
+export function getDataDirectory(): string {
+  return path.join(path.dirname(resolveConfigPath()), "data");
+}
+
+/** The directory holding all of one Application's Volumes. */
+export function getApplicationDataDirectory(application: Application): string {
+  return path.join(getDataDirectory(), application.Name);
+}
+
+/** Resolves a configured Volume to its Piploy-owned host directory. */
+export function getVolumeDirectory(
+  application: Application,
+  volume: Volume,
+): string {
+  return path.join(getApplicationDataDirectory(application), volume.name);
 }
 
 export function getApplicationRootDirectory(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import { z } from "zod";
 
 const portMappingPattern = /^(\d+):(\d+)$/;
-const volumePattern = /^([A-Za-z0-9_-]+):(\/.*)$/;
+// The container path is a plain absolute path: no colons, because Docker reads
+// a third bind field as mount options, and at least one segment, because the
+// container root is not a mount point.
+const volumePattern = /^([A-Za-z0-9_-]+):((?:\/[^:/]+)+\/?)$/;
 
 const PortMappingSchema = z.string().transform((value, ctx) => {
   const match = portMappingPattern.exec(value);
@@ -28,21 +31,34 @@ const VolumeSchema = z.string().transform((value, ctx) => {
     ctx.addIssue({
       code: "custom",
       message:
-        "Invalid volumes. Must have the format <name>:/container/path; host paths and '..' are not allowed",
+        "Invalid volumes. Must have the format <name>:/container/path; host paths, mount options, and '..' are not allowed",
     });
     return z.NEVER;
   }
   return { name: match[1]!, containerPath: match[2]! };
 });
 
-const ApplicationSchema = z.object({
-  Name: z.string().regex(/^[A-Za-z0-9_-]+$/),
-  GitRepositoryUrl: z.string(),
-  DockerfilePath: z.string(),
-  PortMappings: z.array(PortMappingSchema).optional(),
-  Volumes: z.array(VolumeSchema).optional(),
-  EnvironmentVariables: z.record(z.string(), z.string()).optional(),
-});
+const ApplicationSchema = z
+  .object({
+    Name: z.string().regex(/^[A-Za-z0-9_-]+$/),
+    GitRepositoryUrl: z.string(),
+    DockerfilePath: z.string(),
+    PortMappings: z.array(PortMappingSchema).optional(),
+    Volumes: z.array(VolumeSchema).optional(),
+    EnvironmentVariables: z.record(z.string(), z.string()).optional(),
+  })
+  .superRefine((application, ctx) => {
+    const containerPaths = (application.Volumes ?? []).map(
+      (volume) => volume.containerPath,
+    );
+    if (new Set(containerPaths).size !== containerPaths.length) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "Invalid volumes. Two Volumes of one Application cannot share a container path",
+      });
+    }
+  });
 
 const PiploySettingsSchema = z.object({
   RootDirectory: z.string(),
@@ -66,7 +82,40 @@ export function parseSettings(json: unknown): PiploySettings {
 
 export function loadSettings(configPath: string): PiploySettings {
   const raw = readFileSync(configPath, "utf8");
-  return parseSettings(JSON.parse(raw));
+  const settings = parseSettings(JSON.parse(raw));
+  assertDataDirectoryIsSeparateFromRootDirectory(settings, configPath);
+  return settings;
+}
+
+function containsDirectory(directory: string, candidate: string): boolean {
+  const relative = path.relative(path.resolve(directory), candidate);
+  return (
+    relative === "" ||
+    (!relative.startsWith(`..${path.sep}`) &&
+      relative !== ".." &&
+      !path.isAbsolute(relative))
+  );
+}
+
+/**
+ * `wipeall` hands RootDirectory to a recursive forced delete, so Application
+ * data only survives it while the two trees are disjoint. RootDirectory is
+ * free-form, so nothing but this check keeps them that way (ADR-0005).
+ */
+function assertDataDirectoryIsSeparateFromRootDirectory(
+  settings: PiploySettings,
+  configPath: string,
+): void {
+  const dataDirectory = getDataDirectory(configPath);
+  const rootDirectory = settings.RootDirectory;
+  if (
+    containsDirectory(rootDirectory, dataDirectory) ||
+    containsDirectory(dataDirectory, rootDirectory)
+  ) {
+    throw new Error(
+      `Invalid RootDirectory '${rootDirectory}'. It overlaps the application data directory '${dataDirectory}', which wipeall would then delete. Point RootDirectory at a directory outside it.`,
+    );
+  }
 }
 
 /** `piploy.json` resolves relative to the running bundle, not CWD, with a `PIPLOY_CONFIG` override (#8). */
@@ -81,9 +130,14 @@ export function resolveBundleDirectory(): string {
   return path.dirname(process.argv[1] ?? process.cwd());
 }
 
-/** The directory where Piploy keeps Application data that must outlive containers. */
-export function getDataDirectory(): string {
-  return path.join(path.dirname(resolveConfigPath()), "data");
+/**
+ * The directory where Piploy keeps Application data that must outlive
+ * containers. Always absolute: Docker rejects a relative bind mount source.
+ */
+export function getDataDirectory(
+  configPath: string = resolveConfigPath(),
+): string {
+  return path.resolve(path.dirname(configPath), "data");
 }
 
 /** The directory holding all of one Application's Volumes. */

--- a/test/integration/docker.test.ts
+++ b/test/integration/docker.test.ts
@@ -1,7 +1,9 @@
+import { existsSync } from "node:fs";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import Dockerode from "dockerode";
 import { afterAll, describe, expect, it } from "vitest";
 
 import { createDockerService } from "../../src/docker.js";
@@ -19,12 +21,16 @@ const logger: Logger = {
 const temporaryDirectory = await mkdtemp(
   path.join(os.tmpdir(), "piploy-docker-"),
 );
+const originalConfigPath = process.env.PIPLOY_CONFIG;
+process.env.PIPLOY_CONFIG = path.join(temporaryDirectory, "piploy.json");
 const applicationName = `integration${crypto.randomUUID().replaceAll("-", "")}`;
 const commit = { hash: crypto.randomUUID().replaceAll("-", "") };
 const application = {
   Name: applicationName,
   GitRepositoryUrl: "https://example.invalid/integration.git",
   DockerfilePath: "Dockerfile",
+  Volumes: [{ name: "sqlite", containerPath: "/app/data" }],
+  EnvironmentVariables: { DATABASE_PATH: "/app/data/app.db" },
 };
 const settings: PiploySettings = {
   RootDirectory: path.join(temporaryDirectory, "root"),
@@ -36,6 +42,8 @@ const docker = createDockerService(settings, logger);
 afterAll(async () => {
   await docker.cleanupTestCreated();
   await rm(temporaryDirectory, { recursive: true, force: true });
+  if (originalConfigPath === undefined) delete process.env.PIPLOY_CONFIG;
+  else process.env.PIPLOY_CONFIG = originalConfigPath;
 });
 
 describe("docker adapter", () => {
@@ -61,6 +69,18 @@ describe("docker adapter", () => {
 
     const started = await docker.ensureContainerRunning(application, commit);
     expect(started).toMatchObject({ wasCreated: true, wasStarted: true });
+    expect(
+      existsSync(
+        path.join(temporaryDirectory, "data", application.Name, "sqlite"),
+      ),
+    ).toBe(true);
+    const inspect = await new Dockerode()
+      .getContainer(started.containerId)
+      .inspect();
+    expect(inspect.Config.Env).toContain("DATABASE_PATH=/app/data/app.db");
+    expect(inspect.HostConfig.Binds).toContain(
+      `${path.join(temporaryDirectory, "data", application.Name, "sqlite")}:/app/data`,
+    );
     expect(await docker.ensureContainerRunning(application, commit)).toEqual({
       wasCreated: false,
       wasStarted: false,

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -27,6 +27,7 @@ function createDeps(): CommandDeps {
     computeStatusInline: vi.fn(async () => daemonStatus),
     pollInline: vi.fn(),
     wipeAll: vi.fn(),
+    getPreservedApplicationDataDirectories: vi.fn(() => []),
     startDaemon: vi.fn(async () => ({
       socketPath: "/tmp/piploy.sock",
       stop: vi.fn(),
@@ -137,12 +138,18 @@ describe("commands", () => {
 
   it("wipes without contacting the daemon", async () => {
     const deps = createDeps();
-    vi.spyOn(console, "log").mockImplementation(() => {});
+    deps.getPreservedApplicationDataDirectories = vi.fn(() => [
+      "/opt/piploy/data/app",
+    ]);
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
 
     await wipeAll(deps);
 
     expect(deps.wipeAll).toHaveBeenCalledOnce();
     expect(deps.requestDaemon).not.toHaveBeenCalled();
+    expect(output).toHaveBeenCalledWith(
+      "Preserved application data: /opt/piploy/data/app",
+    );
   });
 
   it("starts the daemon", async () => {

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -1,3 +1,5 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -26,6 +28,23 @@ const validApplication = {
   DockerfilePath: "Dockerfile",
 };
 
+/** Writes a piploy.json whose RootDirectory is relative to its own directory. */
+async function writeConfig(relativeRootDirectory: string): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "piploy-settings-"));
+  const configPath = path.join(directory, "piploy.json");
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      Piploy: {
+        RootDirectory: path.join(directory, relativeRootDirectory),
+        Applications: [validApplication],
+      },
+    }),
+    "utf8",
+  );
+  return configPath;
+}
+
 describe("loadSettings", () => {
   it("reads and validates a valid piploy.json fixture", () => {
     const settings = loadSettings(path.join(fixturesDir, "piploy.valid.json"));
@@ -43,6 +62,25 @@ describe("loadSettings", () => {
       ],
       IsTestRun: false,
     });
+  });
+
+  it.each(["", "data", "data/app1"])(
+    "rejects a RootDirectory that overlaps the data directory ('%s')",
+    async (relativeRootDirectory) => {
+      const configPath = await writeConfig(relativeRootDirectory);
+
+      expect(() => loadSettings(configPath)).toThrow(
+        "overlaps the application data directory",
+      );
+    },
+  );
+
+  it("accepts a RootDirectory beside the data directory", async () => {
+    const configPath = await writeConfig("root");
+
+    expect(loadSettings(configPath).RootDirectory).toBe(
+      path.join(path.dirname(configPath), "root"),
+    );
   });
 });
 
@@ -123,6 +161,10 @@ describe("parseSettings", () => {
     "/host/path:/container/path",
     "../host:/container/path",
     "sqlite:/container/../path",
+    "sqlite:/app/data:ro",
+    "sqlite:/app/data:/etc",
+    "sqlite:/",
+    "sqlite://",
   ])("rejects an unsafe volume mapping %s", (volume) => {
     expect(() =>
       parseSettings({
@@ -132,7 +174,25 @@ describe("parseSettings", () => {
         },
       }),
     ).toThrow(
-      "Invalid volumes. Must have the format <name>:/container/path; host paths and '..' are not allowed",
+      "Invalid volumes. Must have the format <name>:/container/path; host paths, mount options, and '..' are not allowed",
+    );
+  });
+
+  it("rejects two volumes sharing a container path", () => {
+    expect(() =>
+      parseSettings({
+        Piploy: {
+          RootDirectory: "/root",
+          Applications: [
+            {
+              ...validApplication,
+              Volumes: ["sqlite:/app/data", "uploads:/app/data"],
+            },
+          ],
+        },
+      }),
+    ).toThrow(
+      "Invalid volumes. Two Volumes of one Application cannot share a container path",
     );
   });
 
@@ -223,6 +283,17 @@ describe("application directories", () => {
       expect(getVolumeDirectory(application, volume)).toBe(
         "/opt/piploy/data/app1/sqlite",
       );
+    } finally {
+      if (originalConfigPath === undefined) delete process.env.PIPLOY_CONFIG;
+      else process.env.PIPLOY_CONFIG = originalConfigPath;
+    }
+  });
+
+  it("keeps the data directory absolute for a relative configuration path", () => {
+    const originalConfigPath = process.env.PIPLOY_CONFIG;
+    process.env.PIPLOY_CONFIG = "piploy.json";
+    try {
+      expect(getDataDirectory()).toBe(path.resolve(process.cwd(), "data"));
     } finally {
       if (originalConfigPath === undefined) delete process.env.PIPLOY_CONFIG;
       else process.env.PIPLOY_CONFIG = originalConfigPath;

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -4,8 +4,11 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  getApplicationDataDirectory,
   getApplicationRepoDirectory,
   getApplicationRootDirectory,
+  getDataDirectory,
+  getVolumeDirectory,
   loadSettings,
   parseSettings,
   resolveBundleDirectory,
@@ -55,6 +58,8 @@ describe("parseSettings", () => {
     expect(settings.MinutesBetweenBackgroundPolls).toBeUndefined();
     expect(settings.IsTestRun).toBeUndefined();
     expect(settings.Applications[0]?.PortMappings).toBeUndefined();
+    expect(settings.Applications[0]?.Volumes).toBeUndefined();
+    expect(settings.Applications[0]?.EnvironmentVariables).toBeUndefined();
   });
 
   it("rejects a config missing the Piploy wrapper key", () => {
@@ -111,6 +116,47 @@ describe("parseSettings", () => {
       { hostPort: 9090, containerPort: 90 },
     ]);
   });
+
+  it.each([
+    "sqlite",
+    "sqlite:relative/path",
+    "/host/path:/container/path",
+    "../host:/container/path",
+    "sqlite:/container/../path",
+  ])("rejects an unsafe volume mapping %s", (volume) => {
+    expect(() =>
+      parseSettings({
+        Piploy: {
+          RootDirectory: "/root",
+          Applications: [{ ...validApplication, Volumes: [volume] }],
+        },
+      }),
+    ).toThrow(
+      "Invalid volumes. Must have the format <name>:/container/path; host paths and '..' are not allowed",
+    );
+  });
+
+  it("parses volumes and environment variables without interpolation", () => {
+    const settings = parseSettings({
+      Piploy: {
+        RootDirectory: "/root",
+        Applications: [
+          {
+            ...validApplication,
+            Volumes: ["sqlite:/app/data"],
+            EnvironmentVariables: { DATABASE_PATH: "/app/data/app.db" },
+          },
+        ],
+      },
+    });
+
+    expect(settings.Applications[0]?.Volumes).toEqual([
+      { name: "sqlite", containerPath: "/app/data" },
+    ]);
+    expect(settings.Applications[0]?.EnvironmentVariables).toEqual({
+      DATABASE_PATH: "/app/data/app.db",
+    });
+  });
 });
 
 describe("resolveConfigPath", () => {
@@ -159,5 +205,27 @@ describe("application directories", () => {
     expect(getApplicationRepoDirectory(settings, application)).toBe(
       "/opt/piploy/root/app1/repo",
     );
+  });
+
+  it("derives data directories next to the active configuration", () => {
+    const originalConfigPath = process.env.PIPLOY_CONFIG;
+    process.env.PIPLOY_CONFIG = "/opt/piploy/piploy.json";
+    try {
+      const application = parseSettings({
+        Piploy: { RootDirectory: "/ignored", Applications: [validApplication] },
+      }).Applications[0]!;
+      const volume = { name: "sqlite", containerPath: "/app/data" };
+
+      expect(getDataDirectory()).toBe("/opt/piploy/data");
+      expect(getApplicationDataDirectory(application)).toBe(
+        "/opt/piploy/data/app1",
+      );
+      expect(getVolumeDirectory(application, volume)).toBe(
+        "/opt/piploy/data/app1/sqlite",
+      );
+    } finally {
+      if (originalConfigPath === undefined) delete process.env.PIPLOY_CONFIG;
+      else process.env.PIPLOY_CONFIG = originalConfigPath;
+    }
   });
 });


### PR DESCRIPTION
Closes #63

## What changed
- Parse optional `Volumes` into validated named container-path mappings and optional `EnvironmentVariables` as string records.
- Derive application data alongside `piploy.json`, create each volume directory before Docker container creation, and pass bind mounts and environment variables to Docker.
- Preserve application data during `wipeall` and print each preserved application data path.
- Document the configuration and add unit and Docker integration coverage.

## Why
Applications can now persist state outside rebuildable Piploy files and receive explicit runtime configuration without granting configuration access to arbitrary host paths.

## Validation
- `pnpm lint`
- `pnpm test`
- `pnpm test:integration`
- `pnpm build`