### PR TITLE
Let Docker maintain declared containers

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,7 +22,8 @@ _Avoid_: Add, install, onboard, provision, deploy
 **Poll**:
 One pass in which Piploy brings every Application's repository, image, and
 container back in line with the configuration. Polling is Piploy's only
-trigger; nothing pushes work to it.
+trigger for changing declared Application state; Docker may maintain that
+declared container between Polls. Nothing pushes work to Piploy.
 _Avoid_: Sync, deploy, tick, reconcile loop
 
 **Application data**:

--- a/docs/adr/0009-docker-maintains-declared-application-containers.md
+++ b/docs/adr/0009-docker-maintains-declared-application-containers.md
@@ -1,0 +1,36 @@
+# Docker maintains declared Application containers
+
+## Decision
+
+Piploy creates each Application container with Docker's `unless-stopped`
+restart policy and without `AutoRemove`. A Poll remains the only operation
+that changes the declared state: it selects an Application's repository
+commit and runtime configuration, then creates, replaces, or starts its one
+container. Docker may restart that already-declared container after an
+unexpected exit or host reboot.
+
+The restart policy is part of the container configuration hash. Existing
+containers therefore differ from the new declared configuration and are
+recreated on their next Poll.
+
+While Docker reports a matching container as `restarting`, Piploy reuses it.
+It must not repeatedly remove and recreate a crash-looping container. A
+matching `exited` container remains a `start` action: a manual Docker stop
+does not change Piploy's configuration, so the next Poll resumes the declared
+Application.
+
+`unless-stopped` is used rather than `always`. It preserves Docker's explicit
+manual-stop behaviour across a Docker daemon restart, and Piploy's cleanup
+path still explicitly stops and removes containers for Applications no longer
+declared.
+
+## Consequences
+
+- Recovery from an Application crash or Pi reboot no longer waits for the next
+  Poll, provided Docker itself is running.
+- A stopped container and its bounded Docker logs remain available for
+  diagnosis. Log bounds are set separately by the container log configuration.
+- Docker is an enforcer of Piploy's declared state, not a second source of
+  configuration or an inbound trigger to Piploy.
+- Container logs and detailed restart/exit reporting remain separate
+  observability work.

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -5,6 +5,7 @@ import Dockerode from "dockerode";
 
 import {
   containerLogConfig,
+  containerRestartPolicy,
   getContainerConfigHash,
   getDockerfilePathFromSetting,
   planContainer,
@@ -313,8 +314,8 @@ export function createDockerService(
       HostConfig: {
         PortBindings: portBindings,
         Binds: binds,
-        AutoRemove: true,
         LogConfig: containerLogConfig,
+        RestartPolicy: containerRestartPolicy,
       },
       Labels: { [containerConfigLabelName]: configHash },
     });

--- a/src/dockerPlan.ts
+++ b/src/dockerPlan.ts
@@ -52,6 +52,13 @@ export const containerLogConfig = {
   Config: { "max-size": "10m", "max-file": "3" },
 } as const;
 
+/**
+ * Docker maintains a declared Application container between Polls. A manual
+ * stop remains stopped across a Docker daemon restart, while an unexpected
+ * exit is restarted by Docker.
+ */
+export const containerRestartPolicy = { Name: "unless-stopped" } as const;
+
 export function planImage(existingImage?: DockerImage): ImagePlan {
   return existingImage
     ? { action: "reuse", imageId: existingImage.id }
@@ -71,7 +78,10 @@ export function planContainer(
     existingContainer.gitTipCommit === gitTipCommit &&
     existingContainer.configHash === configHash
   ) {
-    if (existingContainer.state === "running") {
+    if (
+      existingContainer.state === "running" ||
+      existingContainer.state === "restarting"
+    ) {
       return { action: "reuse", containerId: existingContainer.id };
     }
     if (existingContainer.state === "exited") {
@@ -101,6 +111,7 @@ export function getContainerConfigHash(
         left.containerPort - right.containerPort,
     ),
     logConfig: containerLogConfig,
+    restartPolicy: containerRestartPolicy,
   };
   return createHash("sha256").update(JSON.stringify(normalized)).digest("hex");
 }

--- a/test/integration/docker.test.ts
+++ b/test/integration/docker.test.ts
@@ -86,6 +86,10 @@ describe("docker adapter", () => {
       Type: "json-file",
       Config: { "max-size": "10m", "max-file": "3" },
     });
+    expect(inspect.HostConfig.AutoRemove).toBe(false);
+    expect(inspect.HostConfig.RestartPolicy).toMatchObject({
+      Name: "unless-stopped",
+    });
     expect(inspect.Config.Labels?.piploy_configHash).toBe(
       getContainerConfigHash({
         environmentVariables: ["DATABASE_PATH=/app/data/app.db"],

--- a/test/unit/dockerPlan.test.ts
+++ b/test/unit/dockerPlan.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -49,6 +51,21 @@ describe("planContainer", () => {
         {
           id: "container",
           state: "running",
+          gitTipCommit: "commit",
+          configHash,
+        },
+        "commit",
+        configHash,
+      ),
+    ).toEqual({ action: "reuse", containerId: "container" });
+  });
+
+  it("leaves a matching container to Docker while it is restarting", () => {
+    expect(
+      planContainer(
+        {
+          id: "container",
+          state: "restarting",
           gitTipCommit: "commit",
           configHash,
         },
@@ -112,6 +129,24 @@ describe("planContainer", () => {
         ],
       }),
     );
+  });
+
+  it("changes the hash of containers created before the restart policy", () => {
+    const previousHash = createHash("sha256")
+      .update(
+        JSON.stringify({
+          environmentVariables: [],
+          volumes: [],
+          portMappings: [],
+          logConfig: {
+            Type: "json-file",
+            Config: { "max-size": "10m", "max-file": "3" },
+          },
+        }),
+      )
+      .digest("hex");
+
+    expect(getContainerConfigHash({})).not.toBe(previousHash);
   });
 });
 


### PR DESCRIPTION
## Summary

- Create Piploy Application containers with Docker's `unless-stopped` restart policy and without `AutoRemove`.
- Include the restart policy in the container configuration hash, rolling existing containers forward on their next Poll.
- Reuse a matching Docker container in `restarting` state instead of replacing it during a crash loop.
- Record the lifecycle decision in ADR 0009 and clarify that a Poll is the only trigger that changes declared Application state.

## Why

Docker can now maintain the container state Piploy already declared after an unexpected exit or Pi reboot, rather than deleting the container and waiting for the next Poll. This adds no inbound trigger or second configuration source.

## Validation

- `corepack pnpm lint`
- `corepack pnpm test` — 131 tests passed
- `corepack pnpm exec vitest --config vitest.integration.config.ts run test/integration/docker.test.ts`

The full integration command's unrelated registry-dependent supply-chain policy tests were unable to obtain live registry metadata in this environment.
