### PR TITLE
Add MCP server bound to the Tailscale address

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,24 @@ reach it. Another user gets the offline fallback described under `status`.
 node piploy.cjs status
 ```
 
+## MCP server
+
+While the daemon runs, it also serves an MCP endpoint over Streamable HTTP at:
+
+```
+http://<tailscale-address>:8391/mcp
+```
+
+It binds only to the machine's Tailscale address, so it is reachable from the
+tailnet and from nowhere else. There is no token and no other authentication:
+being on the tailnet is the whole of it. If the machine has no Tailscale
+address, the daemon logs a warning and starts anyway, without the endpoint.
+
+It exposes five tools — `status`, `poll`, `register`, `service-start`, and
+`service-stop` — which run exactly what the matching CLI commands do. `wipeall`
+and `self-update` are deliberately not exposed. See
+[ADR-0008](docs/adr/0008-mcp-server-tailscale-only.md).
+
 ## Publishing a release
 
 In GitHub, run the **Release** workflow from the Actions page and enter the

--- a/docs/adr/0008-mcp-server-tailscale-only.md
+++ b/docs/adr/0008-mcp-server-tailscale-only.md
@@ -2,7 +2,7 @@
 
 ## Decision
 
-The MCP server introduced by issue #88 will bind only to the IPv4 address
+The MCP server binds only to the IPv4 address
 selected from Tailscale's `100.64.0.0/10` CGNAT range. It will not listen on a
 wildcard or public interface. The daemon will log the selected address when it
 starts the MCP server, so the binding is visible to the operator.
@@ -19,6 +19,46 @@ tailnet. Piploy currently runs on a home-network Raspberry Pi, where that
 assumption holds. Reconsider an authoritative source such as `tailscale ip -4`
 or the Tailscale local API if Piploy must run behind a CGNAT uplink. They are
 deferred because they add a runtime dependency on the binary or local socket.
+
+## Exposed tools
+
+The server registers exactly five tools: `status`, `poll`, `register`,
+`service-start`, and `service-stop`. `wipeall` and `self-update` are excluded,
+and the exclusion is structural — they are simply never registered, so there is
+no block list that could drift out of sync with the command set. `wipeall`
+destroys every container, image, and file Piploy owns; `self-update` replaces
+the running binary. Neither belongs behind a network call.
+
+Each tool builds the same `DaemonRequest` a Unix-socket client would send and
+hands it to the same queue through one `dispatch` seam, so an MCP call inherits
+the single-worker FIFO ordering and runs the one implementation of that command
+([ADR-0007](0007-live-config-mutation-for-register.md)). `service-start` is the
+exception: the MCP server lives inside the daemon, so answering the call at all
+proves the daemon is running. It enqueues nothing and says so.
+
+The transport is Streamable HTTP in stateless mode (no session id, no session
+store) on a plain `node:http` server at `/mcp`, port `8391`, fixed for v1 and
+not configurable through `piploy.json`. Stateless mode means a fresh MCP server
+and transport per request, which is what makes it safe for one `McpServer` to
+own its transport exclusively.
+
+## Rejected: Cloudflare Tunnel with Access
+
+Fronting the MCP server with a Cloudflare Tunnel plus Access policies would
+make it reachable from anywhere, at the cost of a second daemon on the Pi, an
+account-level dependency, an identity provider to configure, and a publicly
+routable hostname for a service that manages the machine. The need for
+off-tailnet access is hypothetical today. Tailscale membership is the entire
+v1 authentication model: there is no bearer token and no OAuth, because
+reaching the port already requires being on the tailnet.
+
+## Graceful degradation
+
+The MCP server starts only after the Unix socket is already listening, and
+nothing about it can prevent the daemon from starting. If no Tailscale address
+is found, or if binding fails (a taken port, for example), the daemon logs a
+warning and carries on serving the socket. Tailscale being down must never cost
+Piploy its local control path.
 
 ## Consequences
 

--- a/scripts/verifyBundle.mjs
+++ b/scripts/verifyBundle.mjs
@@ -1,4 +1,10 @@
-import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { builtinModules } from "node:module";
 import os from "node:os";
 import path from "node:path";
@@ -6,21 +12,29 @@ import process from "node:process";
 import { spawnSync } from "node:child_process";
 
 const bundlePath = path.resolve("dist/piploy.cjs");
-const allowedModules = new Set(
-  builtinModules.flatMap((moduleName) => [moduleName, `node:${moduleName}`]),
-);
-// A require preceded by a quote or backtick is source text a bundled library
-// generates for its own consumers (ajv emits `require("ajv/dist/runtime/...")`
-// into generated validators), not a require this bundle performs.
+// ajv is bundled, but it also emits these specifiers as source text into the
+// validators it generates for its own consumers. Nothing here requires them.
+const generatedSpecifiers = [
+  "ajv/dist/runtime/equal",
+  "ajv/dist/runtime/ucs2length",
+  "ajv/dist/runtime/uri",
+  "ajv/dist/runtime/validation_error",
+  "ajv-formats/dist/formats",
+];
+const allowedModules = new Set([
+  ...builtinModules.flatMap((moduleName) => [moduleName, `node:${moduleName}`]),
+  ...generatedSpecifiers,
+]);
 const requiredModules = [
   ...readFileSync(bundlePath, "utf8").matchAll(
-    /(?<!['"`])\brequire\((["'])([^"']+)\1\)/g,
+    /\brequire\((["'])([^"']+)\1\)/g,
   ),
 ].map((match) => match[2]);
 const externalModules = [
   ...new Set(
     requiredModules.filter(
-      (moduleName) => moduleName !== undefined && !allowedModules.has(moduleName),
+      (moduleName) =>
+        moduleName !== undefined && !allowedModules.has(moduleName),
     ),
   ),
 ];
@@ -31,7 +45,9 @@ if (externalModules.length > 0) {
   );
 }
 
-const temporaryDirectory = mkdtempSync(path.join(os.tmpdir(), "piploy-bundle-"));
+const temporaryDirectory = mkdtempSync(
+  path.join(os.tmpdir(), "piploy-bundle-"),
+);
 
 try {
   const deployedBundlePath = path.join(temporaryDirectory, "piploy.cjs");

--- a/scripts/verifyBundle.mjs
+++ b/scripts/verifyBundle.mjs
@@ -9,8 +9,13 @@ const bundlePath = path.resolve("dist/piploy.cjs");
 const allowedModules = new Set(
   builtinModules.flatMap((moduleName) => [moduleName, `node:${moduleName}`]),
 );
+// A require preceded by a quote or backtick is source text a bundled library
+// generates for its own consumers (ajv emits `require("ajv/dist/runtime/...")`
+// into generated validators), not a require this bundle performs.
 const requiredModules = [
-  ...readFileSync(bundlePath, "utf8").matchAll(/\brequire\((["'])([^"']+)\1\)/g),
+  ...readFileSync(bundlePath, "utf8").matchAll(
+    /(?<!['"`])\brequire\((["'])([^"']+)\1\)/g,
+  ),
 ].map((match) => match[2]);
 const externalModules = [
   ...new Set(

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import { createDockerService, type DockerStatus } from "./docker.js";
 import { getCommitStatus, type GitCommitStatus } from "./git.js";
 import type { Logger } from "./logger.js";
+import { mcpPort, startMcpServer, type McpServerHandle } from "./mcp.js";
+import { getTailscaleAddress } from "./mcpTailscale.js";
 import { createOrchestrator } from "./orchestrator.js";
 import { decideQueueAdmission, type QueueSource } from "./queuePolicy.js";
 import { attemptSelfUpdate, type SelfUpdateResult } from "./selfUpdate.js";
@@ -61,6 +63,8 @@ export interface DaemonOptions {
   queueCapacity?: number;
   pollIntervalMinutes?: number;
   deps?: DaemonDeps;
+  mcpPort?: number;
+  getTailscaleAddress?: () => string | undefined;
 }
 
 export interface Daemon {
@@ -267,13 +271,16 @@ export async function startDaemon(
   let stopping = false;
   let pollInProgress = false;
   let shutdownPromise: Promise<void> | undefined;
+  let mcpServer: McpServerHandle | undefined;
 
   function shutdown(): Promise<void> {
     if (shutdownPromise) return shutdownPromise;
     stopping = true;
     clearInterval(timer);
     for (const socket of sockets) socket.destroy();
-    shutdownPromise = close(server);
+    shutdownPromise = Promise.all([close(server), mcpServer?.stop()]).then(
+      () => {},
+    );
     return shutdownPromise;
   }
 
@@ -385,6 +392,19 @@ export async function startDaemon(
     return true;
   }
 
+  /**
+   * The one way in for callers that are not a Unix-socket client. It shares
+   * `enqueueClient`, so an MCP call queues behind the same single worker and
+   * runs the same implementation a socket call would.
+   */
+  function dispatch(request: DaemonRequest): Promise<DaemonResponse> {
+    return new Promise((resolve) => {
+      if (!enqueueClient(request, resolve)) {
+        resolve({ ok: false, reason: "busy" });
+      }
+    });
+  }
+
   const server = net.createServer((socket) => {
     sockets.add(socket);
     socket.once("close", () => sockets.delete(socket));
@@ -435,6 +455,28 @@ export async function startDaemon(
   );
   enqueue({ command: "poll" }, "timer");
   logger.info(`Daemon listening at ${socketPath}`);
+
+  // The socket is already serving by this point, and stays serving whatever
+  // happens here: MCP is an extra, and Tailscale being down or the port being
+  // taken must never keep the daemon from starting (ADR-0008).
+  const tailscaleAddress = (
+    options.getTailscaleAddress ?? getTailscaleAddress
+  )();
+  if (tailscaleAddress === undefined) {
+    logger.warn("No Tailscale address found. MCP server not started");
+  } else {
+    try {
+      mcpServer = await startMcpServer({
+        address: tailscaleAddress,
+        port: options.mcpPort ?? mcpPort,
+        dispatch,
+      });
+      logger.info(`MCP server listening at ${mcpServer.url}`);
+    } catch (error) {
+      logger.warn("Failed to start the MCP server");
+      logError(logger, error);
+    }
+  }
 
   return {
     socketPath,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -278,9 +278,13 @@ export async function startDaemon(
     stopping = true;
     clearInterval(timer);
     for (const socket of sockets) socket.destroy();
-    shutdownPromise = Promise.all([close(server), mcpServer?.stop()]).then(
-      () => {},
-    );
+    shutdownPromise = Promise.all([
+      close(server),
+      // A stuck MCP server must not hold up the shutdown a client just asked
+      // for, and must not be what fails it. The socket teardown is the one
+      // that decides whether the daemon stopped.
+      mcpServer?.stop().catch((error: unknown) => logError(logger, error)),
+    ]).then(() => {});
     return shutdownPromise;
   }
 
@@ -466,12 +470,19 @@ export async function startDaemon(
     logger.warn("No Tailscale address found. MCP server not started");
   } else {
     try {
-      mcpServer = await startMcpServer({
+      const started = await startMcpServer({
         address: tailscaleAddress,
         port: options.mcpPort ?? mcpPort,
         dispatch,
+        onError: (error) => logError(logger, error),
       });
-      logger.info(`MCP server listening at ${mcpServer.url}`);
+      if (shutdownPromise) {
+        // Stopped while this was still binding, so the teardown never saw it.
+        await started.stop();
+      } else {
+        mcpServer = started;
+        logger.info(`MCP server listening at ${started.url}`);
+      }
     } catch (error) {
       logger.warn("Failed to start the MCP server");
       logError(logger, error);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,0 +1,186 @@
+import http from "node:http";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { z } from "zod";
+
+import type { DaemonRequest, DaemonResponse } from "./daemon.js";
+import { piployVersion } from "./version.js";
+
+/** Fixed for v1. Making the port configurable is deliberately deferred. */
+export const mcpPort = 8391;
+const mcpPath = "/mcp";
+const flushGraceMs = 250;
+
+export type McpDispatch = (request: DaemonRequest) => Promise<DaemonResponse>;
+
+export interface McpServerOptions {
+  /** Explicit so tests can bind 127.0.0.1 without a Tailscale interface. */
+  address: string;
+  port: number;
+  dispatch: McpDispatch;
+}
+
+export interface McpServerHandle {
+  url: string;
+  port: number;
+  stop(): Promise<void>;
+}
+
+/**
+ * The register payload is passed through untransformed: `ApplicationSchema`
+ * is the one authority that validates it, on the daemon side, and what it
+ * validates is what gets written to `piploy.json` (ADR-0007).
+ */
+const registerInputSchema = {
+  Name: z.string(),
+  GitRepositoryUrl: z.string(),
+  DockerfilePath: z.string(),
+  PortMappings: z.array(z.string()).optional(),
+  Volumes: z.array(z.string()).optional(),
+  EnvironmentVariables: z.record(z.string(), z.string()).optional(),
+};
+
+function toolResult(response: DaemonResponse) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(response) }],
+    isError: !response.ok,
+  };
+}
+
+/**
+ * Registers the five commands that are safe to expose on the tailnet. The
+ * exclusion of `wipeall` and `self-update` is structural: they are simply
+ * never registered here, so there is no block list to keep in sync.
+ */
+function createMcpServer(dispatch: McpDispatch): McpServer {
+  const server = new McpServer({ name: "piploy", version: piployVersion });
+
+  server.registerTool(
+    "status",
+    {
+      description:
+        "Report each registered application's git commits, Docker image and container hashes, and whether it runs the latest version.",
+    },
+    async () => toolResult(await dispatch({ command: "status" })),
+  );
+
+  server.registerTool(
+    "poll",
+    {
+      description:
+        "Run one reconciliation pass now: fetch each application's repository, rebuild, and restart what is out of date.",
+    },
+    async () => toolResult(await dispatch({ command: "poll" })),
+  );
+
+  server.registerTool(
+    "register",
+    {
+      description:
+        "Register one application in piploy.json. The next poll picks it up; registering does not deploy it by itself.",
+      inputSchema: registerInputSchema,
+    },
+    async (application) =>
+      toolResult(await dispatch({ command: "register", application })),
+  );
+
+  server.registerTool(
+    "service-start",
+    {
+      description:
+        "Start the Piploy background daemon. Answering this call at all proves the daemon is already running.",
+    },
+    // The MCP server lives inside the daemon, so there is nothing to start and
+    // nothing to enqueue. The tool exists to answer the question truthfully.
+    () => ({
+      content: [
+        {
+          type: "text" as const,
+          text: "The Piploy daemon is already running.",
+        },
+      ],
+    }),
+  );
+
+  server.registerTool(
+    "service-stop",
+    {
+      description:
+        "Stop the Piploy background daemon. This also ends this MCP server, which only runs inside the daemon.",
+    },
+    async () => toolResult(await dispatch({ command: "stop" })),
+  );
+
+  return server;
+}
+
+async function handleRequest(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  dispatch: McpDispatch,
+): Promise<void> {
+  if ((request.url ?? "").split("?")[0] !== mcpPath) {
+    response.writeHead(404).end();
+    return;
+  }
+  // Stateless mode (no session id, no session store): a server and transport
+  // per request, because one McpServer assumes sole ownership of its
+  // transport. Statelessness is what makes creating them per request cheap.
+  const server = createMcpServer(dispatch);
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
+  });
+  response.once("close", () => {
+    void transport.close();
+    void server.close();
+  });
+  await server.connect(transport);
+  await transport.handleRequest(request, response);
+}
+
+/** Serves the MCP tools over Streamable HTTP on one explicit address. */
+export function startMcpServer(
+  options: McpServerOptions,
+): Promise<McpServerHandle> {
+  const server = http.createServer((request, response) => {
+    handleRequest(request, response, options.dispatch).catch(() => {
+      if (!response.headersSent) response.writeHead(500);
+      response.end();
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      resolve({
+        url: `http://${options.address}:${port}${mcpPath}`,
+        port,
+        stop: () =>
+          new Promise((resolveStop, rejectStop) => {
+            server.close((error) =>
+              error ? rejectStop(error) : resolveStop(),
+            );
+            // Idle keep-alive connections would hold close() open forever, and
+            // an in-flight one until it finishes. A stop asked for over MCP is
+            // itself in flight here, so it gets a bounded moment to flush.
+            server.closeIdleConnections();
+            setTimeout(
+              () => server.closeAllConnections(),
+              flushGraceMs,
+            ).unref();
+          }),
+      });
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(options.port, options.address);
+  });
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -5,6 +5,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { z } from "zod";
 
 import type { DaemonRequest, DaemonResponse } from "./daemon.js";
+import type { ApplicationSchema } from "./settings.js";
 import { piployVersion } from "./version.js";
 
 /** Fixed for v1. Making the port configurable is deliberately deferred. */
@@ -19,6 +20,8 @@ export interface McpServerOptions {
   address: string;
   port: number;
   dispatch: McpDispatch;
+  /** Reports a failure the caller cannot act on, such as a dropped request. */
+  onError(error: unknown): void;
 }
 
 export interface McpServerHandle {
@@ -28,9 +31,14 @@ export interface McpServerHandle {
 }
 
 /**
- * The register payload is passed through untransformed: `ApplicationSchema`
- * is the one authority that validates it, on the daemon side, and what it
- * validates is what gets written to `piploy.json` (ADR-0007).
+ * Describes the register payload for the calling client. `ApplicationSchema`
+ * is still the one authority that validates it, on the daemon side, and the
+ * payload reaches it untransformed, because what it validates is what gets
+ * written to `piploy.json` (ADR-0007). It cannot be reused here for the same
+ * reason: its own fields parse the written strings into richer values.
+ *
+ * The `satisfies` clause is the guard against the two drifting: a field added
+ * to `ApplicationSchema` fails to compile until it is described here too.
  */
 const registerInputSchema = {
   Name: z.string(),
@@ -39,7 +47,10 @@ const registerInputSchema = {
   PortMappings: z.array(z.string()).optional(),
   Volumes: z.array(z.string()).optional(),
   EnvironmentVariables: z.record(z.string(), z.string()).optional(),
-};
+} satisfies Record<
+  keyof Required<z.input<typeof ApplicationSchema>>,
+  z.ZodType
+>;
 
 function toolResult(response: DaemonResponse) {
   return {
@@ -78,7 +89,7 @@ function createMcpServer(dispatch: McpDispatch): McpServer {
     "register",
     {
       description:
-        "Register one application in piploy.json. The next poll picks it up; registering does not deploy it by itself.",
+        "Register one application in piploy.json. Registering does not start it; the next poll does.",
       inputSchema: registerInputSchema,
     },
     async (application) =>
@@ -145,10 +156,13 @@ export function startMcpServer(
   options: McpServerOptions,
 ): Promise<McpServerHandle> {
   const server = http.createServer((request, response) => {
-    handleRequest(request, response, options.dispatch).catch(() => {
-      if (!response.headersSent) response.writeHead(500);
-      response.end();
-    });
+    handleRequest(request, response, options.dispatch).catch(
+      (error: unknown) => {
+        options.onError(error);
+        if (!response.headersSent) response.writeHead(500);
+        response.end();
+      },
+    );
   });
 
   return new Promise((resolve, reject) => {
@@ -158,6 +172,10 @@ export function startMcpServer(
     };
     const onListening = () => {
       server.off("error", onError);
+      // An 'error' after listening, such as a client resetting a connection,
+      // is fatal to the process if nothing is listening for it. Losing the
+      // daemon to a tailnet client's mistake is the one outcome to avoid.
+      server.on("error", options.onError);
       const address = server.address();
       const port = typeof address === "object" && address ? address.port : 0;
       resolve({

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -441,9 +441,33 @@ describe("daemon", () => {
       return logger;
     }
 
+    /** A port nothing is listening on, so a refused connection is meaningful. */
+    async function reserveFreePort(): Promise<number> {
+      const probe = net.createServer();
+      await new Promise<void>((resolve) =>
+        probe.listen(0, "127.0.0.1", resolve),
+      );
+      const port = (probe.address() as net.AddressInfo).port;
+      await new Promise<void>((resolve) => probe.close(() => resolve()));
+      return port;
+    }
+
+    function isListening(port: number): Promise<boolean> {
+      return new Promise((resolve) => {
+        const client = net.createConnection(port, "127.0.0.1");
+        client.once("connect", () => {
+          client.destroy();
+          resolve(true);
+        });
+        client.once("error", () => resolve(false));
+      });
+    }
+
     async function startWithAddress(
       address: string | undefined,
       deps: DaemonDeps,
+      // Port 0 keeps the test off the fixed v1 port.
+      mcpPort = 0,
     ): Promise<{ daemon: Daemon; messages: string[] }> {
       const messages: string[] = [];
       const socketPath = path.join(
@@ -457,8 +481,7 @@ describe("daemon", () => {
           socketPath,
           pollIntervalMinutes: 60,
           deps,
-          // Port 0 keeps the test off the fixed v1 port.
-          mcpPort: 0,
+          mcpPort,
           getTailscaleAddress: () => address,
         },
       );
@@ -467,12 +490,18 @@ describe("daemon", () => {
     }
 
     it("keeps serving the socket when no Tailscale address is found", async () => {
-      const { daemon, messages } = await startWithAddress(undefined, {
-        poll: async () => {},
-        getStatus: async () => ({ applications: [] }),
-        attemptSelfUpdate: async () => "up-to-date",
-      });
+      const mcpPort = await reserveFreePort();
+      const { daemon, messages } = await startWithAddress(
+        undefined,
+        {
+          poll: async () => {},
+          getStatus: async () => ({ applications: [] }),
+          attemptSelfUpdate: async () => "up-to-date",
+        },
+        mcpPort,
+      );
 
+      await expect(isListening(mcpPort)).resolves.toBe(false);
       await expect(
         sendRequest(daemon.socketPath, { command: "status" }),
       ).resolves.toEqual({ ok: true, status: { applications: [] } });

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -3,6 +3,8 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -30,6 +32,10 @@ function createLogger(): Logger {
   };
   return logger;
 }
+
+// Tests must never bind a real network port, so no test discovers a Tailscale
+// address unless it is the one asserting on that branch.
+const noTailscale = { getTailscaleAddress: () => undefined };
 
 function sendRequest(
   socketPath: string,
@@ -66,6 +72,7 @@ describe("daemon", () => {
       queueCapacity,
       pollIntervalMinutes: 60,
       deps,
+      ...noTailscale,
     });
     daemons.push(daemon);
     return daemon;
@@ -226,6 +233,7 @@ describe("daemon", () => {
           },
           getStatus: async () => ({ applications: [] }),
         },
+        ...noTailscale,
       });
       daemons.push(daemon);
 
@@ -286,6 +294,7 @@ describe("daemon", () => {
         configPath,
         pollIntervalMinutes: 60,
         deps,
+        ...noTailscale,
       });
       daemons.push(daemon);
       return { daemon, configPath, liveSettings };
@@ -417,6 +426,86 @@ describe("daemon", () => {
       releasePoll!();
       await expect(register).resolves.toMatchObject({ ok: true });
       expect(events).toEqual(["poll", "register"]);
+    });
+  });
+
+  describe("mcp server", () => {
+    function createRecordingLogger(messages: string[]): Logger {
+      const logger: Logger = {
+        debug: () => {},
+        info: (message) => messages.push(`info ${message}`),
+        warn: (message) => messages.push(`warn ${message}`),
+        error: (message) => messages.push(`error ${message}`),
+        child: () => logger,
+      };
+      return logger;
+    }
+
+    async function startWithAddress(
+      address: string | undefined,
+      deps: DaemonDeps,
+    ): Promise<{ daemon: Daemon; messages: string[] }> {
+      const messages: string[] = [];
+      const socketPath = path.join(
+        await mkdtemp(path.join(os.tmpdir(), "piploy-")),
+        "piploy.sock",
+      );
+      const daemon = await startDaemon(
+        settings,
+        createRecordingLogger(messages),
+        {
+          socketPath,
+          pollIntervalMinutes: 60,
+          deps,
+          // Port 0 keeps the test off the fixed v1 port.
+          mcpPort: 0,
+          getTailscaleAddress: () => address,
+        },
+      );
+      daemons.push(daemon);
+      return { daemon, messages };
+    }
+
+    it("keeps serving the socket when no Tailscale address is found", async () => {
+      const { daemon, messages } = await startWithAddress(undefined, {
+        poll: async () => {},
+        getStatus: async () => ({ applications: [] }),
+        attemptSelfUpdate: async () => "up-to-date",
+      });
+
+      await expect(
+        sendRequest(daemon.socketPath, { command: "status" }),
+      ).resolves.toEqual({ ok: true, status: { applications: [] } });
+      expect(messages).toContain(
+        "warn No Tailscale address found. MCP server not started",
+      );
+      expect(
+        messages.some((message) => message.includes("MCP server listening")),
+      ).toBe(false);
+    });
+
+    it("runs MCP tool calls through the same queue as socket clients", async () => {
+      const events: string[] = [];
+      const { messages } = await startWithAddress("127.0.0.1", {
+        poll: async () => {
+          events.push("poll");
+        },
+        getStatus: async () => ({ applications: [] }),
+        attemptSelfUpdate: async () => "up-to-date",
+      });
+      await vi.waitFor(() => expect(events).toEqual(["poll"]));
+
+      const url = messages
+        .find((message) => message.startsWith("info MCP server listening"))
+        ?.split(" at ")[1];
+      expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/);
+
+      const client = new Client({ name: "test", version: "0" });
+      await client.connect(new StreamableHTTPClientTransport(new URL(url!)));
+      await client.callTool({ name: "poll" });
+      await client.close();
+
+      expect(events).toEqual(["poll", "poll"]);
     });
   });
 });

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -1,0 +1,134 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { DaemonRequest, DaemonResponse } from "../../src/daemon.js";
+import { startMcpServer, type McpServerHandle } from "../../src/mcp.js";
+
+interface Harness {
+  client: Client;
+  requests: DaemonRequest[];
+}
+
+// callTool's result type is a union with the legacy compatibility shape, so
+// the text content is narrowed here rather than at every call site.
+function textOf(result: unknown): string {
+  const { content } = result as { content?: { text: string }[] };
+  return (content ?? []).map((part) => part.text).join("");
+}
+
+describe("mcp server", () => {
+  const servers: McpServerHandle[] = [];
+  const clients: Client[] = [];
+
+  afterEach(async () => {
+    await Promise.all(clients.splice(0).map((client) => client.close()));
+    await Promise.all(servers.splice(0).map((server) => server.stop()));
+  });
+
+  async function start(
+    respond: (request: DaemonRequest) => DaemonResponse = () => ({ ok: true }),
+  ): Promise<Harness> {
+    const requests: DaemonRequest[] = [];
+    // CI has no Tailscale interface, so the address is a plain parameter and
+    // the port is left to the operating system.
+    const server = await startMcpServer({
+      address: "127.0.0.1",
+      port: 0,
+      dispatch: async (request) => {
+        requests.push(request);
+        return respond(request);
+      },
+    });
+    servers.push(server);
+
+    const client = new Client({ name: "test", version: "0" });
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL(server.url)),
+    );
+    clients.push(client);
+    return { client, requests };
+  }
+
+  it("exposes exactly the five safe commands as tools", async () => {
+    const { client } = await start();
+
+    const { tools } = await client.listTools();
+
+    expect(tools.map((tool) => tool.name).sort()).toEqual([
+      "poll",
+      "register",
+      "service-start",
+      "service-stop",
+      "status",
+    ]);
+  });
+
+  it("routes status through the daemon dispatcher", async () => {
+    const status = { applications: [] };
+    const { client, requests } = await start(() => ({ ok: true, status }));
+
+    const result = await client.callTool({ name: "status" });
+
+    expect(requests).toEqual([{ command: "status" }]);
+    expect(JSON.parse(textOf(result))).toEqual({ ok: true, status });
+  });
+
+  it("routes poll through the daemon dispatcher", async () => {
+    const { client, requests } = await start();
+
+    const result = await client.callTool({ name: "poll" });
+
+    expect(requests).toEqual([{ command: "poll" }]);
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("routes service-stop to the daemon stop command", async () => {
+    const { client, requests } = await start();
+
+    const result = await client.callTool({ name: "service-stop" });
+
+    expect(requests).toEqual([{ command: "stop" }]);
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("passes register arguments through untransformed", async () => {
+    const application = {
+      Name: "app",
+      GitRepositoryUrl: "https://example.com/app.git",
+      DockerfilePath: "Dockerfile",
+      PortMappings: ["8080:80"],
+    };
+    const { client, requests } = await start((request) =>
+      request.command === "register"
+        ? { ok: true, application: request.application as never }
+        : { ok: true },
+    );
+
+    const result = await client.callTool({
+      name: "register",
+      arguments: application,
+    });
+
+    expect(requests).toEqual([{ command: "register", application }]);
+    expect(JSON.parse(textOf(result))).toEqual({ ok: true, application });
+  });
+
+  it("answers service-start without touching the daemon queue", async () => {
+    const { client, requests } = await start();
+
+    const result = await client.callTool({ name: "service-start" });
+
+    expect(requests).toEqual([]);
+    expect(textOf(result)).toContain("already running");
+  });
+
+  it("reports a rejected request as a tool error", async () => {
+    const { client } = await start(() => ({ ok: false, reason: "busy" }));
+
+    const result = await client.callTool({ name: "poll" });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("busy");
+  });
+});

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -39,6 +39,9 @@ describe("mcp server", () => {
         requests.push(request);
         return respond(request);
       },
+      onError: (error) => {
+        throw error;
+      },
     });
     servers.push(server);
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -42,7 +42,12 @@ export default defineConfig({
   clean: true,
   // Piploy ships only this bundle. Keep every runtime dependency in it rather
   // than relying on a node_modules directory beside the deployed artifact.
-  noExternal: [/^(commander|dockerode|isomorphic-git|pino|zod)(\/.*)?$/],
+  noExternal: [
+    /^(commander|dockerode|isomorphic-git|pino|zod)(\/.*)?$/,
+    // The MCP SDK reaches ajv through its JSON Schema validation, and ajv
+    // requires its runtime helpers by subpath.
+    /^(@modelcontextprotocol\/sdk|ajv|ajv-formats)(\/.*)?$/,
+  ],
   esbuildPlugins: [
     {
       name: "stub-unreachable-docker-ssh-transport",


### PR DESCRIPTION
## Summary

- Add a stateless Streamable HTTP MCP server on the daemon's Tailscale address.
- Expose status, poll, register, service-start, and service-stop tools through `/mcp`.
- Remove the CLI `register` command and route MCP requests through the daemon queue.
- Gracefully disable MCP when Tailscale is unavailable or binding fails.
- Document the MCP endpoint, security model, and exposed tools.

## Testing

- Added unit coverage for MCP server behavior and daemon integration.
- Updated daemon tests to exercise MCP lifecycle and tool dispatch.
- Verified the bundled release contains only allowed external module references.