### PR TITLE
Expose container logs and crash state

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ reach it. Another user gets the offline fallback described under `status`.
 
 | Command         | What it does                                                                                                                                       |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `status`        | Prints the Piploy version, whether the background service is reachable, and per-application configured host-to-container port mappings, Git, and Docker state. |
+| `status`        | Prints the Piploy version, whether the background service is reachable, and per-application configured host-to-container port mappings, Git, and Docker state, including the container's state, exit code, and restart count. |
+| `logs`          | Prints one application's recent container output, running or exited. `--tail <lines>` sets how much. Requires the daemon to be running.            |
 | `poll`          | Runs one reconciliation now instead of waiting for the poll timer.                                                                                 |
 | `service-start` | Runs the daemon in the foreground. This is what systemd invokes; do not run it by hand while the service is up.                                    |
 | `service-stop`  | Asks the running daemon to shut down.                                                                                                              |
@@ -111,6 +112,17 @@ reach it. Another user gets the offline fallback described under `status`.
 ```bash
 node piploy.cjs status
 ```
+
+### `logs`
+
+```bash
+node piploy.cjs logs my-app --tail 500
+```
+
+Returns at most 2000 lines and 256 KB, keeping the most recent output. Docker
+caps what it retains at roughly 30 MB per application, so anything older than
+that is already gone. Application logs are returned unredacted and may contain
+secrets.
 
 ### `register`
 
@@ -141,9 +153,9 @@ tailnet and from nowhere else. There is no token and no other authentication:
 being on the tailnet is the whole of it. If the machine has no Tailscale
 address, the daemon logs a warning and starts anyway, without the endpoint.
 
-It exposes five tools — `status`, `poll`, `register`, `service-start`, and
-`service-stop` — which run exactly what the matching CLI commands do. `wipeall`
-and `self-update` are deliberately not exposed. See
+It exposes six tools — `status`, `logs`, `poll`, `register`, `service-start`,
+and `service-stop` — which run exactly what the matching CLI commands do.
+`wipeall` and `self-update` are deliberately not exposed. See
 [ADR-0008](docs/adr/0008-mcp-server-tailscale-only.md).
 
 ## Publishing a release

--- a/docs/adr/0002-module-seams-and-test-split.md
+++ b/docs/adr/0002-module-seams-and-test-split.md
@@ -39,6 +39,7 @@ containers on a developer machine out of test cleanup.
 | `docker.ts` | dockerode adapter and cleanup | integration, with policy covered by `dockerPlan` unit tests |
 | `orchestrator.ts` | poll sequencing through `OrchestratorDeps` | unit |
 | `status.ts` | pure running-version comparison | unit |
+| `containerLogs.ts` | pure log tail bounds and Docker stream decoding | unit |
 | `settings.ts` | configuration loading and Zod validation | unit |
 | `commands.ts` / `cli.ts` | command wiring | thin existing coverage |
 

--- a/docs/adr/0008-mcp-server-tailscale-only.md
+++ b/docs/adr/0008-mcp-server-tailscale-only.md
@@ -22,8 +22,11 @@ deferred because they add a runtime dependency on the binary or local socket.
 
 ## Exposed tools
 
-The server registers exactly five tools: `status`, `poll`, `register`,
-`service-start`, and `service-stop`. `wipeall` and `self-update` are excluded,
+The server registers exactly six tools: `status`, `logs`, `poll`, `register`,
+`service-start`, and `service-stop`. `logs` belongs here because it is
+read-only; it returns a bounded tail of one Application's container output,
+unredacted, so anything on the tailnet can read whatever that Application
+prints. `wipeall` and `self-update` are excluded,
 and the exclusion is structural — they are simply never registered, so there is
 no block list that could drift out of sync with the command set. `wipeall`
 destroys every container, image, and file Piploy owns; `self-update` replaces

--- a/docs/adr/0009-docker-maintains-declared-application-containers.md
+++ b/docs/adr/0009-docker-maintains-declared-application-containers.md
@@ -32,5 +32,11 @@ declared.
   diagnosis. Log bounds are set separately by the container log configuration.
 - Docker is an enforcer of Piploy's declared state, not a second source of
   configuration or an inbound trigger to Piploy.
-- Container logs and detailed restart/exit reporting remain separate
-  observability work.
+- Container logs and restart/exit reporting are read back through `status` and
+  the read-only `logs` tool ([ADR-0008](0008-mcp-server-tailscale-only.md)).
+  Because a crash-looping container is `Running` to Docker while it waits out
+  its restart backoff, Piploy reports the inspected state rather than the list
+  state, so a crash loop is never mistaken for the latest running version.
+- Cleanup removes a container rather than stopping it. Without `AutoRemove` a
+  stop would leave it behind, holding its image and occupying its
+  Application's slot.

--- a/docs/agents/registering-an-application.md
+++ b/docs/agents/registering-an-application.md
@@ -138,7 +138,11 @@ status → approval → register → approval → poll → status
 ```
 
 `register` does not start an Application or trigger a Poll. Never call
-`service-stop` as part of this guide. Do not promise log access or
+`service-stop` as part of this guide. When `status` reports an Application that
+is not running its latest version, its container state tells you why: a
+`restarting` state with a non-zero exit code is a crash loop, and the read-only
+`logs` tool returns that container's recent output. Those logs are unredacted
+and may contain secrets, so treat them as sensitive. Do not promise
 Application-level health checks. If the available MCP results are insufficient,
 ask for explicit human permission before falling back to SSH.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import {
   commandFailed,
   createCommandDeps,
+  logs,
   parseRegisterOptions,
   poll,
   register,
@@ -14,6 +15,7 @@ import {
   type CommandDeps,
   type RegisterOptions,
 } from "./commands.js";
+import { defaultLogTailLines, maxLogTailLines } from "./containerLogs.js";
 import { requestDaemon } from "./daemon.js";
 import { createLogger, type Logger } from "./logger.js";
 import { loadSettings, resolveConfigPath } from "./settings.js";
@@ -27,6 +29,7 @@ const commandNames = [
   "poll",
   "wipeall",
   "register",
+  "logs",
 ] as const;
 
 function collect(value: string, previous: string[]): string[] {
@@ -60,8 +63,8 @@ function addRegisterOptions(command: Command): Command {
     .option("--json <application>", "the whole Application as JSON");
 }
 
-// Only `register` reads the second argument; the rest are zero-arg commands.
-type CommandAction = (deps: CommandDeps, application: unknown) => Promise<void>;
+// Only `register` and `logs` read the second argument; the rest are zero-arg.
+type CommandAction = (deps: CommandDeps, payload: never) => Promise<void>;
 
 const actions: Record<(typeof commandNames)[number], CommandAction> = {
   status,
@@ -70,15 +73,16 @@ const actions: Record<(typeof commandNames)[number], CommandAction> = {
   poll,
   wipeall: wipeAll,
   register,
+  logs,
 };
 
 async function runCommand(
   commandName: (typeof commandNames)[number],
-  application: unknown,
+  payload: unknown,
 ): Promise<void> {
   const settings = loadSettings(resolveConfigPath());
   const deps = createCommandDeps(settings, createLogger(settings));
-  await actions[commandName](deps, application);
+  await actions[commandName](deps, payload as never);
 }
 
 function defineCommand(
@@ -86,6 +90,24 @@ function defineCommand(
   commandName: (typeof commandNames)[number],
 ): void {
   const command = program.command(commandName);
+  if (commandName === "logs") {
+    command
+      .argument("<application>", "registered application name")
+      .option(
+        "--tail <lines>",
+        `lines to return (default ${defaultLogTailLines}, maximum ${maxLogTailLines})`,
+      )
+      .action(async (application: string, options: { tail?: string }) => {
+        const tail =
+          options.tail === undefined ? undefined : Number(options.tail);
+        if (tail !== undefined && !Number.isInteger(tail)) {
+          commandFailed("Invalid --tail. It must be a whole number of lines.");
+          return;
+        }
+        await runCommand(commandName, { application, tail });
+      });
+    return;
+  }
   if (commandName !== "register") {
     command.action(() => runCommand(commandName, undefined));
     return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import {
   createCommandDeps,
   logs,
   parseRegisterOptions,
+  parseTailOption,
   poll,
   register,
   restartDaemonAfterUpdate,
@@ -63,26 +64,24 @@ function addRegisterOptions(command: Command): Command {
     .option("--json <application>", "the whole Application as JSON");
 }
 
-// Only `register` and `logs` read the second argument; the rest are zero-arg.
-type CommandAction = (deps: CommandDeps, payload: never) => Promise<void>;
-
-const actions: Record<(typeof commandNames)[number], CommandAction> = {
+// `register` and `logs` carry a payload, so each is wired to its own action
+// below. Everything else takes nothing but the dependencies.
+const plainActions: Record<
+  Exclude<(typeof commandNames)[number], "register" | "logs">,
+  (deps: CommandDeps) => Promise<void>
+> = {
   status,
   "service-start": serviceStart,
   "service-stop": serviceStop,
   poll,
   wipeall: wipeAll,
-  register,
-  logs,
 };
 
 async function runCommand(
-  commandName: (typeof commandNames)[number],
-  payload: unknown,
+  run: (deps: CommandDeps) => Promise<void>,
 ): Promise<void> {
   const settings = loadSettings(resolveConfigPath());
-  const deps = createCommandDeps(settings, createLogger(settings));
-  await actions[commandName](deps, payload as never);
+  await run(createCommandDeps(settings, createLogger(settings)));
 }
 
 function defineCommand(
@@ -98,18 +97,19 @@ function defineCommand(
         `lines to return (default ${defaultLogTailLines}, maximum ${maxLogTailLines})`,
       )
       .action(async (application: string, options: { tail?: string }) => {
-        const tail =
-          options.tail === undefined ? undefined : Number(options.tail);
-        if (tail !== undefined && !Number.isInteger(tail)) {
-          commandFailed("Invalid --tail. It must be a whole number of lines.");
+        const parsed = parseTailOption(options.tail);
+        if (!parsed.ok) {
+          commandFailed(parsed.message);
           return;
         }
-        await runCommand(commandName, { application, tail });
+        await runCommand((deps) =>
+          logs(deps, { application, tail: parsed.tail }),
+        );
       });
     return;
   }
   if (commandName !== "register") {
-    command.action(() => runCommand(commandName, undefined));
+    command.action(() => runCommand(plainActions[commandName]));
     return;
   }
   // Flags are parsed before the configuration is loaded, so bad input fails on
@@ -120,7 +120,7 @@ function defineCommand(
       commandFailed(parsed.message);
       return;
     }
-    await runCommand(commandName, parsed.application);
+    await runCommand((deps) => register(deps, parsed.application));
   });
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,6 @@
 import { rmSync } from "node:fs";
 
+import { maxLogTailLines } from "./containerLogs.js";
 import {
   createDaemonDeps,
   requestDaemon,
@@ -60,6 +61,10 @@ export function createCommandDeps(
   };
 }
 
+// Both read-only commands are refused for the same reason while a poll runs,
+// and "install" is the operator-facing word for what a poll does to a Pi.
+const pollInProgressMessage = "An install is in progress. Try again shortly.";
+
 /** The one place a command's failure sets both the message and the exit code. */
 export function commandFailed(message: string): void {
   console.error(message);
@@ -113,7 +118,7 @@ export async function status(deps: CommandDeps): Promise<void> {
     if (response.reason === "poll-in-progress") {
       console.log(`Piploy version: ${piployVersion}`);
       console.log("Background service: running");
-      console.log("\nAn install is in progress. Try again shortly.");
+      console.log(`\n${pollInProgressMessage}`);
       return;
     }
     commandFailed(`Daemon status request failed: ${response.reason}`);
@@ -132,10 +137,30 @@ export interface LogsOptions {
   tail?: number;
 }
 
+export type ParsedTailOption =
+  { ok: true; tail: number | undefined } | { ok: false; message: string };
+
+/**
+ * Parses `--tail` to the same bounds the MCP tool enforces on its own input,
+ * so a rejected line count fails with a CLI message rather than being quietly
+ * replaced by the default.
+ */
+export function parseTailOption(value: string | undefined): ParsedTailOption {
+  if (value === undefined) return { ok: true, tail: undefined };
+  const tail = Number(value);
+  if (!Number.isInteger(tail) || tail < 1 || tail > maxLogTailLines) {
+    return {
+      ok: false,
+      message: `Invalid --tail '${value}'. It must be a whole number of lines between 1 and ${maxLogTailLines}.`,
+    };
+  }
+  return { ok: true, tail };
+}
+
 const logsFailureMessages: Record<string, string> = {
   "unknown-application": "No such application is registered.",
   "no-container": "That application has no container yet. Run a poll first.",
-  "poll-in-progress": "An install is in progress. Try again shortly.",
+  "poll-in-progress": pollInProgressMessage,
 };
 
 /**
@@ -170,7 +195,7 @@ export async function logs(
     return;
   }
   console.log(
-    `${response.logs.application} (container ${response.logs.containerState})`,
+    `${response.logs.application} (container ${response.logs.containerState}, last ${response.logs.tail} lines)`,
   );
   if (response.logs.truncated) {
     console.log("Older output was dropped to stay within the size limit.");

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -91,6 +91,14 @@ function printStatus(status: DaemonStatus, daemonReachable: boolean): void {
     console.log(
       `  Port mappings: ${application.portMappings.length === 0 ? "none" : application.portMappings.map(({ hostPort, containerPort }) => `${hostPort}:${containerPort}`).join(", ")}`,
     );
+    const container = application.docker.container;
+    console.log(`  Container state: ${container?.state ?? "none"}`);
+    if (container) {
+      console.log(
+        `  Container exit code: ${container.exitCode ?? "not exited"}`,
+      );
+      console.log(`  Container restart count: ${container.restartCount}`);
+    }
   }
 }
 
@@ -116,6 +124,58 @@ export async function status(deps: CommandDeps): Promise<void> {
     return;
   }
   printStatus(response.status, true);
+}
+
+/** The `logs` positional argument and flags, before they reach the daemon. */
+export interface LogsOptions {
+  application: string;
+  tail?: number;
+}
+
+const logsFailureMessages: Record<string, string> = {
+  "unknown-application": "No such application is registered.",
+  "no-container": "That application has no container yet. Run a poll first.",
+  "poll-in-progress": "An install is in progress. Try again shortly.",
+};
+
+/**
+ * Prints one Application's container logs. There is no inline fallback: the
+ * logs come from the daemon's Docker adapter, and asking a daemon that is not
+ * running would say nothing useful about a container it did not start.
+ */
+export async function logs(
+  deps: CommandDeps,
+  options: LogsOptions,
+): Promise<void> {
+  const response = await deps.requestDaemon({
+    command: "logs",
+    application: options.application,
+    tail: options.tail,
+  });
+  if (response === undefined) {
+    commandFailed(
+      "Background service not running. Start it, then run 'piploy logs' again.",
+    );
+    return;
+  }
+  if (!response.ok) {
+    commandFailed(
+      logsFailureMessages[response.reason] ??
+        `Daemon logs request failed: ${response.reason}`,
+    );
+    return;
+  }
+  if (!("logs" in response)) {
+    commandFailed("Daemon logs request returned no logs");
+    return;
+  }
+  console.log(
+    `${response.logs.application} (container ${response.logs.containerState})`,
+  );
+  if (response.logs.truncated) {
+    console.log("Older output was dropped to stay within the size limit.");
+  }
+  console.log(response.logs.text);
 }
 
 /** Requests an immediate daemon poll, or reconciles inline when no daemon is running. */

--- a/src/containerLogs.ts
+++ b/src/containerLogs.ts
@@ -9,8 +9,8 @@ export const maxLogTailLines = 2000;
 export const maxLogBytes = 256 * 1024;
 
 const frameHeaderBytes = 8;
-const stdinStream = 0;
 const stderrStream = 2;
+const newline = 0x0a;
 
 /** Clamps a caller's requested tail; anything unusable falls back to the default. */
 export function resolveTailLines(requested: number | undefined): number {
@@ -24,8 +24,7 @@ function readFrames(buffer: Buffer): string | undefined {
   let offset = 0;
   while (offset < buffer.length) {
     if (offset + frameHeaderBytes > buffer.length) return undefined;
-    const streamType = buffer.readUInt8(offset);
-    if (streamType < stdinStream || streamType > stderrStream) return undefined;
+    if (buffer.readUInt8(offset) > stderrStream) return undefined;
     const length = buffer.readUInt32BE(offset + 4);
     const start = offset + frameHeaderBytes;
     const end = start + length;
@@ -46,15 +45,30 @@ export function decodeContainerLog(buffer: Buffer): string {
   return readFrames(buffer) ?? buffer.toString("utf8");
 }
 
-/** Caps the returned output, keeping the most recent bytes. */
+/**
+ * Caps the returned output, keeping the most recent bytes. The cut is moved
+ * forward to the next line break so it cannot land inside a multi-byte
+ * character and open the output with a replacement character.
+ */
 export function limitLogBytes(text: string): {
   text: string;
   truncated: boolean;
 } {
   const buffer = Buffer.from(text, "utf8");
   if (buffer.length <= maxLogBytes) return { text, truncated: false };
-  return {
-    text: buffer.subarray(buffer.length - maxLogBytes).toString("utf8"),
-    truncated: true,
-  };
+
+  const cut = buffer.length - maxLogBytes;
+  const lineBreak = buffer.indexOf(newline, cut);
+  // One unbroken line longer than the cap has no line break to fall forward
+  // to, so the boundary is found at the character level instead.
+  const start =
+    lineBreak === -1 ? startOfCharacter(buffer, cut) : lineBreak + 1;
+  return { text: buffer.subarray(start).toString("utf8"), truncated: true };
+}
+
+function startOfCharacter(buffer: Buffer, offset: number): number {
+  let start = offset;
+  // UTF-8 continuation bytes are 10xxxxxx; skipping them lands on a lead byte.
+  while (start < buffer.length && (buffer[start]! & 0xc0) === 0x80) start += 1;
+  return start;
 }

--- a/src/containerLogs.ts
+++ b/src/containerLogs.ts
@@ -1,0 +1,60 @@
+/**
+ * Container log output is read for diagnosis, not archival: a caller asks for
+ * the tail and gets a bounded answer. The limits are hardcoded because an
+ * unbounded tail returned over MCP is its own problem, and nothing so far has
+ * needed to tune them per Application.
+ */
+export const defaultLogTailLines = 200;
+export const maxLogTailLines = 2000;
+export const maxLogBytes = 256 * 1024;
+
+const frameHeaderBytes = 8;
+const stdinStream = 0;
+const stderrStream = 2;
+
+/** Clamps a caller's requested tail; anything unusable falls back to the default. */
+export function resolveTailLines(requested: number | undefined): number {
+  if (requested === undefined) return defaultLogTailLines;
+  if (!Number.isInteger(requested) || requested < 1) return defaultLogTailLines;
+  return Math.min(requested, maxLogTailLines);
+}
+
+function readFrames(buffer: Buffer): string | undefined {
+  const parts: Buffer[] = [];
+  let offset = 0;
+  while (offset < buffer.length) {
+    if (offset + frameHeaderBytes > buffer.length) return undefined;
+    const streamType = buffer.readUInt8(offset);
+    if (streamType < stdinStream || streamType > stderrStream) return undefined;
+    const length = buffer.readUInt32BE(offset + 4);
+    const start = offset + frameHeaderBytes;
+    const end = start + length;
+    if (end > buffer.length) return undefined;
+    parts.push(buffer.subarray(start, end));
+    offset = end;
+  }
+  return Buffer.concat(parts).toString("utf8");
+}
+
+/**
+ * Docker multiplexes stdout and stderr into length-prefixed frames for a
+ * container without a TTY, which is every container Piploy creates. Anything
+ * that does not parse as frames is returned as-is rather than mangled, so a
+ * TTY container or a partial read still yields readable output.
+ */
+export function decodeContainerLog(buffer: Buffer): string {
+  return readFrames(buffer) ?? buffer.toString("utf8");
+}
+
+/** Caps the returned output, keeping the most recent bytes. */
+export function limitLogBytes(text: string): {
+  text: string;
+  truncated: boolean;
+} {
+  const buffer = Buffer.from(text, "utf8");
+  if (buffer.length <= maxLogBytes) return { text, truncated: false };
+  return {
+    text: buffer.subarray(buffer.length - maxLogBytes).toString("utf8"),
+    truncated: true,
+  };
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2,6 +2,7 @@ import { chmodSync, existsSync, lstatSync, unlinkSync } from "node:fs";
 import net from "node:net";
 import path from "node:path";
 
+import { resolveTailLines } from "./containerLogs.js";
 import { createDockerService, type DockerStatus } from "./docker.js";
 import { getCommitStatus, type GitCommitStatus } from "./git.js";
 import type { Logger } from "./logger.js";
@@ -32,18 +33,39 @@ export type DaemonRequest =
   | { command: "status" }
   | { command: "poll" }
   | { command: "stop" }
+  | { command: "logs"; application: string; tail?: number }
   | { command: "register"; application: unknown };
 
 export type DaemonResponse =
   | { ok: true; status: DaemonStatus }
   | { ok: true; applications: PollApplicationResult[] }
   | { ok: true; application: Application }
+  | { ok: true; logs: ApplicationLogs }
   | { ok: true }
   | {
       ok: false;
-      reason: "busy" | "invalid-request" | "failed" | "poll-in-progress";
+      reason:
+        | "busy"
+        | "invalid-request"
+        | "failed"
+        | "poll-in-progress"
+        | "unknown-application"
+        | "no-container";
     }
   | { ok: false; reason: RegisterApplicationFailure; message: string };
+
+export interface ApplicationLogs {
+  application: string;
+  containerState: string;
+  /** Timestamped stdout and stderr, oldest first. May contain secrets. */
+  text: string;
+  truncated: boolean;
+  tail: number;
+}
+
+export type ApplicationLogsResult =
+  | { ok: true; logs: ApplicationLogs }
+  | { ok: false; reason: "unknown-application" | "no-container" };
 
 export interface ApplicationDaemonStatus {
   application: string;
@@ -61,6 +83,7 @@ export interface DaemonStatus {
 export interface DaemonDeps {
   poll(): Promise<PollApplicationResult[]>;
   getStatus(): Promise<DaemonStatus>;
+  getLogs(application: string, tail?: number): Promise<ApplicationLogsResult>;
   attemptSelfUpdate(): Promise<SelfUpdateResult>;
 }
 
@@ -106,6 +129,14 @@ function parseRequest(value: unknown): DaemonRequest | undefined {
   if (command === "register" && "application" in value) {
     return { command: "register", application: value.application };
   }
+  if (command === "logs" && "application" in value) {
+    if (typeof value.application !== "string") return undefined;
+    const tail =
+      "tail" in value && typeof value.tail === "number"
+        ? value.tail
+        : undefined;
+    return { command: "logs", application: value.application, tail };
+  }
   return undefined;
 }
 
@@ -138,6 +169,30 @@ export function createDaemonDeps(
     };
   }
 
+  async function getLogs(
+    name: string,
+    tail?: number,
+  ): Promise<ApplicationLogsResult> {
+    const application = settings.Applications.find(
+      (candidate) => candidate.Name === name,
+    );
+    if (!application) return { ok: false, reason: "unknown-application" };
+
+    const tailLines = resolveTailLines(tail);
+    const logs = await docker.getContainerLogs(application, tailLines);
+    if (!logs) return { ok: false, reason: "no-container" };
+    return {
+      ok: true,
+      logs: {
+        application: application.Name,
+        containerState: logs.containerState,
+        text: logs.text,
+        truncated: logs.truncated,
+        tail: tailLines,
+      },
+    };
+  }
+
   return {
     poll: () => orchestrator.poll(),
     getStatus: async () => ({
@@ -145,6 +200,7 @@ export function createDaemonDeps(
         settings.Applications.map(getApplicationStatus),
       ),
     }),
+    getLogs,
     attemptSelfUpdate: () => attemptSelfUpdate(logger),
   };
 }
@@ -324,6 +380,12 @@ export async function startDaemon(
       switch (request.command) {
         case "status":
           return { ok: true, status: await deps.getStatus() };
+        case "logs": {
+          const result = await deps.getLogs(request.application, request.tail);
+          return result.ok
+            ? { ok: true, logs: result.logs }
+            : { ok: false, reason: result.reason };
+        }
         case "stop":
           return { ok: true };
         case "register":
@@ -388,7 +450,12 @@ export async function startDaemon(
     request: DaemonRequest,
     respond: (response: DaemonResponse) => void,
   ): boolean {
-    if (request.command === "status" && pollInProgress) {
+    // Both read-only commands answer about state a running poll is actively
+    // changing, so they say so rather than queue behind a slow build.
+    if (
+      (request.command === "status" || request.command === "logs") &&
+      pollInProgress
+    ) {
       respond({ ok: false, reason: "poll-in-progress" });
       return true;
     }

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import Dockerode from "dockerode";
 
+import { decodeContainerLog, limitLogBytes } from "./containerLogs.js";
 import {
   containerLogConfig,
   containerRestartPolicy,
@@ -38,9 +39,32 @@ export interface EnsureContainerResult {
   containerId: string;
 }
 
+/**
+ * The container occupying an Application's slot, as Docker reports it. This is
+ * what tells `isRunningLatestVersion: false` apart from a container that
+ * crashes on boot: under the `unless-stopped` restart policy (ADR-0009) a
+ * crash loop shows as `restarting` with the last non-zero `exitCode`.
+ */
+export interface ContainerRuntimeStatus {
+  state: string;
+  /** Absent while the container is running; it has not exited yet. */
+  exitCode?: number;
+  restartCount: number;
+  startedAt?: string;
+  finishedAt?: string;
+}
+
 export interface DockerStatus {
   latestImageHash?: string;
   runningContainerHash?: string;
+  container?: ContainerRuntimeStatus;
+}
+
+export interface ContainerLogs {
+  containerState: string;
+  text: string;
+  /** True when the oldest returned bytes were dropped to stay within the cap. */
+  truncated: boolean;
 }
 
 export interface PiployDockerService {
@@ -53,6 +77,11 @@ export interface PiployDockerService {
     commit: GitCommit,
   ): Promise<EnsureContainerResult>;
   getDockerStatus(application: Application): Promise<DockerStatus>;
+  /** Resolves to `undefined` when the Application has no container at all. */
+  getContainerLogs(
+    application: Application,
+    tailLines: number,
+  ): Promise<ContainerLogs | undefined>;
   cleanupInactive(applications: Application[]): Promise<void>;
   cleanupAll(): Promise<void>;
   cleanupTestCreated(): Promise<void>;
@@ -345,13 +374,59 @@ export function createDockerService(
       findImage(getImageVersionTagLatest(application.Name)),
       findContainer(getContainerName(application)),
     ]);
+    const runtime = container
+      ? await inspectRuntimeStatus(container.Id)
+      : undefined;
     return {
       latestImageHash: image?.Labels[imageCommitLabelName],
+      // The inspected state decides this, not the list state: Docker's list
+      // API reports a crash-looping container as running, and calling that the
+      // latest running version is the confusion this whole status exists to
+      // remove.
       runningContainerHash:
-        container?.State === "running"
+        container && runtime?.state === "running"
           ? container.Labels[imageCommitLabelName]
           : undefined,
+      container: runtime,
     };
+  }
+
+  async function inspectRuntimeStatus(
+    containerId: string,
+  ): Promise<ContainerRuntimeStatus> {
+    const { State, RestartCount } = await docker
+      .getContainer(containerId)
+      .inspect();
+    return {
+      state: State.Status,
+      // Docker reports 0 for a container that has not exited yet, which reads
+      // as a clean exit. Report the code only once there has been one. A
+      // restarting container is `Running` while Docker waits out its backoff,
+      // and its exit code is the whole point of asking, so it counts as exited.
+      exitCode: State.Running && !State.Restarting ? undefined : State.ExitCode,
+      restartCount: RestartCount,
+      startedAt: State.StartedAt,
+      finishedAt: State.FinishedAt,
+    };
+  }
+
+  async function getContainerLogs(
+    application: Application,
+    tailLines: number,
+  ): Promise<ContainerLogs | undefined> {
+    const container = await findContainer(getContainerName(application));
+    if (!container) return undefined;
+
+    // `follow: false` makes dockerode resolve the whole response as a buffer
+    // rather than hand back a live stream, which is what a bounded tail wants.
+    const raw = (await docker.getContainer(container.Id).logs({
+      stdout: true,
+      stderr: true,
+      timestamps: true,
+      tail: tailLines,
+    })) as unknown as Buffer;
+    const { text, truncated } = limitLogBytes(decodeContainerLog(raw));
+    return { containerState: container.State, text, truncated };
   }
 
   async function getPiployImages(
@@ -374,10 +449,12 @@ export function createDockerService(
     const containers = (await docker.listContainers({ all: true })).filter(
       (container) => imageIds.has(container.ImageID),
     );
+    // Containers no longer back a declared Application, so they are removed
+    // rather than stopped (ADR-0009). Without `AutoRemove` a stop alone would
+    // leave the container behind, holding a reference to the image below and
+    // occupying its Application's slot indefinitely.
     for (const container of containers) {
-      if (container.State === "running") {
-        await docker.getContainer(container.Id).stop();
-      }
+      await docker.getContainer(container.Id).remove({ force: true });
     }
     for (const image of images) {
       await docker.getImage(image.Id).remove({ force: true });
@@ -411,6 +488,7 @@ export function createDockerService(
     ensureImageExists,
     ensureContainerRunning,
     getDockerStatus,
+    getContainerLogs,
     cleanupInactive,
     cleanupAll,
     cleanupTestCreated,

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -47,11 +47,9 @@ export interface EnsureContainerResult {
  */
 export interface ContainerRuntimeStatus {
   state: string;
-  /** Absent while the container is running; it has not exited yet. */
+  /** Absent until the container has exited at least once. */
   exitCode?: number;
   restartCount: number;
-  startedAt?: string;
-  finishedAt?: string;
 }
 
 export interface DockerStatus {
@@ -142,6 +140,17 @@ function asDockerContainer(
     gitTipCommit: container.Labels[imageCommitLabelName],
     configHash: container.Labels[containerConfigLabelName],
   };
+}
+
+/**
+ * Whether the container has run and stopped at least once. Docker zeroes
+ * `FinishedAt` for a container that has never run, so `ExitCode` 0 there means
+ * "no exit yet" rather than a clean one.
+ */
+function hasExited(state: Dockerode.ContainerInspectInfo["State"]): boolean {
+  return (
+    (!state.Running || state.Restarting) && Date.parse(state.FinishedAt) > 0
+  );
 }
 
 function isPortAlreadyAllocated(error: unknown): boolean {
@@ -399,14 +408,12 @@ export function createDockerService(
       .inspect();
     return {
       state: State.Status,
-      // Docker reports 0 for a container that has not exited yet, which reads
-      // as a clean exit. Report the code only once there has been one. A
-      // restarting container is `Running` while Docker waits out its backoff,
-      // and its exit code is the whole point of asking, so it counts as exited.
-      exitCode: State.Running && !State.Restarting ? undefined : State.ExitCode,
+      // Docker reports 0 for a container that is running or has never run at
+      // all, which both read as a clean exit. Report the code only once there
+      // has been one. A restarting container is `Running` while Docker waits
+      // out its backoff, and its last exit code is the whole point of asking.
+      exitCode: hasExited(State) ? State.ExitCode : undefined,
       restartCount: RestartCount,
-      startedAt: State.StartedAt,
-      finishedAt: State.FinishedAt,
     };
   }
 
@@ -417,6 +424,10 @@ export function createDockerService(
     const container = await findContainer(getContainerName(application));
     if (!container) return undefined;
 
+    // The inspected state, for the same reason `getDockerStatus` uses it: the
+    // list state would label a crash-looping container as running, right above
+    // the output showing it crash.
+    const runtime = await inspectRuntimeStatus(container.Id);
     // `follow: false` makes dockerode resolve the whole response as a buffer
     // rather than hand back a live stream, which is what a bounded tail wants.
     const raw = (await docker.getContainer(container.Id).logs({
@@ -426,7 +437,7 @@ export function createDockerService(
       tail: tailLines,
     })) as unknown as Buffer;
     const { text, truncated } = limitLogBytes(decodeContainerLog(raw));
-    return { containerState: container.State, text, truncated };
+    return { containerState: runtime.state, text, truncated };
   }
 
   async function getPiployImages(

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -4,6 +4,11 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";
 
+import {
+  defaultLogTailLines,
+  maxLogBytes,
+  maxLogTailLines,
+} from "./containerLogs.js";
 import type { DaemonRequest, DaemonResponse } from "./daemon.js";
 import type { ApplicationSchema } from "./settings.js";
 import { piployVersion } from "./version.js";
@@ -60,7 +65,7 @@ function toolResult(response: DaemonResponse) {
 }
 
 /**
- * Registers the five commands that are safe to expose on the tailnet. The
+ * Registers the six commands that are safe to expose on the tailnet. The
  * exclusion of `wipeall` and `self-update` is structural: they are simply
  * never registered here, so there is no block list to keep in sync.
  */
@@ -71,9 +76,22 @@ function createMcpServer(dispatch: McpDispatch): McpServer {
     "status",
     {
       description:
-        "Report each registered application's configured host-to-container port mappings (an empty array means none), git commits, Docker image and container hashes, and whether it runs the latest version.",
+        "Report each registered application's configured host-to-container port mappings (an empty array means none), git commits, Docker image and container hashes, whether it runs the latest version, and its container's state, exit code, and restart count. A 'restarting' state with a non-zero exit code means the container is crash-looping.",
     },
     async () => toolResult(await dispatch({ command: "status" })),
+  );
+
+  server.registerTool(
+    "logs",
+    {
+      description: `Read the recent stdout and stderr of one application's container, running or exited. Returns at most ${maxLogTailLines} lines (default ${defaultLogTailLines}) and at most ${maxLogBytes} bytes, keeping the most recent output. Application logs may contain secrets; they are returned unredacted.`,
+      inputSchema: {
+        application: z.string(),
+        tail: z.number().int().min(1).max(maxLogTailLines).optional(),
+      },
+    },
+    async ({ application, tail }) =>
+      toolResult(await dispatch({ command: "logs", application, tail })),
   );
 
   server.registerTool(

--- a/test/integration/docker.test.ts
+++ b/test/integration/docker.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import Dockerode from "dockerode";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 
 import { createDockerService } from "../../src/docker.js";
 import { getContainerConfigHash } from "../../src/dockerPlan.js";
@@ -33,9 +33,15 @@ const application = {
   Volumes: [{ name: "sqlite", containerPath: "/app/data" }],
   EnvironmentVariables: { DATABASE_PATH: "/app/data/app.db" },
 };
+const crashingCommit = { hash: crypto.randomUUID().replaceAll("-", "") };
+const crashingApplication = {
+  Name: `${applicationName}crash`,
+  GitRepositoryUrl: "https://example.invalid/integration.git",
+  DockerfilePath: "Dockerfile",
+};
 const settings: PiploySettings = {
   RootDirectory: path.join(temporaryDirectory, "root"),
-  Applications: [application],
+  Applications: [application, crashingApplication],
   IsTestRun: true,
 };
 const docker = createDockerService(settings, logger);
@@ -57,7 +63,7 @@ describe("docker adapter", () => {
     await mkdir(repoDirectory, { recursive: true });
     await writeFile(
       path.join(repoDirectory, "Dockerfile"),
-      'FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc\nCMD ["sh", "-c", "while true; do sleep 3600; done"]\n',
+      'FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc\nCMD ["sh", "-c", "echo hello-from-piploy; while true; do sleep 3600; done"]\n',
     );
 
     const built = await docker.ensureImageExists(application, commit);
@@ -103,12 +109,50 @@ describe("docker adapter", () => {
       wasStarted: false,
       containerId: started.containerId,
     });
-    expect(await docker.getDockerStatus(application)).toEqual({
+    expect(await docker.getDockerStatus(application)).toMatchObject({
       latestImageHash: commit.hash,
       runningContainerHash: commit.hash,
+      container: { state: "running", exitCode: undefined, restartCount: 0 },
     });
+
+    const logs = await docker.getContainerLogs(application, 10);
+    expect(logs?.containerState).toBe("running");
+    expect(logs?.text).toContain("hello-from-piploy");
+    expect(logs?.truncated).toBe(false);
 
     await docker.cleanupTestCreated();
     expect(await docker.getDockerStatus(application)).toEqual({});
+    expect(await docker.getContainerLogs(application, 10)).toBeUndefined();
+  });
+
+  it("reports the exit code and logs of a container that crashes on boot", async () => {
+    const repoDirectory = path.join(
+      settings.RootDirectory,
+      crashingApplication.Name,
+      "repo",
+    );
+    await mkdir(repoDirectory, { recursive: true });
+    await writeFile(
+      path.join(repoDirectory, "Dockerfile"),
+      'FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc\nCMD ["sh", "-c", "echo crashing-on-boot >&2; exit 3"]\n',
+    );
+
+    await docker.ensureImageExists(crashingApplication, crashingCommit);
+    await docker.ensureContainerRunning(crashingApplication, crashingCommit);
+
+    // The restart policy keeps the container alive as a slot, so it is seen
+    // either mid-restart or between attempts. Both carry the last exit code.
+    const status = await vi.waitFor(async () => {
+      const current = await docker.getDockerStatus(crashingApplication);
+      expect(current.container?.exitCode).toBe(3);
+      return current;
+    });
+    expect(status.runningContainerHash).toBeUndefined();
+    expect(["restarting", "exited"]).toContain(status.container?.state);
+
+    const logs = await docker.getContainerLogs(crashingApplication, 10);
+    expect(logs?.text).toContain("crashing-on-boot");
+
+    await docker.cleanupTestCreated();
   });
 });

--- a/test/integration/docker.test.ts
+++ b/test/integration/docker.test.ts
@@ -109,7 +109,7 @@ describe("docker adapter", () => {
       wasStarted: false,
       containerId: started.containerId,
     });
-    expect(await docker.getDockerStatus(application)).toMatchObject({
+    expect(await docker.getDockerStatus(application)).toEqual({
       latestImageHash: commit.hash,
       runningContainerHash: commit.hash,
       container: { state: "running", exitCode: undefined, restartCount: 0 },

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  logs,
   parseRegisterOptions,
   poll,
   register,
@@ -83,6 +84,46 @@ describe("commands", () => {
     expect(output).toHaveBeenCalledWith("  Port mappings: none");
   });
 
+  it("prints the container state, exit code, and restart count", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => ({
+      ok: true as const,
+      status: {
+        applications: [
+          {
+            ...daemonStatus.applications[0]!,
+            docker: {
+              container: { state: "restarting", exitCode: 1, restartCount: 4 },
+            },
+          },
+        ],
+      },
+    }));
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await status(deps);
+
+    expect(output).toHaveBeenCalledWith("  Container state: restarting");
+    expect(output).toHaveBeenCalledWith("  Container exit code: 1");
+    expect(output).toHaveBeenCalledWith("  Container restart count: 4");
+  });
+
+  it("prints no container state when the application has no container", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => ({
+      ok: true as const,
+      status: daemonStatus,
+    }));
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await status(deps);
+
+    expect(output).toHaveBeenCalledWith("  Container state: none");
+    expect(output).not.toHaveBeenCalledWith(
+      expect.stringContaining("Container exit code"),
+    );
+  });
+
   it("computes status inline only when no daemon is reachable", async () => {
     const deps = createDeps();
     deps.requestDaemon = vi.fn(async () => undefined);
@@ -126,6 +167,86 @@ describe("commands", () => {
     );
     expect(error).not.toHaveBeenCalled();
     expect(process.exitCode).toBeUndefined();
+  });
+
+  it("prints container logs from a reachable daemon", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => ({
+      ok: true as const,
+      logs: {
+        application: "app",
+        containerState: "exited",
+        text: "boom\n",
+        truncated: false,
+        tail: 200,
+      },
+    }));
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await logs(deps, { application: "app", tail: 200 });
+
+    expect(deps.requestDaemon).toHaveBeenCalledWith({
+      command: "logs",
+      application: "app",
+      tail: 200,
+    });
+    expect(output).toHaveBeenCalledWith("app (container exited)");
+    expect(output).toHaveBeenCalledWith("boom\n");
+  });
+
+  it("says when older log output was dropped", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => ({
+      ok: true as const,
+      logs: {
+        application: "app",
+        containerState: "running",
+        text: "tail\n",
+        truncated: true,
+        tail: 200,
+      },
+    }));
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await logs(deps, { application: "app" });
+
+    expect(output).toHaveBeenCalledWith(
+      "Older output was dropped to stay within the size limit.",
+    );
+  });
+
+  it.each([
+    ["unknown-application" as const, "No such application is registered."],
+    [
+      "no-container" as const,
+      "That application has no container yet. Run a poll first.",
+    ],
+    [
+      "poll-in-progress" as const,
+      "An install is in progress. Try again shortly.",
+    ],
+  ])("explains the %s logs rejection", async (reason, message) => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => ({ ok: false as const, reason }));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await logs(deps, { application: "app" });
+
+    expect(error).toHaveBeenCalledWith(message);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("refuses to read logs without a running daemon", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => undefined);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await logs(deps, { application: "app" });
+
+    expect(error).toHaveBeenCalledWith(
+      "Background service not running. Start it, then run 'piploy logs' again.",
+    );
+    expect(process.exitCode).toBe(1);
   });
 
   it("delegates poll to a reachable daemon", async () => {

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   logs,
   parseRegisterOptions,
+  parseTailOption,
   poll,
   register,
   restartDaemonAfterUpdate,
@@ -190,7 +191,9 @@ describe("commands", () => {
       application: "app",
       tail: 200,
     });
-    expect(output).toHaveBeenCalledWith("app (container exited)");
+    expect(output).toHaveBeenCalledWith(
+      "app (container exited, last 200 lines)",
+    );
     expect(output).toHaveBeenCalledWith("boom\n");
   });
 
@@ -248,6 +251,22 @@ describe("commands", () => {
     );
     expect(process.exitCode).toBe(1);
   });
+
+  it.each([undefined, "1", "2000"])("accepts the tail option %s", (value) => {
+    expect(parseTailOption(value)).toEqual({
+      ok: true,
+      tail: value === undefined ? undefined : Number(value),
+    });
+  });
+
+  it.each(["0", "-5", "1.5", "2001", "all"])(
+    "rejects the tail option %s before contacting the daemon",
+    (value) => {
+      const parsed = parseTailOption(value);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.ok ? "" : parsed.message).toContain("between 1 and 2000");
+    },
+  );
 
   it("delegates poll to a reachable daemon", async () => {
     const deps = createDeps();

--- a/test/unit/containerLogs.test.ts
+++ b/test/unit/containerLogs.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decodeContainerLog,
+  defaultLogTailLines,
+  limitLogBytes,
+  maxLogBytes,
+  maxLogTailLines,
+  resolveTailLines,
+} from "../../src/containerLogs.js";
+
+function frame(streamType: number, payload: string): Buffer {
+  const body = Buffer.from(payload, "utf8");
+  const header = Buffer.alloc(8);
+  header.writeUInt8(streamType, 0);
+  header.writeUInt32BE(body.length, 4);
+  return Buffer.concat([header, body]);
+}
+
+describe("resolveTailLines", () => {
+  it("uses the default when no tail is requested", () => {
+    expect(resolveTailLines(undefined)).toBe(defaultLogTailLines);
+  });
+
+  it("keeps a requested tail within the allowed range", () => {
+    expect(resolveTailLines(50)).toBe(50);
+  });
+
+  it("clamps a tail above the hard maximum", () => {
+    expect(resolveTailLines(maxLogTailLines + 1000)).toBe(maxLogTailLines);
+  });
+
+  it.each([0, -5, 1.5, Number.NaN])(
+    "falls back to the default for the unusable request %s",
+    (requested) => {
+      expect(resolveTailLines(requested)).toBe(defaultLogTailLines);
+    },
+  );
+});
+
+describe("decodeContainerLog", () => {
+  it("joins stdout and stderr frames in the order Docker emitted them", () => {
+    const buffer = Buffer.concat([
+      frame(1, "starting\n"),
+      frame(2, "boom\n"),
+      frame(1, "done\n"),
+    ]);
+    expect(decodeContainerLog(buffer)).toBe("starting\nboom\ndone\n");
+  });
+
+  it("returns the raw text when the stream is not multiplexed", () => {
+    expect(decodeContainerLog(Buffer.from("plain tty output\n", "utf8"))).toBe(
+      "plain tty output\n",
+    );
+  });
+
+  it("returns the raw text when a frame claims more bytes than remain", () => {
+    const truncated = frame(1, "hello").subarray(0, 10);
+    expect(decodeContainerLog(truncated)).toBe(truncated.toString("utf8"));
+  });
+
+  it("returns an empty string for an empty buffer", () => {
+    expect(decodeContainerLog(Buffer.alloc(0))).toBe("");
+  });
+});
+
+describe("limitLogBytes", () => {
+  it("returns short output untouched", () => {
+    expect(limitLogBytes("a\nb\n")).toEqual({
+      text: "a\nb\n",
+      truncated: false,
+    });
+  });
+
+  it("keeps the most recent bytes when the output is too large", () => {
+    const text = `${"x".repeat(maxLogBytes)}TAIL`;
+    const result = limitLogBytes(text);
+    expect(result.truncated).toBe(true);
+    expect(Buffer.byteLength(result.text, "utf8")).toBeLessThanOrEqual(
+      maxLogBytes,
+    );
+    expect(result.text.endsWith("TAIL")).toBe(true);
+  });
+});

--- a/test/unit/containerLogs.test.ts
+++ b/test/unit/containerLogs.test.ts
@@ -81,4 +81,18 @@ describe("limitLogBytes", () => {
     );
     expect(result.text.endsWith("TAIL")).toBe(true);
   });
+
+  it("drops the partly cut line rather than starting mid-line", () => {
+    const text = `${"x".repeat(maxLogBytes)}\nkept\nalso kept\n`;
+    expect(limitLogBytes(text).text).toBe("kept\nalso kept\n");
+  });
+
+  it("never opens with half a multi-byte character", () => {
+    // One unbroken line, so there is no line break to fall forward to.
+    const text = "å".repeat(maxLogBytes);
+    const result = limitLogBytes(text);
+    expect(result.truncated).toBe(true);
+    expect(result.text).not.toContain("�");
+    expect(result.text.startsWith("å")).toBe(true);
+  });
 });

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -37,6 +37,12 @@ function createLogger(): Logger {
 // address unless it is the one asserting on that branch.
 const noTailscale = { getTailscaleAddress: () => undefined };
 
+// The default for every test that is not about logs: nothing is registered.
+const noLogs: DaemonDeps["getLogs"] = async () => ({
+  ok: false,
+  reason: "unknown-application",
+});
+
 function sendRequest(
   socketPath: string,
   request: unknown,
@@ -80,6 +86,7 @@ describe("daemon", () => {
 
   it("serves daemon-computed status over a private socket", async () => {
     const daemon = await start({
+      getLogs: noLogs,
       poll: async () => [],
       getStatus: async () => ({
         applications: [
@@ -114,6 +121,60 @@ describe("daemon", () => {
     });
   });
 
+  it("returns container logs for one application over the private socket", async () => {
+    const logs = {
+      application: "app",
+      containerState: "exited",
+      text: "boom\n",
+      truncated: false,
+      tail: 50,
+    };
+    const requested: { application: string; tail?: number }[] = [];
+    const daemon = await start({
+      getLogs: async (application, tail) => {
+        requested.push({ application, tail });
+        return { ok: true, logs };
+      },
+      poll: async () => [],
+      getStatus: async () => ({ applications: [] }),
+      attemptSelfUpdate: async () => "up-to-date",
+    });
+
+    await expect(
+      requestDaemon(
+        { command: "logs", application: "app", tail: 50 },
+        daemon.socketPath,
+      ),
+    ).resolves.toEqual({ ok: true, logs });
+    expect(requested).toEqual([{ application: "app", tail: 50 }]);
+  });
+
+  it("reports an application with no container as a distinct logs rejection", async () => {
+    const daemon = await start({
+      getLogs: async () => ({ ok: false, reason: "no-container" }),
+      poll: async () => [],
+      getStatus: async () => ({ applications: [] }),
+      attemptSelfUpdate: async () => "up-to-date",
+    });
+
+    await expect(
+      requestDaemon({ command: "logs", application: "app" }, daemon.socketPath),
+    ).resolves.toEqual({ ok: false, reason: "no-container" });
+  });
+
+  it("rejects a logs request without an application name", async () => {
+    const daemon = await start({
+      getLogs: noLogs,
+      poll: async () => [],
+      getStatus: async () => ({ applications: [] }),
+      attemptSelfUpdate: async () => "up-to-date",
+    });
+
+    await expect(
+      sendRequest(daemon.socketPath, { command: "logs", application: 7 }),
+    ).resolves.toEqual({ ok: false, reason: "invalid-request" });
+  });
+
   it("returns per-application poll results over the private socket", async () => {
     const applications = [
       {
@@ -124,6 +185,7 @@ describe("daemon", () => {
       },
     ];
     const daemon = await start({
+      getLogs: noLogs,
       poll: async () => applications,
       getStatus: async () => ({ applications: [] }),
       attemptSelfUpdate: async () => "up-to-date",
@@ -142,6 +204,7 @@ describe("daemon", () => {
     let polls = 0;
     const daemon = await start(
       {
+        getLogs: noLogs,
         poll: async () => {
           polls += 1;
           if (polls === 2) await firstPoll;
@@ -176,6 +239,7 @@ describe("daemon", () => {
       releasePoll = resolve;
     });
     const daemon = await start({
+      getLogs: noLogs,
       poll: async () => {
         await pollGate;
         return [];
@@ -190,6 +254,11 @@ describe("daemon", () => {
     await expect(
       sendRequest(daemon.socketPath, { command: "status" }),
     ).resolves.toEqual({ ok: false, reason: "poll-in-progress" });
+    // Logs report on the same state a running poll is changing, so they answer
+    // the same way rather than queueing behind a slow build.
+    await expect(
+      sendRequest(daemon.socketPath, { command: "logs", application: "app" }),
+    ).resolves.toEqual({ ok: false, reason: "poll-in-progress" });
 
     releasePoll!();
     await expect(poll).resolves.toEqual({ ok: true, applications: [] });
@@ -197,6 +266,7 @@ describe("daemon", () => {
 
   it("rejects malformed requests", async () => {
     const daemon = await start({
+      getLogs: noLogs,
       poll: async () => [],
       getStatus: async () => ({ applications: [] }),
       attemptSelfUpdate: async () => "up-to-date",
@@ -215,6 +285,7 @@ describe("daemon", () => {
       return undefined as never;
     }) as typeof process.exit);
     const daemon = await start({
+      getLogs: noLogs,
       poll: async () => [],
       getStatus: async () => ({ applications: [] }),
       attemptSelfUpdate: async () => "up-to-date",
@@ -255,6 +326,7 @@ describe("daemon", () => {
             events.push("update");
             return updateResult;
           },
+          getLogs: noLogs,
           poll: async () => {
             events.push("poll");
             return [];
@@ -286,6 +358,7 @@ describe("daemon", () => {
         events.push("update");
         return "up-to-date";
       },
+      getLogs: noLogs,
       poll: async () => {
         events.push("poll");
         return [];
@@ -337,6 +410,7 @@ describe("daemon", () => {
 
     function idleDeps(): DaemonDeps {
       return {
+        getLogs: noLogs,
         poll: async () => [],
         getStatus: async () => ({ applications: [] }),
         attemptSelfUpdate: async () => "up-to-date",
@@ -531,6 +605,7 @@ describe("daemon", () => {
       const { daemon, messages } = await startWithAddress(
         undefined,
         {
+          getLogs: noLogs,
           poll: async () => [],
           getStatus: async () => ({ applications: [] }),
           attemptSelfUpdate: async () => "up-to-date",
@@ -553,6 +628,7 @@ describe("daemon", () => {
     it("runs MCP tool calls through the same queue as socket clients", async () => {
       const events: string[] = [];
       const { messages } = await startWithAddress("127.0.0.1", {
+        getLogs: noLogs,
         poll: async () => {
           events.push("poll");
           return [];

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -53,12 +53,13 @@ describe("mcp server", () => {
     return { client, requests };
   }
 
-  it("exposes exactly the five safe commands as tools", async () => {
+  it("exposes exactly the six safe commands as tools", async () => {
     const { client } = await start();
 
     const { tools } = await client.listTools();
 
     expect(tools.map((tool) => tool.name).sort()).toEqual([
+      "logs",
       "poll",
       "register",
       "service-start",
@@ -75,6 +76,50 @@ describe("mcp server", () => {
     expect(tools.find((tool) => tool.name === "status")?.description).toContain(
       "host-to-container port mappings",
     );
+  });
+
+  it("warns that logs are returned unredacted", async () => {
+    const { client } = await start();
+
+    const { tools } = await client.listTools();
+
+    expect(tools.find((tool) => tool.name === "logs")?.description).toContain(
+      "may contain secrets",
+    );
+  });
+
+  it("routes logs through the daemon dispatcher with the requested tail", async () => {
+    const logs = {
+      application: "app",
+      containerState: "restarting",
+      text: "boom\n",
+      truncated: false,
+      tail: 10,
+    };
+    const { client, requests } = await start(() => ({ ok: true, logs }));
+
+    const result = await client.callTool({
+      name: "logs",
+      arguments: { application: "app", tail: 10 },
+    });
+
+    expect(requests).toEqual([
+      { command: "logs", application: "app", tail: 10 },
+    ]);
+    expect(JSON.parse(textOf(result))).toEqual({ ok: true, logs });
+  });
+
+  it("rejects a logs tail above the hard maximum before dispatching", async () => {
+    const { client, requests } = await start();
+
+    const result = await client.callTool({
+      name: "logs",
+      arguments: { application: "app", tail: 1_000_000 },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("tail");
+    expect(requests).toEqual([]);
   });
 
   it("routes status through the daemon dispatcher", async () => {


### PR DESCRIPTION
Closes #105.

## Summary

- Add a read-only `logs` tool to the tailnet MCP and a `piploy logs <application> [--tail N]` CLI command, returning a bounded tail of one Application's container output whether it is running or exited.
- Report the container's state, exit code, and restart count in `status`, so a crash loop can be told apart from an Application that never deployed.
- Fix two consequences of dropping `AutoRemove` in #110, both found by the integration tests here.

## Scope against the issue

Issue #105 lists four steps. Two are already settled:

- **Step 1** (drop `AutoRemove`) landed in #110.
- **Step 2** (sweep the stopped container at the start of the next poll) is deliberately **not** implemented. #79 was settled as `unless-stopped` in ADR-0009, and the issue's own comment says that decision "contradicts step 2 ... under `unless-stopped` a crashed container is restarting, not durably dead, so there is no stable moment to sweep."

So this PR is steps 3 and 4, which that comment calls decision-independent, plus the two repairs below.

The issue's **Follow-on** — updating the `piploy-deploy` skill, which lives in `alundgren/irudd-skills`, not this repo — is filed as alundgren/irudd-skills#34. The in-repo public guide `docs/agents/registering-an-application.md` is updated here.

## Two bugs fixed along the way

Both are fallout from removing `AutoRemove`, and neither is visible without a container that outlives its own exit:

1. **Cleanup stopped containers instead of removing them.** `stopContainersAndDeleteImages` called `stop()` and never `remove()`. With `AutoRemove` gone the container survived, held a reference to the image being deleted, and occupied its Application's slot indefinitely. In the integration suite this surfaced as `(HTTP code 409) conflict - image is being used by running container`.
2. **Docker reports a crash-looping container as running.** Its `State.Running` stays true while Docker waits out the restart backoff, so `listContainers` said `running` and `isRunningLatestVersion` was true for a container that never stays up — the exact confusion step 4 exists to remove. `status` and `logs` now both report the *inspected* state.

## Design notes

- `logs` is queued like `status` and answers `poll-in-progress` rather than waiting behind a slow build.
- Limits are hardcoded in `containerLogs.ts`: default 200 lines, maximum 2000, 256 KB. The MCP tool enforces the line bound in its input schema, and the CLI's `--tail` parser enforces the same bound rather than silently falling back to the default.
- The byte cap keeps the most recent output and cuts at a line break, falling back to a UTF-8 character boundary for one unbroken line, so the output cannot open with half a character.
- Docker's multiplexed stdout/stderr framing is decoded in `containerLogs.ts`, a pure module with unit tests, per ADR-0002; anything that does not parse as frames is returned as-is rather than mangled.
- Logs are returned **unredacted**. The tool description, README, and public guide all say so; #105 explicitly asked not to attempt redaction.

## Validation

- `pnpm lint` — clean.
- `pnpm test` — 168 unit tests pass.
- `pnpm exec vitest --config vitest.integration.config.ts run test/integration/docker.test.ts` — 2 pass, including a new case that deploys an Application whose `CMD` exits 3 immediately, then asserts `status` reports the exit code and `logs` returns the container's stderr. `docker ps -a` shows no leftover test containers afterwards.
- The unrelated registry-dependent supply-chain tests in `test/integration/pnpmPolicy.test.ts` cannot reach a live registry in this environment and were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)