### PR TITLE
Answer status instantly during an install instead of hanging

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -87,6 +87,12 @@ export async function status(deps: CommandDeps): Promise<void> {
     return;
   }
   if (!response.ok) {
+    if (response.reason === "poll-in-progress") {
+      console.log(`Piploy version: ${piployVersion}`);
+      console.log("Background service: running");
+      console.log("\nAn install is in progress. Try again shortly.");
+      return;
+    }
     commandFailed(`Daemon status request failed: ${response.reason}`);
     return;
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -25,7 +25,10 @@ export type DaemonRequest =
 export type DaemonResponse =
   | { ok: true; status: DaemonStatus }
   | { ok: true }
-  | { ok: false; reason: "busy" | "invalid-request" | "failed" };
+  | {
+      ok: false;
+      reason: "busy" | "invalid-request" | "failed" | "poll-in-progress";
+    };
 
 export interface ApplicationDaemonStatus {
   application: string;
@@ -250,6 +253,7 @@ export async function startDaemon(
   const sockets = new Set<net.Socket>();
   let workerRunning = false;
   let stopping = false;
+  let pollInProgress = false;
   let shutdownPromise: Promise<void> | undefined;
 
   function shutdown(): Promise<void> {
@@ -269,7 +273,12 @@ export async function startDaemon(
       if (request.command === "stop") {
         return { ok: true };
       }
-      await deps.poll();
+      pollInProgress = true;
+      try {
+        await deps.poll();
+      } finally {
+        pollInProgress = false;
+      }
       return { ok: true };
     } catch (error) {
       logError(logger, error);
@@ -323,6 +332,10 @@ export async function startDaemon(
     request: DaemonRequest,
     respond: (response: DaemonResponse) => void,
   ): boolean {
+    if (request.command === "status" && pollInProgress) {
+      respond({ ok: false, reason: "poll-in-progress" });
+      return true;
+    }
     if (
       decideQueueAdmission(queue.length, queueCapacity, "client") !== "enqueue"
     ) {

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -82,6 +82,25 @@ describe("commands", () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it("reports an in-progress install without treating it as a failure", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => ({
+      ok: false as const,
+      reason: "poll-in-progress" as const,
+    }));
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await status(deps);
+
+    expect(deps.computeStatusInline).not.toHaveBeenCalled();
+    expect(output).toHaveBeenCalledWith(
+      "\nAn install is in progress. Try again shortly.",
+    );
+    expect(error).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+
   it("delegates poll to a reachable daemon", async () => {
     const deps = createDeps();
     deps.requestDaemon = vi.fn(async () => ({ ok: true as const }));

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -140,6 +140,30 @@ describe("daemon", () => {
     expect(polls).toBe(3);
   });
 
+  it("answers status immediately with poll-in-progress instead of waiting behind a running poll", async () => {
+    let releasePoll: (() => void) | undefined;
+    const pollGate = new Promise<void>((resolve) => {
+      releasePoll = resolve;
+    });
+    const daemon = await start({
+      poll: async () => {
+        await pollGate;
+      },
+      getStatus: async () => ({ applications: [] }),
+      attemptSelfUpdate: async () => "up-to-date",
+    });
+
+    const poll = sendRequest(daemon.socketPath, { command: "poll" });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    await expect(
+      sendRequest(daemon.socketPath, { command: "status" }),
+    ).resolves.toEqual({ ok: false, reason: "poll-in-progress" });
+
+    releasePoll!();
+    await expect(poll).resolves.toEqual({ ok: true });
+  });
+
   it("rejects malformed requests", async () => {
     const daemon = await start({
       poll: async () => {},


### PR DESCRIPTION
## Summary
- The daemon processed `status`/`poll`/`stop` one at a time from a single queue, so a `status` check would silently wait behind a slow install (git fetch, Docker build) triggered by `poll`.
- The daemon now tracks whether a `poll` is currently running. A concurrent `status` request skips the queue and answers immediately with "install in progress" instead of hanging.
- `piploy status` prints a friendly message for that case rather than treating it as a command failure.

## Why
Fixes #73 — status/poll appeared to hang whenever a new version was being installed. The root cause was queueing, not an actual freeze: the client only times out the socket *connection*, not the response, so it waited indefinitely behind the in-flight install.

## Reviewer notes
- Scope is intentionally narrow: only `status` gets the fast-path. `poll` still waits its turn behind another running `poll`, since progress streaming and any bigger rework of the queue is deliberately out of scope here — tracked separately in #74 (exploring replacing the single global queue with a richer execution model).
- Git/Docker operations still need to stay serialized per application; this change doesn't touch that.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (82 tests passing, including new coverage in `test/unit/daemon.test.ts` and `test/unit/commands.test.ts` for the poll-in-progress path)