### PR TITLE
Add Tailscale address discovery

### DIFF
--- a/docs/adr/0008-mcp-server-tailscale-only.md
+++ b/docs/adr/0008-mcp-server-tailscale-only.md
@@ -1,0 +1,28 @@
+# MCP server, Tailscale-only binding
+
+## Decision
+
+The MCP server introduced by issue #88 will bind only to the IPv4 address
+selected from Tailscale's `100.64.0.0/10` CGNAT range. It will not listen on a
+wildcard or public interface. The daemon will log the selected address when it
+starts the MCP server, so the binding is visible to the operator.
+
+Discovery is intentionally independent of an interface name: macOS, for
+example, uses `utun*` rather than Linux's `tailscale0`. When multiple addresses
+are in the CGNAT range, discovery prefers an interface whose name starts with
+`tailscale`; otherwise, it uses the first match, which is arbitrary.
+
+This is a heuristic. `100.64.0.0/10` is RFC 6598 shared address space, so a
+host on a CGNAT uplink could have a non-Tailscale address in that range. In
+that situation the MCP server could bind to the uplink rather than the
+tailnet. Piploy currently runs on a home-network Raspberry Pi, where that
+assumption holds. Reconsider an authoritative source such as `tailscale ip -4`
+or the Tailscale local API if Piploy must run behind a CGNAT uplink. They are
+deferred because they add a runtime dependency on the binary or local socket.
+
+## Consequences
+
+The MCP binding remains unreachable from the public internet, but a wrong
+selection on a CGNAT uplink could expose it to peers on that shared network.
+The explicit startup log makes that failure mode diagnosable. IPv6 Tailscale
+addresses are not supported in v1.

--- a/src/mcpTailscale.ts
+++ b/src/mcpTailscale.ts
@@ -1,0 +1,51 @@
+import * as os from "node:os";
+
+const tailscaleCgnatNetwork = 0x64400000;
+const tailscaleCgnatMask = 0xffc00000;
+
+function ipv4ToNumber(address: string): number | undefined {
+  const octets = address.split(".");
+  if (octets.length !== 4) return undefined;
+
+  let value = 0;
+  for (const octet of octets) {
+    const number = Number(octet);
+    if (!Number.isInteger(number) || number < 0 || number > 255) {
+      return undefined;
+    }
+    value = (value << 8) | number;
+  }
+  return value >>> 0;
+}
+
+function isTailscaleIpv4(address: string): boolean {
+  const value = ipv4ToNumber(address);
+  return (
+    value !== undefined &&
+    (value & tailscaleCgnatMask) === tailscaleCgnatNetwork
+  );
+}
+
+export function findTailscaleAddress(
+  interfaces: NodeJS.Dict<os.NetworkInterfaceInfo[]>,
+): string | undefined {
+  let firstMatch: string | undefined;
+  for (const [name, addresses] of Object.entries(interfaces)) {
+    for (const address of addresses ?? []) {
+      if (address.family === "IPv4" && isTailscaleIpv4(address.address)) {
+        if (name.startsWith("tailscale")) return address.address;
+        firstMatch ??= address.address;
+      }
+    }
+  }
+  // Interface enumeration determines this fallback, so it is deliberately
+  // arbitrary when no matching interface has a Tailscale-specific name.
+  return firstMatch;
+}
+
+/**
+ * IPv6 Tailscale addresses (`fd7a:115c:a1e0::/48`) are out of scope for v1.
+ */
+export function getTailscaleAddress(): string | undefined {
+  return findTailscaleAddress(os.networkInterfaces());
+}

--- a/test/unit/mcpTailscale.test.ts
+++ b/test/unit/mcpTailscale.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { NetworkInterfaceInfo } from "node:os";
+
+import { findTailscaleAddress } from "../../src/mcpTailscale.js";
+
+function ipv4(address: string): NetworkInterfaceInfo {
+  return {
+    address,
+    netmask: "255.255.255.0",
+    family: "IPv4",
+    mac: "00:00:00:00:00:00",
+    internal: false,
+    cidr: `${address}/24`,
+  };
+}
+
+function ipv6(address: string): NetworkInterfaceInfo {
+  return {
+    address,
+    netmask: "ffff:ffff:ffff:ffff::",
+    family: "IPv6",
+    mac: "00:00:00:00:00:00",
+    internal: false,
+    cidr: `${address}/64`,
+    scopeid: 0,
+  };
+}
+
+describe("findTailscaleAddress", () => {
+  it("returns undefined when the host has no interfaces", () => {
+    expect(findTailscaleAddress({})).toBeUndefined();
+  });
+
+  it("returns undefined when every interface is unavailable", () => {
+    expect(findTailscaleAddress({ tailscale0: undefined })).toBeUndefined();
+  });
+
+  it("returns an IPv4 address in Tailscale's CGNAT range", () => {
+    expect(findTailscaleAddress({ utun4: [ipv4("100.101.102.103")] })).toBe(
+      "100.101.102.103",
+    );
+  });
+
+  it("uses the complete /10 range rather than matching only a textual prefix", () => {
+    expect(
+      findTailscaleAddress({
+        utun4: [ipv4("100.127.255.255")],
+        en0: [ipv4("100.128.0.0")],
+      }),
+    ).toBe("100.127.255.255");
+  });
+
+  it("selects a Tailscale address instead of LAN and loopback addresses", () => {
+    expect(
+      findTailscaleAddress({
+        lo0: [ipv4("127.0.0.1")],
+        en0: [ipv4("192.168.1.10")],
+        utun4: [ipv4("100.64.0.1")],
+      }),
+    ).toBe("100.64.0.1");
+  });
+
+  it("returns the first matching address when no interface name breaks the tie", () => {
+    expect(
+      findTailscaleAddress({
+        utun4: [ipv4("100.64.0.1")],
+        utun5: [ipv4("100.64.0.2")],
+      }),
+    ).toBe("100.64.0.1");
+  });
+
+  it("prefers a matching address on a tailscale-named interface", () => {
+    expect(
+      findTailscaleAddress({
+        wwan0: [ipv4("100.64.0.1")],
+        tailscale0: [ipv4("100.64.0.2")],
+      }),
+    ).toBe("100.64.0.2");
+  });
+
+  it("ignores IPv6-only interfaces in v1", () => {
+    expect(
+      findTailscaleAddress({ utun4: [ipv6("fd7a:115c:a1e0::1")] }),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Discover the host's IPv4 address from the Tailscale CGNAT range.
- Bind the MCP server to the selected Tailscale address only.
- Log the selected address at startup and document the binding decision.
- Remove the obsolete MCP SDK dependency and live register-mutation code.

## Testing

- Added unit coverage for Tailscale address discovery and selection.
- Updated daemon and register policy tests for the revised behavior.
- Build and full test suite: Not run.