### PR TITLE
Add `piploy register` CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,22 +85,39 @@ The daemon's control socket is created with `0600` permissions and owned by the
 user the daemon runs as, so the commands below must run as that same user to
 reach it. Another user gets the offline fallback described under `status`.
 
-| Command | What it does |
-| --- | --- |
-| `status` | Prints the Piploy version, whether the background service is reachable, and per-application Git and Docker state. |
-| `poll` | Runs one reconciliation now instead of waiting for the poll timer. |
-| `service-start` | Runs the daemon in the foreground. This is what systemd invokes; do not run it by hand while the service is up. |
-| `service-stop` | Asks the running daemon to shut down. |
-| `wipeall` | Removes all Piploy containers and images and deletes the root directory. Application data is preserved and its paths are printed. |
-| `self-update` | Checks GitHub for a newer release and installs it. |
-| `--version` | Prints the running bundle's version. |
-| `--help` | Lists the commands. |
+| Command         | What it does                                                                                                                                       |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `status`        | Prints the Piploy version, whether the background service is reachable, and per-application Git and Docker state.                                  |
+| `poll`          | Runs one reconciliation now instead of waiting for the poll timer.                                                                                 |
+| `service-start` | Runs the daemon in the foreground. This is what systemd invokes; do not run it by hand while the service is up.                                    |
+| `service-stop`  | Asks the running daemon to shut down.                                                                                                              |
+| `register`      | Adds one application to `piploy.json` and to the running daemon, so the next poll deploys it without a restart. Requires the daemon to be running. |
+| `wipeall`       | Removes all Piploy containers and images and deletes the root directory. Application data is preserved and its paths are printed.                  |
+| `self-update`   | Checks GitHub for a newer release and installs it.                                                                                                 |
+| `--version`     | Prints the running bundle's version.                                                                                                               |
+| `--help`        | Lists the commands.                                                                                                                                |
 
 ### `status`
 
 ```bash
 node piploy.cjs status
 ```
+
+### `register`
+
+```bash
+node piploy.cjs register \
+  --name my-app \
+  --git-repository-url https://github.com/me/my-app.git \
+  --dockerfile-path Dockerfile \
+  --port-mapping 8080:80 \
+  --volume data:/var/lib/my-app \
+  --env NODE_ENV=production
+```
+
+`--port-mapping`, `--volume`, and `--env` may each be repeated. For scripting,
+`--json '<application-json>'` passes the whole application instead; it cannot be
+combined with the individual flags.
 
 ## Publishing a release
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,11 +2,14 @@ import { Command } from "commander";
 
 import {
   createCommandDeps,
+  parseRegisterOptions,
   poll,
+  register,
   serviceStart,
   serviceStop,
   status,
   wipeAll,
+  type RegisterOptions,
 } from "./commands.js";
 import { createLogger, type Logger } from "./logger.js";
 import { loadSettings, resolveConfigPath } from "./settings.js";
@@ -19,15 +22,60 @@ const commandNames = [
   "service-stop",
   "poll",
   "wipeall",
+  "register",
 ] as const;
+
+function collect(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+/** `register` is the one command carrying a payload, so it alone takes flags. */
+function addRegisterOptions(command: Command): Command {
+  return command
+    .option("--name <name>", "application name")
+    .option("--git-repository-url <url>", "git repository to deploy from")
+    .option("--dockerfile-path <path>", "Dockerfile path within the repository")
+    .option(
+      "--port-mapping <hostPort:containerPort>",
+      "port mapping, repeatable",
+      collect,
+      [],
+    )
+    .option(
+      "--volume <name:/container/path>",
+      "volume, repeatable",
+      collect,
+      [],
+    )
+    .option(
+      "--env <KEY=VALUE>",
+      "environment variable, repeatable",
+      collect,
+      [],
+    )
+    .option("--json <application>", "the whole Application as JSON");
+}
 
 function registerCommand(
   program: Command,
   commandName: (typeof commandNames)[number],
 ): void {
-  program.command(commandName).action(async () => {
+  const command = program.command(commandName);
+  if (commandName === "register") addRegisterOptions(command);
+  command.action(async (options: RegisterOptions) => {
+    const parsed =
+      commandName === "register" ? parseRegisterOptions(options) : undefined;
+    if (parsed?.ok === false) {
+      console.error(parsed.message);
+      process.exitCode = 1;
+      return;
+    }
     const settings = loadSettings(resolveConfigPath());
     const deps = createCommandDeps(settings, createLogger(settings));
+    if (parsed) {
+      await register(deps, parsed.application);
+      return;
+    }
     const actions = {
       status,
       "service-start": serviceStart,
@@ -35,7 +83,7 @@ function registerCommand(
       poll,
       wipeall: wipeAll,
     } as const;
-    await actions[commandName](deps);
+    await actions[commandName as Exclude<typeof commandName, "register">](deps);
   });
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 
 import {
+  commandFailed,
   createCommandDeps,
   parseRegisterOptions,
   poll,
@@ -9,6 +10,7 @@ import {
   serviceStop,
   status,
   wipeAll,
+  type CommandDeps,
   type RegisterOptions,
 } from "./commands.js";
 import { createLogger, type Logger } from "./logger.js";
@@ -56,34 +58,45 @@ function addRegisterOptions(command: Command): Command {
     .option("--json <application>", "the whole Application as JSON");
 }
 
-function registerCommand(
+// Only `register` reads the second argument; the rest are zero-arg commands.
+type CommandAction = (deps: CommandDeps, application: unknown) => Promise<void>;
+
+const actions: Record<(typeof commandNames)[number], CommandAction> = {
+  status,
+  "service-start": serviceStart,
+  "service-stop": serviceStop,
+  poll,
+  wipeall: wipeAll,
+  register,
+};
+
+async function runCommand(
+  commandName: (typeof commandNames)[number],
+  application: unknown,
+): Promise<void> {
+  const settings = loadSettings(resolveConfigPath());
+  const deps = createCommandDeps(settings, createLogger(settings));
+  await actions[commandName](deps, application);
+}
+
+function defineCommand(
   program: Command,
   commandName: (typeof commandNames)[number],
 ): void {
   const command = program.command(commandName);
-  if (commandName === "register") addRegisterOptions(command);
-  command.action(async (options: RegisterOptions) => {
-    const parsed =
-      commandName === "register" ? parseRegisterOptions(options) : undefined;
-    if (parsed?.ok === false) {
-      console.error(parsed.message);
-      process.exitCode = 1;
+  if (commandName !== "register") {
+    command.action(() => runCommand(commandName, undefined));
+    return;
+  }
+  // Flags are parsed before the configuration is loaded, so bad input fails on
+  // its own terms rather than on a missing or broken piploy.json.
+  addRegisterOptions(command).action(async (options: RegisterOptions) => {
+    const parsed = parseRegisterOptions(options);
+    if (!parsed.ok) {
+      commandFailed(parsed.message);
       return;
     }
-    const settings = loadSettings(resolveConfigPath());
-    const deps = createCommandDeps(settings, createLogger(settings));
-    if (parsed) {
-      await register(deps, parsed.application);
-      return;
-    }
-    const actions = {
-      status,
-      "service-start": serviceStart,
-      "service-stop": serviceStop,
-      poll,
-      wipeall: wipeAll,
-    } as const;
-    await actions[commandName as Exclude<typeof commandName, "register">](deps);
+    await runCommand(commandName, parsed.application);
   });
 }
 
@@ -109,7 +122,7 @@ export function createProgram(): Command {
     }
   });
   for (const commandName of commandNames) {
-    registerCommand(program, commandName);
+    defineCommand(program, commandName);
   }
 
   return program;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -12,13 +12,21 @@ import {
 import { createDockerService } from "./docker.js";
 import type { Logger } from "./logger.js";
 import type { PiploySettings } from "./settings.js";
-import { getApplicationDataDirectory } from "./settings.js";
+import {
+  getApplicationDataDirectory,
+  parseApplication,
+  RegisterApplicationError,
+} from "./settings.js";
 import { piployVersion } from "./version.js";
+
+/** A daemon register response, or `undefined` when no daemon answered. */
+export type RegisterResult = DaemonResponse | undefined;
 
 export interface CommandDeps {
   requestDaemon(request: DaemonRequest): Promise<DaemonResponse | undefined>;
   computeStatusInline(): Promise<DaemonStatus>;
   pollInline(): Promise<void>;
+  register(application: unknown): Promise<RegisterResult>;
   wipeAll(): Promise<void>;
   getPreservedApplicationDataDirectories(): string[];
   startDaemon(): Promise<Daemon>;
@@ -34,6 +42,8 @@ export function createCommandDeps(
     requestDaemon,
     computeStatusInline: daemonDeps.getStatus,
     pollInline: daemonDeps.poll,
+    register: (application) =>
+      requestDaemon({ command: "register", application }),
     async wipeAll() {
       try {
         await createDockerService(settings, logger).cleanupAll();
@@ -116,6 +126,139 @@ export async function poll(deps: CommandDeps): Promise<void> {
     return;
   }
   console.log("Poll completed.");
+}
+
+/** The `register` flags commander collects, before they become an Application. */
+export interface RegisterOptions {
+  json?: string;
+  name?: string;
+  gitRepositoryUrl?: string;
+  dockerfilePath?: string;
+  portMapping?: string[];
+  volume?: string[];
+  env?: string[];
+}
+
+export type ParsedRegisterOptions =
+  { ok: true; application: unknown } | { ok: false; message: string };
+
+function parseEnvironmentVariables(
+  values: string[],
+): Record<string, string> | string {
+  const environmentVariables: Record<string, string> = {};
+  for (const value of values) {
+    const separator = value.indexOf("=");
+    if (separator < 1) {
+      return `Invalid --env '${value}'. Must have the format KEY=VALUE`;
+    }
+    environmentVariables[value.slice(0, separator)] = value.slice(
+      separator + 1,
+    );
+  }
+  return environmentVariables;
+}
+
+function buildApplicationFromFlags(options: RegisterOptions): unknown {
+  // Optional fields stay absent rather than empty, so a flagless invocation
+  // produces the same document an operator would have hand-written.
+  const application: Record<string, unknown> = {
+    Name: options.name,
+    GitRepositoryUrl: options.gitRepositoryUrl,
+    DockerfilePath: options.dockerfilePath,
+  };
+  if (options.portMapping?.length) {
+    application.PortMappings = options.portMapping;
+  }
+  if (options.volume?.length) application.Volumes = options.volume;
+  return application;
+}
+
+/**
+ * Turns `register` flags into the raw Application to send. Raw, not parsed:
+ * the daemon persists exactly what it receives, and `PortMappings`/`Volumes`
+ * are strings on disk. Validation runs here only to fail with a CLI message
+ * instead of a daemon rejection reason.
+ */
+export function parseRegisterOptions(
+  options: RegisterOptions,
+): ParsedRegisterOptions {
+  const usesFlags =
+    options.name !== undefined ||
+    options.gitRepositoryUrl !== undefined ||
+    options.dockerfilePath !== undefined ||
+    (options.portMapping?.length ?? 0) > 0 ||
+    (options.volume?.length ?? 0) > 0 ||
+    (options.env?.length ?? 0) > 0;
+
+  let application: unknown;
+  if (options.json !== undefined) {
+    if (usesFlags) {
+      return {
+        ok: false,
+        message: "Use either --json or the individual flags, not both.",
+      };
+    }
+    try {
+      application = JSON.parse(options.json);
+    } catch (error) {
+      return {
+        ok: false,
+        message: `Invalid --json. ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  } else {
+    const environmentVariables = parseEnvironmentVariables(options.env ?? []);
+    if (typeof environmentVariables === "string") {
+      return { ok: false, message: environmentVariables };
+    }
+    const fromFlags = buildApplicationFromFlags(options) as Record<
+      string,
+      unknown
+    >;
+    if (Object.keys(environmentVariables).length > 0) {
+      fromFlags.EnvironmentVariables = environmentVariables;
+    }
+    application = fromFlags;
+  }
+
+  try {
+    parseApplication(application);
+  } catch (error) {
+    if (!(error instanceof RegisterApplicationError)) throw error;
+    return { ok: false, message: `Invalid application. ${error.message}` };
+  }
+  return { ok: true, application };
+}
+
+/**
+ * Registers one Application with the running daemon. There is no inline
+ * fallback: register exists to reach the live daemon's settings, and writing
+ * the file alone would still need a restart (ADR-0007).
+ */
+export async function register(
+  deps: CommandDeps,
+  application: unknown,
+): Promise<void> {
+  const response = await deps.register(application);
+  if (response === undefined) {
+    commandFailed(
+      "Background service not running. Start it, then run 'piploy register' again.",
+    );
+    return;
+  }
+  if (!response.ok) {
+    commandFailed(
+      "message" in response
+        ? `Register failed: ${response.reason}. ${response.message}`
+        : `Daemon register request failed: ${response.reason}`,
+    );
+    return;
+  }
+  if (!("application" in response)) {
+    commandFailed("Daemon register request returned no application");
+    return;
+  }
+  console.log(`Registered application ${response.application.Name}.`);
 }
 
 /** Asks the running daemon to stop without falling back to a local action. */

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -59,7 +59,8 @@ export function createCommandDeps(
   };
 }
 
-function commandFailed(message: string): void {
+/** The one place a command's failure sets both the message and the exit code. */
+export function commandFailed(message: string): void {
   console.error(message);
   process.exitCode = 1;
 }
@@ -142,23 +143,33 @@ export interface RegisterOptions {
 export type ParsedRegisterOptions =
   { ok: true; application: unknown } | { ok: false; message: string };
 
+type ParsedEnvironmentVariables =
+  | { ok: true; environmentVariables: Record<string, string> }
+  | { ok: false; message: string };
+
 function parseEnvironmentVariables(
   values: string[],
-): Record<string, string> | string {
+): ParsedEnvironmentVariables {
   const environmentVariables: Record<string, string> = {};
   for (const value of values) {
+    // Only the first '=' separates: a value may legitimately contain more.
     const separator = value.indexOf("=");
     if (separator < 1) {
-      return `Invalid --env '${value}'. Must have the format KEY=VALUE`;
+      return {
+        ok: false,
+        message: `Invalid --env '${value}'. Must have the format KEY=VALUE`,
+      };
     }
     environmentVariables[value.slice(0, separator)] = value.slice(
       separator + 1,
     );
   }
-  return environmentVariables;
+  return { ok: true, environmentVariables };
 }
 
-function buildApplicationFromFlags(options: RegisterOptions): unknown {
+function buildApplicationFromFlags(
+  options: RegisterOptions,
+): Record<string, unknown> {
   // Optional fields stay absent rather than empty, so a flagless invocation
   // produces the same document an operator would have hand-written.
   const application: Record<string, unknown> = {
@@ -207,16 +218,11 @@ export function parseRegisterOptions(
       };
     }
   } else {
-    const environmentVariables = parseEnvironmentVariables(options.env ?? []);
-    if (typeof environmentVariables === "string") {
-      return { ok: false, message: environmentVariables };
-    }
-    const fromFlags = buildApplicationFromFlags(options) as Record<
-      string,
-      unknown
-    >;
-    if (Object.keys(environmentVariables).length > 0) {
-      fromFlags.EnvironmentVariables = environmentVariables;
+    const parsedEnvironment = parseEnvironmentVariables(options.env ?? []);
+    if (!parsedEnvironment.ok) return parsedEnvironment;
+    const fromFlags = buildApplicationFromFlags(options);
+    if (Object.keys(parsedEnvironment.environmentVariables).length > 0) {
+      fromFlags.EnvironmentVariables = parsedEnvironment.environmentVariables;
     }
     application = fromFlags;
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -120,6 +120,22 @@ function describeValidationError(error: z.ZodError): string {
 }
 
 /**
+ * Validates one candidate Application, throwing the same rejection a daemon
+ * register request would produce. Shared so the CLI can reject bad input before
+ * a round trip and report it the same way the daemon would.
+ */
+export function parseApplication(rawApplication: unknown): Application {
+  const parsed = ApplicationSchema.safeParse(rawApplication);
+  if (!parsed.success) {
+    throw new RegisterApplicationError(
+      "invalid-application",
+      describeValidationError(parsed.error),
+    );
+  }
+  return parsed.data;
+}
+
+/**
  * Adds one Application to `piploy.json`. The raw input is what gets persisted:
  * `PortMappings` and `Volumes` are strings on disk and only the parsed value is
  * transformed, so writing the transformed Application back would produce a
@@ -129,14 +145,7 @@ export function registerApplication(
   configPath: string,
   rawApplication: unknown,
 ): Application {
-  const parsed = ApplicationSchema.safeParse(rawApplication);
-  if (!parsed.success) {
-    throw new RegisterApplicationError(
-      "invalid-application",
-      describeValidationError(parsed.error),
-    );
-  }
-  const application = parsed.data;
+  const application = parseApplication(rawApplication);
 
   const currentConfig = JSON.parse(readFileSync(configPath, "utf8")) as unknown;
   // An invalid file here is a broken installation, not a bad request, so it

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  parseRegisterOptions,
   poll,
+  register,
   serviceStart,
   serviceStop,
   status,
@@ -9,6 +11,12 @@ import {
   type CommandDeps,
 } from "../../src/commands.js";
 import type { DaemonStatus } from "../../src/daemon.js";
+
+const application = {
+  Name: "app",
+  GitRepositoryUrl: "https://example.com/app.git",
+  DockerfilePath: "Dockerfile",
+};
 
 const daemonStatus: DaemonStatus = {
   applications: [
@@ -26,6 +34,7 @@ function createDeps(): CommandDeps {
     requestDaemon: vi.fn(),
     computeStatusInline: vi.fn(async () => daemonStatus),
     pollInline: vi.fn(),
+    register: vi.fn(),
     wipeAll: vi.fn(),
     getPreservedApplicationDataDirectories: vi.fn(() => []),
     startDaemon: vi.fn(async () => ({
@@ -177,5 +186,201 @@ describe("commands", () => {
     await serviceStart(deps);
 
     expect(deps.startDaemon).toHaveBeenCalledOnce();
+  });
+
+  it("reports the registered application name on success", async () => {
+    const deps = createDeps();
+    deps.register = vi.fn(async () => ({
+      ok: true as const,
+      application: { ...application },
+    }));
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await register(deps, application);
+
+    expect(deps.register).toHaveBeenCalledWith(application);
+    expect(output).toHaveBeenCalledWith("Registered application app.");
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("reports an invalid application with the daemon message", async () => {
+    const deps = createDeps();
+    deps.register = vi.fn(async () => ({
+      ok: false as const,
+      reason: "invalid-application" as const,
+      message: "Name: Invalid input",
+    }));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await register(deps, application);
+
+    expect(error).toHaveBeenCalledWith(
+      "Register failed: invalid-application. Name: Invalid input",
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("reports a duplicate application with the daemon message", async () => {
+    const deps = createDeps();
+    deps.register = vi.fn(async () => ({
+      ok: false as const,
+      reason: "duplicate-application" as const,
+      message: "An application named 'app' is already registered",
+    }));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await register(deps, application);
+
+    expect(error).toHaveBeenCalledWith(
+      "Register failed: duplicate-application. An application named 'app' is already registered",
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("reports a generic daemon rejection without a message", async () => {
+    const deps = createDeps();
+    deps.register = vi.fn(async () => ({
+      ok: false as const,
+      reason: "busy" as const,
+    }));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await register(deps, application);
+
+    expect(error).toHaveBeenCalledWith("Daemon register request failed: busy");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("refuses to register without a running daemon", async () => {
+    const deps = createDeps();
+    deps.register = vi.fn(async () => undefined);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await register(deps, application);
+
+    expect(error).toHaveBeenCalledWith(
+      "Background service not running. Start it, then run 'piploy register' again.",
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("reports a success response missing its application", async () => {
+    const deps = createDeps();
+    deps.register = vi.fn(async () => ({ ok: true as const }));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await register(deps, application);
+
+    expect(error).toHaveBeenCalledWith(
+      "Daemon register request returned no application",
+    );
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+describe("parseRegisterOptions", () => {
+  it("builds a raw application from the individual flags", () => {
+    const parsed = parseRegisterOptions({
+      name: "app",
+      gitRepositoryUrl: "https://example.com/app.git",
+      dockerfilePath: "Dockerfile",
+      portMapping: ["8080:80", "8443:443"],
+      volume: ["data:/var/lib/app"],
+      env: ["A=1", "B=x=y"],
+    });
+
+    expect(parsed).toEqual({
+      ok: true,
+      application: {
+        ...application,
+        PortMappings: ["8080:80", "8443:443"],
+        Volumes: ["data:/var/lib/app"],
+        EnvironmentVariables: { A: "1", B: "x=y" },
+      },
+    });
+  });
+
+  it("omits optional fields when their flags are absent", () => {
+    const parsed = parseRegisterOptions({
+      name: "app",
+      gitRepositoryUrl: "https://example.com/app.git",
+      dockerfilePath: "Dockerfile",
+      portMapping: [],
+      volume: [],
+      env: [],
+    });
+
+    expect(parsed).toEqual({ ok: true, application });
+  });
+
+  it("accepts a whole application as JSON", () => {
+    const parsed = parseRegisterOptions({
+      json: JSON.stringify({ ...application, PortMappings: ["8080:80"] }),
+    });
+
+    expect(parsed).toEqual({
+      ok: true,
+      application: { ...application, PortMappings: ["8080:80"] },
+    });
+  });
+
+  it("rejects mixing --json with the individual flags", () => {
+    const parsed = parseRegisterOptions({
+      json: JSON.stringify(application),
+      name: "other",
+    });
+
+    expect(parsed).toEqual({
+      ok: false,
+      message: "Use either --json or the individual flags, not both.",
+    });
+  });
+
+  it("rejects malformed JSON", () => {
+    const parsed = parseRegisterOptions({ json: "{" });
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.ok === false && parsed.message).toMatch(/^Invalid --json\./);
+  });
+
+  it("rejects an --env flag without a key and value", () => {
+    const parsed = parseRegisterOptions({
+      name: "app",
+      gitRepositoryUrl: "https://example.com/app.git",
+      dockerfilePath: "Dockerfile",
+      env: ["=1"],
+    });
+
+    expect(parsed).toEqual({
+      ok: false,
+      message: "Invalid --env '=1'. Must have the format KEY=VALUE",
+    });
+  });
+
+  it("rejects an application the schema refuses", () => {
+    const parsed = parseRegisterOptions({
+      name: "not a valid name",
+      gitRepositoryUrl: "https://example.com/app.git",
+      dockerfilePath: "Dockerfile",
+    });
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.ok === false && parsed.message).toMatch(
+      /^Invalid application\./,
+    );
+  });
+
+  it("rejects a port mapping the schema refuses before contacting the daemon", () => {
+    const parsed = parseRegisterOptions({
+      name: "app",
+      gitRepositoryUrl: "https://example.com/app.git",
+      dockerfilePath: "Dockerfile",
+      portMapping: ["80"],
+    });
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.ok === false && parsed.message).toContain(
+      "Invalid port mappings",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Add a `register` command for registering applications with the running daemon.
- Support individual application flags and whole-application JSON input.
- Validate registration input and report daemon errors clearly.
- Document the command and remove obsolete Tailscale MCP binding code.

## Testing

- Added unit tests covering registration, option parsing, validation, and error handling.
- Not run.