### PR TITLE
Report per-application poll failures

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -11,6 +11,7 @@ import {
 } from "./daemon.js";
 import { createDockerService } from "./docker.js";
 import type { Logger } from "./logger.js";
+import type { PollApplicationResult } from "./orchestrator.js";
 import type { PiploySettings } from "./settings.js";
 import {
   getApplicationDataDirectory,
@@ -25,7 +26,7 @@ export type RegisterResult = DaemonResponse | undefined;
 export interface CommandDeps {
   requestDaemon(request: DaemonRequest): Promise<DaemonResponse | undefined>;
   computeStatusInline(): Promise<DaemonStatus>;
-  pollInline(): Promise<void>;
+  pollInline(): Promise<PollApplicationResult[]>;
   register(application: unknown): Promise<RegisterResult>;
   wipeAll(): Promise<void>;
   getPreservedApplicationDataDirectories(): string[];
@@ -121,15 +122,32 @@ export async function status(deps: CommandDeps): Promise<void> {
 export async function poll(deps: CommandDeps): Promise<void> {
   const response = await deps.requestDaemon({ command: "poll" });
   if (response === undefined) {
-    await deps.pollInline();
-    console.log("Poll completed.");
+    printPollResult(await deps.pollInline());
     return;
   }
   if (!response.ok) {
     commandFailed(`Daemon poll request failed: ${response.reason}`);
     return;
   }
+  if ("applications" in response) {
+    printPollResult(response.applications);
+    return;
+  }
   console.log("Poll completed.");
+}
+
+function printPollResult(applications: PollApplicationResult[]): void {
+  const failures = applications.filter((application) => !application.ok);
+  if (failures.length === 0) {
+    console.log("Poll completed.");
+    return;
+  }
+  console.log("Poll completed with failures:");
+  for (const failure of failures) {
+    console.log(
+      `  ${failure.application} (${failure.stage}): ${failure.message}`,
+    );
+  }
 }
 
 /** The `register` flags commander collects, before they become an Application. */

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -7,7 +7,10 @@ import { getCommitStatus, type GitCommitStatus } from "./git.js";
 import type { Logger } from "./logger.js";
 import { mcpPort, startMcpServer, type McpServerHandle } from "./mcp.js";
 import { getTailscaleAddress } from "./mcpTailscale.js";
-import { createOrchestrator } from "./orchestrator.js";
+import {
+  createOrchestrator,
+  type PollApplicationResult,
+} from "./orchestrator.js";
 import { decideQueueAdmission, type QueueSource } from "./queuePolicy.js";
 import { attemptSelfUpdate, type SelfUpdateResult } from "./selfUpdate.js";
 import {
@@ -33,6 +36,7 @@ export type DaemonRequest =
 
 export type DaemonResponse =
   | { ok: true; status: DaemonStatus }
+  | { ok: true; applications: PollApplicationResult[] }
   | { ok: true; application: Application }
   | { ok: true }
   | {
@@ -55,7 +59,7 @@ export interface DaemonStatus {
 }
 
 export interface DaemonDeps {
-  poll(): Promise<void>;
+  poll(): Promise<PollApplicationResult[]>;
   getStatus(): Promise<DaemonStatus>;
   attemptSelfUpdate(): Promise<SelfUpdateResult>;
 }
@@ -327,11 +331,10 @@ export async function startDaemon(
         case "poll":
           pollInProgress = true;
           try {
-            await deps.poll();
+            return { ok: true, applications: await deps.poll() };
           } finally {
             pollInProgress = false;
           }
-          return { ok: true };
       }
     } catch (error) {
       logError(logger, error);

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,4 +1,4 @@
-import { createDockerService } from "./docker.js";
+import { createDockerService, PortAlreadyInUseError } from "./docker.js";
 import { ensureLocalRepository, getLatestCommit } from "./git.js";
 import type { Logger } from "./logger.js";
 import type { Application, PiploySettings } from "./settings.js";
@@ -18,11 +18,27 @@ export interface OrchestratorDeps {
 }
 
 export interface Orchestrator {
-  poll(): Promise<void>;
+  poll(): Promise<PollApplicationResult[]>;
+}
+
+export type PollApplicationResult =
+  | { application: string; ok: true }
+  | {
+      application: string;
+      ok: false;
+      stage: PollFailureStage;
+      message: string;
+      code?: "portAlreadyInUse";
+    };
+
+export type PollFailureStage = "fetch" | "build" | "start";
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function logError(logger: Logger, error: unknown): void {
-  logger.error(error instanceof Error ? error.message : String(error));
+  logger.error(errorMessage(error));
 }
 
 /** Wires the one real git and Docker adapter into the orchestrator's narrow seam. */
@@ -51,9 +67,10 @@ export function createOrchestrator(
   logger: Logger,
   deps: OrchestratorDeps = createOrchestratorDeps(settings, logger),
 ): Orchestrator {
-  async function poll(): Promise<void> {
+  async function poll(): Promise<PollApplicationResult[]> {
     const pollLogger = logger.child({ operation: "poll" });
     pollLogger.info("Polling applications");
+    const results: PollApplicationResult[] = [];
 
     try {
       for (const application of settings.Applications) {
@@ -62,19 +79,34 @@ export function createOrchestrator(
         });
         applicationLogger.info(`Polling application: ${application.Name}`);
 
+        let stage: PollFailureStage = "fetch";
         try {
           await deps.ensureLocalRepository(application);
           const commit = await deps.getLatestCommit(application);
+          stage = "build";
           await deps.ensureImageExists(application, commit);
+          stage = "start";
           await deps.ensureContainerRunning(application, commit);
+          results.push({ application: application.Name, ok: true });
         } catch (error) {
           logError(applicationLogger, error);
+          results.push({
+            application: application.Name,
+            ok: false,
+            stage,
+            message: errorMessage(error),
+            ...(error instanceof PortAlreadyInUseError
+              ? { code: error.code }
+              : {}),
+          });
         }
       }
     } finally {
       pollLogger.info("Cleaning up unused images");
       await deps.cleanupInactive(settings.Applications);
     }
+
+    return results;
   }
 
   return { poll };

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -11,7 +11,7 @@ import {
   wipeAll,
   type CommandDeps,
 } from "../../src/commands.js";
-import type { DaemonStatus } from "../../src/daemon.js";
+import type { DaemonResponse, DaemonStatus } from "../../src/daemon.js";
 
 const application = {
   Name: "app",
@@ -35,7 +35,7 @@ function createDeps(): CommandDeps {
   return {
     requestDaemon: vi.fn(),
     computeStatusInline: vi.fn(async () => daemonStatus),
-    pollInline: vi.fn(),
+    pollInline: vi.fn(async () => []),
     register: vi.fn(),
     wipeAll: vi.fn(),
     getPreservedApplicationDataDirectories: vi.fn(() => []),
@@ -130,13 +130,26 @@ describe("commands", () => {
 
   it("delegates poll to a reachable daemon", async () => {
     const deps = createDeps();
-    deps.requestDaemon = vi.fn(async () => ({ ok: true as const }));
-    vi.spyOn(console, "log").mockImplementation(() => {});
+    const response: DaemonResponse = {
+      ok: true,
+      applications: [
+        {
+          application: "app",
+          ok: false,
+          stage: "build",
+          message: "Dockerfile is invalid",
+        },
+      ],
+    };
+    deps.requestDaemon = vi.fn(async () => response);
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
 
     await poll(deps);
 
     expect(deps.requestDaemon).toHaveBeenCalledWith({ command: "poll" });
     expect(deps.pollInline).not.toHaveBeenCalled();
+    expect(output).toHaveBeenCalledWith("Poll completed with failures:");
+    expect(output).toHaveBeenCalledWith("  app (build): Dockerfile is invalid");
   });
 
   it("runs poll inline only when no daemon is reachable", async () => {

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -80,7 +80,7 @@ describe("daemon", () => {
 
   it("serves daemon-computed status over a private socket", async () => {
     const daemon = await start({
-      poll: async () => {},
+      poll: async () => [],
       getStatus: async () => ({
         applications: [
           {
@@ -114,6 +114,26 @@ describe("daemon", () => {
     });
   });
 
+  it("returns per-application poll results over the private socket", async () => {
+    const applications = [
+      {
+        application: "app",
+        ok: false as const,
+        stage: "build" as const,
+        message: "build failed",
+      },
+    ];
+    const daemon = await start({
+      poll: async () => applications,
+      getStatus: async () => ({ applications: [] }),
+      attemptSelfUpdate: async () => "up-to-date",
+    });
+
+    await expect(
+      requestDaemon({ command: "poll" }, daemon.socketPath),
+    ).resolves.toEqual({ ok: true, applications });
+  });
+
   it("runs poll requests serially and rejects a client when its queue is full", async () => {
     let releaseFirstPoll: (() => void) | undefined;
     const firstPoll = new Promise<void>((resolve) => {
@@ -125,6 +145,7 @@ describe("daemon", () => {
         poll: async () => {
           polls += 1;
           if (polls === 2) await firstPoll;
+          return [];
         },
         getStatus: async () => ({ applications: [] }),
         attemptSelfUpdate: async () => "up-to-date",
@@ -144,8 +165,8 @@ describe("daemon", () => {
     });
 
     releaseFirstPoll!();
-    await expect(first).resolves.toEqual({ ok: true });
-    await expect(second).resolves.toEqual({ ok: true });
+    await expect(first).resolves.toEqual({ ok: true, applications: [] });
+    await expect(second).resolves.toEqual({ ok: true, applications: [] });
     expect(polls).toBe(3);
   });
 
@@ -157,6 +178,7 @@ describe("daemon", () => {
     const daemon = await start({
       poll: async () => {
         await pollGate;
+        return [];
       },
       getStatus: async () => ({ applications: [] }),
       attemptSelfUpdate: async () => "up-to-date",
@@ -170,12 +192,12 @@ describe("daemon", () => {
     ).resolves.toEqual({ ok: false, reason: "poll-in-progress" });
 
     releasePoll!();
-    await expect(poll).resolves.toEqual({ ok: true });
+    await expect(poll).resolves.toEqual({ ok: true, applications: [] });
   });
 
   it("rejects malformed requests", async () => {
     const daemon = await start({
-      poll: async () => {},
+      poll: async () => [],
       getStatus: async () => ({ applications: [] }),
       attemptSelfUpdate: async () => "up-to-date",
     });
@@ -193,7 +215,7 @@ describe("daemon", () => {
       return undefined as never;
     }) as typeof process.exit);
     const daemon = await start({
-      poll: async () => {},
+      poll: async () => [],
       getStatus: async () => ({ applications: [] }),
       attemptSelfUpdate: async () => "up-to-date",
     });
@@ -235,6 +257,7 @@ describe("daemon", () => {
           },
           poll: async () => {
             events.push("poll");
+            return [];
           },
           getStatus: async () => ({ applications: [] }),
         },
@@ -265,6 +288,7 @@ describe("daemon", () => {
       },
       poll: async () => {
         events.push("poll");
+        return [];
       },
       getStatus: async () => ({ applications: [] }),
     });
@@ -313,7 +337,7 @@ describe("daemon", () => {
 
     function idleDeps(): DaemonDeps {
       return {
-        poll: async () => {},
+        poll: async () => [],
         getStatus: async () => ({ applications: [] }),
         attemptSelfUpdate: async () => "up-to-date",
       };
@@ -393,6 +417,7 @@ describe("daemon", () => {
         ...idleDeps(),
         poll: async () => {
           polls += 1;
+          return [];
         },
       });
       // The daemon polls once at startup; register must not add another.
@@ -420,6 +445,7 @@ describe("daemon", () => {
         poll: async () => {
           await pollGate;
           events.push("poll");
+          return [];
         },
       });
       await new Promise<void>((resolve) => setImmediate(resolve));
@@ -505,7 +531,7 @@ describe("daemon", () => {
       const { daemon, messages } = await startWithAddress(
         undefined,
         {
-          poll: async () => {},
+          poll: async () => [],
           getStatus: async () => ({ applications: [] }),
           attemptSelfUpdate: async () => "up-to-date",
         },
@@ -529,6 +555,7 @@ describe("daemon", () => {
       const { messages } = await startWithAddress("127.0.0.1", {
         poll: async () => {
           events.push("poll");
+          return [];
         },
         getStatus: async () => ({ applications: [] }),
         attemptSelfUpdate: async () => "up-to-date",

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -88,12 +88,25 @@ describe("mcp server", () => {
   });
 
   it("routes poll through the daemon dispatcher", async () => {
-    const { client, requests } = await start();
+    const applications = [
+      {
+        application: "app",
+        ok: false as const,
+        stage: "start" as const,
+        code: "portAlreadyInUse" as const,
+        message: "Port 8080 is already in use",
+      },
+    ];
+    const { client, requests } = await start(() => ({
+      ok: true,
+      applications,
+    }));
 
     const result = await client.callTool({ name: "poll" });
 
     expect(requests).toEqual([{ command: "poll" }]);
     expect(result.isError).toBeFalsy();
+    expect(JSON.parse(textOf(result))).toEqual({ ok: true, applications });
   });
 
   it("routes service-stop to the daemon stop command", async () => {

--- a/test/unit/orchestrator.test.ts
+++ b/test/unit/orchestrator.test.ts
@@ -4,6 +4,7 @@ import {
   createOrchestrator,
   type OrchestratorDeps,
 } from "../../src/orchestrator.js";
+import { PortAlreadyInUseError } from "../../src/docker.js";
 import type { Logger } from "../../src/logger.js";
 import type { Application, PiploySettings } from "../../src/settings.js";
 
@@ -95,7 +96,7 @@ describe("orchestrator", () => {
       if (application.Name === "first") throw new Error("build failed");
     });
 
-    await createOrchestrator(settings, logger, deps).poll();
+    const results = await createOrchestrator(settings, logger, deps).poll();
 
     expect(deps.ensureContainerRunning).toHaveBeenCalledTimes(1);
     expect(deps.ensureContainerRunning).toHaveBeenCalledWith(applications[1], {
@@ -103,5 +104,69 @@ describe("orchestrator", () => {
     });
     expect(deps.cleanupInactive).toHaveBeenCalledWith(applications);
     expect(errors).toEqual(["build failed"]);
+    expect(results).toEqual([
+      {
+        application: "first",
+        ok: false,
+        stage: "build",
+        message: "build failed",
+      },
+      { application: "second", ok: true },
+    ]);
+  });
+
+  it("identifies a repository failure as fetch", async () => {
+    const deps = createDeps();
+    deps.ensureLocalRepository = vi.fn(async () => {
+      throw new Error("clone failed");
+    });
+
+    const results = await createOrchestrator(
+      settings,
+      createLogger(),
+      deps,
+    ).poll();
+
+    expect(results).toEqual([
+      {
+        application: "first",
+        ok: false,
+        stage: "fetch",
+        message: "clone failed",
+      },
+      {
+        application: "second",
+        ok: false,
+        stage: "fetch",
+        message: "clone failed",
+      },
+    ]);
+  });
+
+  it("surfaces a port conflict as a typed start failure", async () => {
+    const deps = createDeps();
+    deps.ensureContainerRunning = vi.fn(async (application) => {
+      if (application.Name === "first") {
+        throw new PortAlreadyInUseError([8080]);
+      }
+    });
+
+    const results = await createOrchestrator(
+      settings,
+      createLogger(),
+      deps,
+    ).poll();
+
+    expect(results).toEqual([
+      {
+        application: "first",
+        ok: false,
+        stage: "start",
+        code: "portAlreadyInUse",
+        message:
+          "At least one of these ports are already in use by the host: 8080",
+      },
+      { application: "second", ok: true },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Poll now returns a machine-readable result for every Application. Failures identify the fetch, build, or start stage and include the error message; port conflicts also retain their typed `portAlreadyInUse` code.

The daemon carries those results through its successful poll response, so the existing tailnet MCP tool exposes them directly. The CLI now prints individual failures instead of only saying `Poll completed.`

## Why

Individual Application failures were previously logged only on the Pi while a poll response reported success, leaving remote callers unable to distinguish clone, build, or start failures.

## Validation

- `pnpm lint`
- `pnpm test` — 129 tests passed
- Standards and spec review: no actionable findings

Closes #104