### PR TITLE
Add manual release tagging workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (for example 1.2.3 or v1.2.3)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -12,8 +18,34 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Normalize release tag
+        id: release_tag
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            version="${INPUT_VERSION#v}"
+            if ! [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+              echo "Version must be valid semantic versioning, such as 1.2.3 or 1.2.3-rc.1." >&2
+              exit 1
+            fi
+            echo "tag=v$version" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out the tagged revision
+        if: github.event_name == 'push'
+        uses: actions/checkout@v4
         with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Check out the default branch
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
@@ -40,7 +72,20 @@ jobs:
 
       - run: pnpm build
 
+      - name: Create release tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
+        run: |
+          if git rev-parse --verify --quiet "refs/tags/$RELEASE_TAG"; then
+            echo "Tag $RELEASE_TAG already exists." >&2
+            exit 1
+          fi
+          git tag --annotate "$RELEASE_TAG" --message "Release $RELEASE_TAG"
+          git push origin "$RELEASE_TAG"
+
       - name: Create release and attach the bundle
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${{ github.ref_name }}" dist/piploy.cjs sbom.cdx.json pnpm-audit.json --title "${{ github.ref_name }}" --generate-notes
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
+        run: gh release create "$RELEASE_TAG" dist/piploy.cjs sbom.cdx.json pnpm-audit.json --title "$RELEASE_TAG" --generate-notes

--- a/README.md
+++ b/README.md
@@ -104,7 +104,12 @@ node piploy.cjs status
 
 ## Deploying a release
 
-Tag and push the release:
+In GitHub, run the **Release** workflow from the Actions page and enter the
+version (with or without a leading `v`). It runs the release checks against the
+current default branch, then creates an annotated `vX.Y.Z` tag and publishes
+the release.
+
+To create a release from the command line, tag and push it instead:
 
 ```bash
 git tag vX.Y.Z


### PR DESCRIPTION
## Summary

Adds a manual **Release** workflow entry point that accepts a version, validates and normalizes it to a `v…` tag, runs the existing release checks against the default branch, then creates the annotated tag and publishes the release.

This avoids GitHub's release UI bypassing the project’s release checks, while retaining the existing tag-push trigger.

## Validation

- `pnpm lint`
- `pnpm test`
- Workflow YAML and version-format checks