### PR TITLE
Expose registered Application port mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ reach it. Another user gets the offline fallback described under `status`.
 
 | Command         | What it does                                                                                                                                       |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `status`        | Prints the Piploy version, whether the background service is reachable, and per-application Git and Docker state.                                  |
+| `status`        | Prints the Piploy version, whether the background service is reachable, and per-application configured host-to-container port mappings, Git, and Docker state. |
 | `poll`          | Runs one reconciliation now instead of waiting for the poll timer.                                                                                 |
 | `service-start` | Runs the daemon in the foreground. This is what systemd invokes; do not run it by hand while the service is up.                                    |
 | `service-stop`  | Asks the running daemon to shut down.                                                                                                              |

--- a/docs/agents/registering-an-application.md
+++ b/docs/agents/registering-an-application.md
@@ -11,9 +11,17 @@ container. Do not use this workflow for a group of containers.
 ## Read-only first
 
 Start with the MCP `status` tool. It is read-only: use it to see the currently
-registered Applications and their Git and Docker state. Do not infer that a
-missing health-check result or logs are available; this MCP does not promise
-either.
+registered Applications, their configured host-to-container `portMappings`,
+and their Git and Docker state. `portMappings` is always an array: an empty
+array means that Application has no configured host ports. Each entry has a
+`hostPort` and `containerPort`, corresponding to the `"hostPort:containerPort"`
+form in an Application payload.
+
+Use those configured host ports to avoid a conflict with another Piploy
+Application when proposing `PortMappings`. This is not a host-wide port scan:
+a port absent from `status` can still be bound by a non-Piploy process, so do
+not claim it is globally available. Do not infer that a missing health-check
+result or logs are available; this MCP does not promise either.
 
 ## Derive the payload from the repository
 
@@ -106,3 +114,13 @@ status → approval → register → approval → poll → status
 `service-stop` as part of this guide. Do not promise log access or
 Application-level health checks. If the available MCP results are insufficient,
 ask for explicit human permission before falling back to SSH.
+
+## Cloudflare Tunnel mapping
+
+Cloudflare Tunnel configuration is currently manual. After the Application is
+running, use the chosen **host** side of its `PortMappings` entry as the tunnel
+service port — not the container port. For example, a mapping of
+`"8080:80"` means Piploy publishes container port `80` on host port `8080`,
+so the Cloudflare Tunnel public-hostname service must point to
+`http://localhost:8080` (or the equivalent local-host service address for the
+tunnel process). State this mapping to the human who maintains the tunnel.

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -87,6 +87,9 @@ function printStatus(status: DaemonStatus, daemonReachable: boolean): void {
     console.log(
       `  Running container hash: ${application.docker.runningContainerHash ?? "none"}`,
     );
+    console.log(
+      `  Port mappings: ${application.portMappings.length === 0 ? "none" : application.portMappings.map(({ hostPort, containerPort }) => `${hostPort}:${containerPort}`).join(", ")}`,
+    );
   }
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -16,6 +16,7 @@ import {
   resolveConfigPath,
   type Application,
   type PiploySettings,
+  type PortMapping,
   type RegisterApplicationFailure,
 } from "./settings.js";
 import { isRunningLatestVersion } from "./status.js";
@@ -42,6 +43,8 @@ export type DaemonResponse =
 
 export interface ApplicationDaemonStatus {
   application: string;
+  /** Configured host-to-container mappings; empty means this Application exposes none. */
+  portMappings: PortMapping[];
   git: GitCommitStatus | null;
   docker: DockerStatus;
   isRunningLatestVersion: boolean;
@@ -122,6 +125,9 @@ export function createDaemonDeps(
     ]);
     return {
       application: application.Name,
+      // `PortMappings` is optional in configuration, but status is an agent
+      // API: make the no-mappings case unambiguous rather than omitting it.
+      portMappings: application.PortMappings ?? [],
       git,
       docker: dockerStatus,
       isRunningLatestVersion: isRunningLatestVersion(git, dockerStatus),

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -71,7 +71,7 @@ function createMcpServer(dispatch: McpDispatch): McpServer {
     "status",
     {
       description:
-        "Report each registered application's git commits, Docker image and container hashes, and whether it runs the latest version.",
+        "Report each registered application's configured host-to-container port mappings (an empty array means none), git commits, Docker image and container hashes, and whether it runs the latest version.",
     },
     async () => toolResult(await dispatch({ command: "status" })),
   );

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -22,6 +22,7 @@ const daemonStatus: DaemonStatus = {
   applications: [
     {
       application: "app",
+      portMappings: [{ hostPort: 8080, containerPort: 80 }],
       git: null,
       docker: {},
       isRunningLatestVersion: false,
@@ -63,6 +64,22 @@ describe("commands", () => {
     expect(deps.requestDaemon).toHaveBeenCalledWith({ command: "status" });
     expect(deps.computeStatusInline).not.toHaveBeenCalled();
     expect(output).toHaveBeenCalledWith("Background service: running");
+    expect(output).toHaveBeenCalledWith("  Port mappings: 8080:80");
+  });
+
+  it("prints an explicit no-port-mappings state", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => ({
+      ok: true as const,
+      status: {
+        applications: [{ ...daemonStatus.applications[0]!, portMappings: [] }],
+      },
+    }));
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await status(deps);
+
+    expect(output).toHaveBeenCalledWith("  Port mappings: none");
   });
 
   it("computes status inline only when no daemon is reachable", async () => {

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -85,6 +85,7 @@ describe("daemon", () => {
         applications: [
           {
             application: "app",
+            portMappings: [{ hostPort: 8080, containerPort: 80 }],
             git: null,
             docker: {},
             isRunningLatestVersion: false,
@@ -103,6 +104,7 @@ describe("daemon", () => {
         applications: [
           {
             application: "app",
+            portMappings: [{ hostPort: 8080, containerPort: 80 }],
             git: null,
             docker: {},
             isRunningLatestVersion: false,

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -67,6 +67,16 @@ describe("mcp server", () => {
     ]);
   });
 
+  it("describes status port mappings", async () => {
+    const { client } = await start();
+
+    const { tools } = await client.listTools();
+
+    expect(tools.find((tool) => tool.name === "status")?.description).toContain(
+      "host-to-container port mappings",
+    );
+  });
+
   it("routes status through the daemon dispatcher", async () => {
     const status = { applications: [] };
     const { client, requests } = await start(() => ({ ok: true, status }));


### PR DESCRIPTION
## Summary
- include each registered Application configured host-to-container port mappings in the shared daemon-backed status response, using an explicit empty array when none are configured
- render the same mappings in CLI status and describe them in the MCP status tool
- extend the agent deployment guide with Piploy-only port-conflict guidance and manual Cloudflare Tunnel mapping instructions

## Verification
- corepack pnpm lint
- corepack pnpm test (124 passed)

Closes #98