### PR TITLE
Fix release workflow: unknown git identity when tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,8 @@ jobs:
             echo "Tag $RELEASE_TAG already exists." >&2
             exit 1
           fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag --annotate "$RELEASE_TAG" --message "Release $RELEASE_TAG"
           git push origin "$RELEASE_TAG"
 


### PR DESCRIPTION
## Summary
- The manual "Create release tag" step failed with `Committer identity unknown` / exit 128 (see [failed run](https://github.com/alundgren/Irudd.Piploy/actions/runs/31173146086/job/92849185056)).
- Cause: `git tag --annotate` requires a committer identity, and the GitHub Actions runner has no git user configured.
- Fix: set `user.name`/`user.email` for the runner before tagging.

## Test plan
- [ ] Trigger the `Release` workflow via `workflow_dispatch` with a test version and confirm the "Create release tag" step succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)