### PR TITLE
Cap container log size

### DIFF
--- a/src/docker.ts
+++ b/src/docker.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import Dockerode from "dockerode";
 
 import {
+  containerLogConfig,
   getContainerConfigHash,
   getDockerfilePathFromSetting,
   planContainer,
@@ -313,6 +314,7 @@ export function createDockerService(
         PortBindings: portBindings,
         Binds: binds,
         AutoRemove: true,
+        LogConfig: containerLogConfig,
       },
       Labels: { [containerConfigLabelName]: configHash },
     });

--- a/src/dockerPlan.ts
+++ b/src/dockerPlan.ts
@@ -41,6 +41,17 @@ export interface DockerfileImageReferenceViolation {
 const invalidDockerfilePathMessage =
   "Invalid DockerfilePath. It must point to a dockerfile relative to the repository root. Examples: 'Dockerfile' or 'SubDirectory/Dockerfile' or Dockerfile.custom'";
 
+/**
+ * Bounds the container log files so a long running application cannot fill the
+ * host disk. Docker rotates and drops the oldest file itself, so nothing in
+ * Piploy has to sweep them. This is part of the container config hash, so
+ * containers created before the cap existed are recreated on the next poll.
+ */
+export const containerLogConfig = {
+  Type: "json-file",
+  Config: { "max-size": "10m", "max-file": "3" },
+} as const;
+
 export function planImage(existingImage?: DockerImage): ImagePlan {
   return existingImage
     ? { action: "reuse", imageId: existingImage.id }
@@ -89,6 +100,7 @@ export function getContainerConfigHash(
         left.hostPort - right.hostPort ||
         left.containerPort - right.containerPort,
     ),
+    logConfig: containerLogConfig,
   };
   return createHash("sha256").update(JSON.stringify(normalized)).digest("hex");
 }

--- a/test/integration/docker.test.ts
+++ b/test/integration/docker.test.ts
@@ -82,6 +82,10 @@ describe("docker adapter", () => {
     expect(inspect.HostConfig.Binds).toContain(
       `${path.join(temporaryDirectory, "data", application.Name, "sqlite")}:/app/data`,
     );
+    expect(inspect.HostConfig.LogConfig).toEqual({
+      Type: "json-file",
+      Config: { "max-size": "10m", "max-file": "3" },
+    });
     expect(inspect.Config.Labels?.piploy_configHash).toBe(
       getContainerConfigHash({
         environmentVariables: ["DATABASE_PATH=/app/data/app.db"],


### PR DESCRIPTION
Closes #103.

Containers were created with no `LogConfig`, so Docker used the `json-file` driver with no size limit. A healthy long-running application grows its log file until the Pi's disk fills. `AutoRemove: true` only helps containers that exit.

## Change

- `containerLogConfig` in `src/dockerPlan.ts`: `json-file`, `max-size: 10m`, `max-file: 3` — ~30 MB per application, rotated by Docker itself.
- Applied to `HostConfig` in `ensureContainerRunning`.
- Included in `getContainerConfigHash`, so containers created before the cap are recreated on the next poll rather than waiting for the next deploy.

The values are hardcoded, not configurable per Application or in `PiploySettings` — the issue asked that the default stay bounded either way, and nothing so far needs to tune it.

## Verification

- `pnpm lint` clean.
- `pnpm test` — 126 unit tests pass.
- `test/integration/docker.test.ts` asserts the cap on a real container and passes. (`test/integration/pnpmPolicy.test.ts` fails in my sandbox for lack of registry access; unrelated to this change.)
- On the Pi, after the daemon updates: `docker inspect piploy_<name> --format '{{json .HostConfig.LogConfig}}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)