### PR TITLE
Add daemon register request

### DIFF
--- a/docs/adr/0001-config-validation-and-logging.md
+++ b/docs/adr/0001-config-validation-and-logging.md
@@ -24,6 +24,15 @@ Application data must survive it (see
 The daemon reads and validates configuration once at startup. Restart Piploy
 after changing `piploy.json`.
 
+The one exception is `register`, which adds a single Application. It validates
+the payload, rejects a duplicate `Name`, re-validates the whole resulting
+configuration, writes `piploy.json` through a temporary file and a rename, and
+then adds the Application to the daemon's live configuration, so the next poll
+deploys it without a restart (see
+[ADR-0007](0007-live-config-mutation-for-register.md)). Every other change to
+`piploy.json` — editing or removing an Application, `RootDirectory`,
+`MinutesBetweenBackgroundPolls` — still requires a restart.
+
 Piploy uses pino for level filtering and contextual child loggers. It writes
 human-readable text lines in the form `timestamp [key=value, ...] message`;
 the expected operator workflow is SSH access and reading the log file. Docker

--- a/docs/adr/0007-live-config-mutation-for-register.md
+++ b/docs/adr/0007-live-config-mutation-for-register.md
@@ -1,0 +1,39 @@
+# Live configuration mutation for register
+
+## Decision
+
+A successful `register` request mutates the daemon's in-memory
+`PiploySettings.Applications` array in place, by pushing the newly validated
+Application onto it. The orchestrator reads that same array on every `poll()`,
+so the next poll deploys the new Application with no orchestrator change and no
+daemon restart.
+
+This mutation is **additive only**. Nothing may splice, remove, reorder, or
+replace entries in the live array, and no code may replace the `settings`
+object itself. Removing or editing an Application means editing `piploy.json`
+and restarting the daemon
+([ADR-0001](0001-config-validation-and-logging.md)).
+
+The mutation is safe because every request — `register` included — runs through
+the daemon's single-worker FIFO queue. A register can therefore never interleave
+with a poll that is reading the array. `register` is not special-cased in
+queue admission, and it does not trigger a poll of its own: polling stays
+Piploy's only trigger.
+
+Disk and memory are updated in that order. `piploy.json` is written first,
+through a temporary file and a rename, and the live array is only extended once
+that write succeeded. A crash between the two leaves the Application registered
+on disk, which the next startup picks up.
+
+`isDuplicateApplicationName` in `registerPolicy.ts` is the pure duplicate-name
+check, kept as its own testable seam like `queuePolicy.ts`
+([ADR-0002](0002-module-seams-and-test-split.md)). It matches names exactly,
+without case folding.
+
+## Consequences
+
+Registering an Application takes effect within one poll interval instead of
+requiring an operator to edit a file and restart the service. In exchange, the
+settings object is no longer immutable after startup, so any future code that
+caches a snapshot of `settings.Applications` — rather than reading it per poll —
+would silently miss newly registered Applications.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -9,9 +9,12 @@ import { createOrchestrator } from "./orchestrator.js";
 import { decideQueueAdmission, type QueueSource } from "./queuePolicy.js";
 import { attemptSelfUpdate, type SelfUpdateResult } from "./selfUpdate.js";
 import {
+  registerApplication,
+  RegisterApplicationError,
   resolveConfigPath,
   type Application,
   type PiploySettings,
+  type RegisterApplicationFailure,
 } from "./settings.js";
 import { isRunningLatestVersion } from "./status.js";
 
@@ -20,15 +23,20 @@ const defaultPollIntervalMinutes = 60;
 const socketProbeTimeoutMilliseconds = 750;
 
 export type DaemonRequest =
-  { command: "status" } | { command: "poll" } | { command: "stop" };
+  | { command: "status" }
+  | { command: "poll" }
+  | { command: "stop" }
+  | { command: "register"; application: unknown };
 
 export type DaemonResponse =
   | { ok: true; status: DaemonStatus }
+  | { ok: true; application: Application }
   | { ok: true }
   | {
       ok: false;
       reason: "busy" | "invalid-request" | "failed" | "poll-in-progress";
-    };
+    }
+  | { ok: false; reason: RegisterApplicationFailure; message: string };
 
 export interface ApplicationDaemonStatus {
   application: string;
@@ -49,6 +57,7 @@ export interface DaemonDeps {
 
 export interface DaemonOptions {
   socketPath?: string;
+  configPath?: string;
   queueCapacity?: number;
   pollIntervalMinutes?: number;
   deps?: DaemonDeps;
@@ -74,17 +83,19 @@ function getSocketPath(options: DaemonOptions): string {
 }
 
 function parseRequest(value: unknown): DaemonRequest | undefined {
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    !("command" in value) ||
-    (value.command !== "status" &&
-      value.command !== "poll" &&
-      value.command !== "stop")
-  ) {
+  if (typeof value !== "object" || value === null || !("command" in value)) {
     return undefined;
   }
-  return { command: value.command };
+  const command = value.command;
+  if (command === "status" || command === "poll" || command === "stop") {
+    return { command };
+  }
+  // Only the envelope is checked here. The payload is validated once, by the
+  // Application schema, when the request runs.
+  if (command === "register" && "application" in value) {
+    return { command: "register", application: value.application };
+  }
+  return undefined;
 }
 
 function logError(logger: Logger, error: unknown): void {
@@ -248,6 +259,7 @@ export async function startDaemon(
     throw new Error("Daemon poll interval must be greater than zero");
   }
 
+  const configPath = options.configPath ?? resolveConfigPath();
   const deps = options.deps ?? createDaemonDeps(settings, logger);
   const queue: QueuedRequest[] = [];
   const sockets = new Set<net.Socket>();
@@ -265,21 +277,45 @@ export async function startDaemon(
     return shutdownPromise;
   }
 
+  /**
+   * Registering writes `piploy.json` and then appends to the very array the
+   * orchestrator re-reads on each poll, so the next poll picks the Application
+   * up (ADR-0007). It deliberately does not poll itself: polling is Piploy's
+   * only trigger, and nothing pushes work to it.
+   */
+  function runRegister(rawApplication: unknown): DaemonResponse {
+    try {
+      const application = registerApplication(configPath, rawApplication);
+      settings.Applications.push(application);
+      logger.info(`Registered application ${application.Name}`);
+      return { ok: true, application };
+    } catch (error) {
+      if (!(error instanceof RegisterApplicationError)) throw error;
+      logger.warn(`Rejected register request. ${error.message}`);
+      return { ok: false, reason: error.reason, message: error.message };
+    }
+  }
+
   async function runRequest(request: DaemonRequest): Promise<DaemonResponse> {
     try {
-      if (request.command === "status") {
-        return { ok: true, status: await deps.getStatus() };
+      // Every command is matched explicitly: a fallthrough here would run
+      // something other than what the client asked for.
+      switch (request.command) {
+        case "status":
+          return { ok: true, status: await deps.getStatus() };
+        case "stop":
+          return { ok: true };
+        case "register":
+          return runRegister(request.application);
+        case "poll":
+          pollInProgress = true;
+          try {
+            await deps.poll();
+          } finally {
+            pollInProgress = false;
+          }
+          return { ok: true };
       }
-      if (request.command === "stop") {
-        return { ok: true };
-      }
-      pollInProgress = true;
-      try {
-        await deps.poll();
-      } finally {
-        pollInProgress = false;
-      }
-      return { ok: true };
     } catch (error) {
       logError(logger, error);
       return { ok: false, reason: "failed" };

--- a/src/registerPolicy.ts
+++ b/src/registerPolicy.ts
@@ -1,0 +1,12 @@
+/**
+ * Decides whether an Application name is already taken. Matching is exact:
+ * `Name` is validated as `[A-Za-z0-9_-]+` and compared case-sensitively
+ * everywhere else (directories, image names), so two names differing only in
+ * case are two Applications.
+ */
+export function isDuplicateApplicationName(
+  applications: { Name: string }[],
+  name: string,
+): boolean {
+  return applications.some((application) => application.Name === name);
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,7 +1,15 @@
-import { readFileSync } from "node:fs";
+import {
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 
 import { z } from "zod";
+
+import { isDuplicateApplicationName } from "./registerPolicy.js";
 
 const portMappingPattern = /^(\d+):(\d+)$/;
 // The container path is a plain absolute path: no colons, because Docker reads
@@ -38,7 +46,7 @@ const VolumeSchema = z.string().transform((value, ctx) => {
   return { name: match[1]!, containerPath: match[2]! };
 });
 
-const ApplicationSchema = z
+export const ApplicationSchema = z
   .object({
     Name: z.string().regex(/^[A-Za-z0-9_-]+$/),
     GitRepositoryUrl: z.string(),
@@ -85,6 +93,113 @@ export function loadSettings(configPath: string): PiploySettings {
   const settings = parseSettings(JSON.parse(raw));
   assertDataDirectoryIsSeparateFromRootDirectory(settings, configPath);
   return settings;
+}
+
+export type RegisterApplicationFailure =
+  "invalid-application" | "duplicate-application";
+
+/** A register request rejected on its own merits, not on an I/O failure. */
+export class RegisterApplicationError extends Error {
+  constructor(
+    readonly reason: RegisterApplicationFailure,
+    message: string,
+  ) {
+    super(message);
+    this.name = "RegisterApplicationError";
+  }
+}
+
+function describeValidationError(error: z.ZodError): string {
+  return error.issues
+    .map((issue) =>
+      issue.path.length > 0
+        ? `${issue.path.join(".")}: ${issue.message}`
+        : issue.message,
+    )
+    .join("; ");
+}
+
+/**
+ * Adds one Application to `piploy.json`. The raw input is what gets persisted:
+ * `PortMappings` and `Volumes` are strings on disk and only the parsed value is
+ * transformed, so writing the transformed Application back would produce a
+ * config the schema then rejects.
+ */
+export function registerApplication(
+  configPath: string,
+  rawApplication: unknown,
+): Application {
+  const parsed = ApplicationSchema.safeParse(rawApplication);
+  if (!parsed.success) {
+    throw new RegisterApplicationError(
+      "invalid-application",
+      describeValidationError(parsed.error),
+    );
+  }
+  const application = parsed.data;
+
+  const currentConfig = JSON.parse(readFileSync(configPath, "utf8")) as unknown;
+  // An invalid file here is a broken installation, not a bad request, so it
+  // propagates rather than becoming a register-specific rejection.
+  const currentSettings = parseSettings(currentConfig);
+  if (
+    isDuplicateApplicationName(currentSettings.Applications, application.Name)
+  ) {
+    throw new RegisterApplicationError(
+      "duplicate-application",
+      `An application named '${application.Name}' is already registered`,
+    );
+  }
+
+  const nextConfig = structuredClone(currentConfig) as {
+    Piploy: { Applications: unknown[] };
+  };
+  nextConfig.Piploy.Applications = [
+    ...nextConfig.Piploy.Applications,
+    rawApplication,
+  ];
+  try {
+    assertDataDirectoryIsSeparateFromRootDirectory(
+      parseSettings(nextConfig),
+      configPath,
+    );
+  } catch (error) {
+    throw new RegisterApplicationError(
+      "invalid-application",
+      error instanceof z.ZodError
+        ? describeValidationError(error)
+        : error instanceof Error
+          ? error.message
+          : String(error),
+    );
+  }
+
+  writeConfigAtomically(configPath, nextConfig);
+  return application;
+}
+
+/**
+ * Writes the config through a temporary file in the same directory, so a crash
+ * mid-write leaves the previous `piploy.json` intact rather than a truncated
+ * one the daemon would refuse to start from.
+ */
+function writeConfigAtomically(configPath: string, config: unknown): void {
+  const temporaryPath = `${configPath}.tmp-${process.pid.toString()}`;
+  try {
+    writeFileSync(temporaryPath, JSON.stringify(config, null, 2) + "\n", {
+      // Keep whatever the operator set on the existing file: a rename replaces
+      // the inode, so the mode has to be carried over explicitly.
+      mode: statSync(configPath).mode & 0o777,
+    });
+    renameSync(temporaryPath, configPath);
+  } catch (error) {
+    try {
+      unlinkSync(temporaryPath);
+    } catch {
+      // The temporary file was never created, or is already gone.
+    }
+    throw error;
+  }
 }
 
 function containsDirectory(directory: string, candidate: string): boolean {

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, stat } from "node:fs/promises";
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -13,7 +13,7 @@ import {
   type DaemonResponse,
 } from "../../src/daemon.js";
 import type { Logger } from "../../src/logger.js";
-import type { PiploySettings } from "../../src/settings.js";
+import { loadSettings, type PiploySettings } from "../../src/settings.js";
 
 const settings: PiploySettings = {
   RootDirectory: "/tmp/piploy",
@@ -251,5 +251,172 @@ describe("daemon", () => {
     });
 
     await vi.waitFor(() => expect(events).toEqual(["poll"]));
+  });
+
+  describe("register", () => {
+    const newApplication = {
+      Name: "app",
+      GitRepositoryUrl: "https://example.com/app.git",
+      DockerfilePath: "Dockerfile",
+      PortMappings: ["8080:80"],
+    };
+
+    async function startWithConfig(
+      deps: DaemonDeps,
+      registered: unknown[] = [],
+    ): Promise<{
+      daemon: Daemon;
+      configPath: string;
+      liveSettings: PiploySettings;
+    }> {
+      const directory = await mkdtemp(path.join(os.tmpdir(), "piploy-"));
+      const configPath = path.join(directory, "piploy.json");
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          Piploy: {
+            RootDirectory: path.join(directory, "root"),
+            Applications: registered,
+          },
+        }),
+      );
+      const liveSettings = loadSettings(configPath);
+      const daemon = await startDaemon(liveSettings, createLogger(), {
+        socketPath: path.join(directory, "piploy.sock"),
+        configPath,
+        pollIntervalMinutes: 60,
+        deps,
+      });
+      daemons.push(daemon);
+      return { daemon, configPath, liveSettings };
+    }
+
+    function idleDeps(): DaemonDeps {
+      return {
+        poll: async () => {},
+        getStatus: async () => ({ applications: [] }),
+        attemptSelfUpdate: async () => "up-to-date",
+      };
+    }
+
+    it("persists a new application, returns it transformed, and adds it to the live settings", async () => {
+      const { daemon, configPath, liveSettings } =
+        await startWithConfig(idleDeps());
+
+      await expect(
+        sendRequest(daemon.socketPath, {
+          command: "register",
+          application: newApplication,
+        }),
+      ).resolves.toEqual({
+        ok: true,
+        application: {
+          Name: "app",
+          GitRepositoryUrl: "https://example.com/app.git",
+          DockerfilePath: "Dockerfile",
+          PortMappings: [{ hostPort: 8080, containerPort: 80 }],
+        },
+      });
+
+      // The file keeps the raw string form the schema parses, not the
+      // transformed port pairs.
+      const written = JSON.parse(await readFile(configPath, "utf8")) as {
+        Piploy: { Applications: unknown[] };
+      };
+      expect(written.Piploy.Applications).toEqual([newApplication]);
+      expect(liveSettings.Applications.map((one) => one.Name)).toEqual(["app"]);
+    });
+
+    it("rejects an application the schema does not accept", async () => {
+      const { daemon, configPath, liveSettings } =
+        await startWithConfig(idleDeps());
+
+      const response = await sendRequest(daemon.socketPath, {
+        command: "register",
+        application: { ...newApplication, PortMappings: ["not-a-mapping"] },
+      });
+
+      expect(response).toMatchObject({
+        ok: false,
+        reason: "invalid-application",
+      });
+      expect(liveSettings.Applications).toEqual([]);
+      const written = JSON.parse(await readFile(configPath, "utf8")) as {
+        Piploy: { Applications: unknown[] };
+      };
+      expect(written.Piploy.Applications).toEqual([]);
+    });
+
+    it("rejects an application whose name is already registered", async () => {
+      const { daemon, configPath } = await startWithConfig(idleDeps(), [
+        newApplication,
+      ]);
+
+      const response = await sendRequest(daemon.socketPath, {
+        command: "register",
+        application: { ...newApplication, PortMappings: ["9090:80"] },
+      });
+
+      expect(response).toMatchObject({
+        ok: false,
+        reason: "duplicate-application",
+      });
+      const written = JSON.parse(await readFile(configPath, "utf8")) as {
+        Piploy: { Applications: unknown[] };
+      };
+      expect(written.Piploy.Applications).toEqual([newApplication]);
+    });
+
+    it("does not poll", async () => {
+      let polls = 0;
+      const { daemon } = await startWithConfig({
+        ...idleDeps(),
+        poll: async () => {
+          polls += 1;
+        },
+      });
+      // The daemon polls once at startup; register must not add another.
+      await vi.waitFor(() => expect(polls).toBe(1));
+
+      await expect(
+        sendRequest(daemon.socketPath, {
+          command: "register",
+          application: newApplication,
+        }),
+      ).resolves.toMatchObject({ ok: true });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(polls).toBe(1);
+    });
+
+    it("waits behind a poll that is already running", async () => {
+      let releasePoll: (() => void) | undefined;
+      const pollGate = new Promise<void>((resolve) => {
+        releasePoll = resolve;
+      });
+      const events: string[] = [];
+      const { daemon } = await startWithConfig({
+        ...idleDeps(),
+        poll: async () => {
+          await pollGate;
+          events.push("poll");
+        },
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      const register = sendRequest(daemon.socketPath, {
+        command: "register",
+        application: newApplication,
+      }).then((response) => {
+        events.push("register");
+        return response;
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(events).toEqual([]);
+
+      releasePoll!();
+      await expect(register).resolves.toMatchObject({ ok: true });
+      expect(events).toEqual(["poll", "register"]);
+    });
   });
 });

--- a/test/unit/registerPolicy.test.ts
+++ b/test/unit/registerPolicy.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { isDuplicateApplicationName } from "../../src/registerPolicy.js";
+
+describe("isDuplicateApplicationName", () => {
+  it("finds an exactly matching name", () => {
+    expect(
+      isDuplicateApplicationName([{ Name: "other" }, { Name: "app" }], "app"),
+    ).toBe(true);
+  });
+
+  it("does not match a name that differs only in case", () => {
+    expect(isDuplicateApplicationName([{ Name: "App" }], "app")).toBe(false);
+  });
+
+  it("does not match a partial name", () => {
+    expect(isDuplicateApplicationName([{ Name: "app-two" }], "app")).toBe(
+      false,
+    );
+  });
+
+  it("is false when nothing is registered", () => {
+    expect(isDuplicateApplicationName([], "app")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a queued `register` daemon request for validating and registering Applications.
- Persist configuration atomically and update live settings without requiring a restart.
- Reject invalid or duplicate Applications with explicit errors.
- Document the live configuration mutation decision and update related ADR guidance.

## Testing
- Added daemon tests covering persistence, validation failures, duplicates, queue ordering, and no implicit polling.
- Added unit tests for exact duplicate-name matching.