### PR TITLE
Enable safe host-environment references

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ node piploy.cjs register \
 `--json '<application-json>'` passes the whole application instead; it cannot be
 combined with the individual flags.
 
+An `EnvironmentVariables` value is normally literal. The one exception is an
+entire value in the form `${hostEnv:NAME}`, where `NAME` starts with a letter or
+underscore and then contains only letters, digits, or underscores. Piploy stores
+that reference unchanged and resolves it from the daemon's environment only
+when it creates or recreates a container; it does not include the resolved value
+in its ordinary diagnostics. Restart the daemon after changing its environment,
+then make a configuration or commit change that recreates the container for the
+new value to apply. Other interpolation-like values remain literal.
+
 ## MCP server
 
 While the daemon runs, it also serves an MCP endpoint over Streamable HTTP at:

--- a/docs/adr/0001-config-validation-and-logging.md
+++ b/docs/adr/0001-config-validation-and-logging.md
@@ -13,8 +13,15 @@ configuration is parsed. Volumes are validated as
 `<name>:/container/path` and likewise converted to typed names and container
 paths; host paths, `..`, the container root, a second colon — which Docker
 would read as mount options — and two Volumes of one Application sharing a
-container path are all rejected. Environment variables are passed to Docker
-verbatim, without interpolation.
+container path are all rejected. Environment-variable values are literals,
+except that an entire value exactly matching `${hostEnv:NAME}` (where `NAME`
+uses letters, digits, and underscores and does not start with a digit) is a
+reference to the daemon's host environment. Piploy persists that reference,
+uses the reference itself in its container identity, and resolves it only when
+it is about to create or recreate a container. It never writes the resolved
+value to its normal diagnostics. A daemon-environment change takes effect only
+after restarting the daemon and a later configuration- or commit-driven
+container recreation; all other interpolation-like strings remain literal.
 
 `RootDirectory` is rejected when it overlaps the data directory in either
 direction, because `wipeall` deletes `RootDirectory` recursively and

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -11,6 +11,7 @@ import {
   getDockerfilePathFromSetting,
   planContainer,
   planImage,
+  resolveContainerEnvironmentVariables,
   type DockerContainer,
   validateDockerfileImageReferences,
 } from "./dockerPlan.js";
@@ -293,11 +294,11 @@ export function createDockerService(
       (volume) =>
         `${getVolumeDirectory(application, volume)}:${volume.containerPath}`,
     );
-    const environment = Object.entries(
+    const declaredEnvironment = Object.entries(
       application.EnvironmentVariables ?? {},
     ).map(([name, value]) => `${name}=${value}`);
     const configHash = getContainerConfigHash({
-      environmentVariables: environment,
+      environmentVariables: declaredEnvironment,
       volumes: binds,
       portMappings: application.PortMappings,
     });
@@ -323,6 +324,14 @@ export function createDockerService(
         containerId: containerPlan.containerId,
       };
     }
+
+    // Resolve only after planning proves that Docker must create a new
+    // container. In particular, an unset host value must not disturb the
+    // existing container that a failed recreation would otherwise replace.
+    const environment = resolveContainerEnvironmentVariables(
+      application.EnvironmentVariables ?? {},
+      process.env,
+    );
 
     if (containerPlan.existingContainerId) {
       logger.info(`Removing container ${containerName}`);

--- a/src/dockerPlan.ts
+++ b/src/dockerPlan.ts
@@ -20,6 +20,9 @@ export interface ContainerConfiguration {
   }[];
 }
 
+const hostEnvironmentReferencePattern =
+  /^\$\{hostEnv:([A-Za-z_][A-Za-z0-9_]*)\}$/;
+
 export type ImagePlan =
   { action: "reuse"; imageId: string } | { action: "build" };
 
@@ -114,6 +117,33 @@ export function getContainerConfigHash(
     restartPolicy: containerRestartPolicy,
   };
   return createHash("sha256").update(JSON.stringify(normalized)).digest("hex");
+}
+
+/**
+ * Converts the declared environment into Docker's `KEY=VALUE` form. A host
+ * environment reference is deliberately recognized only when it is the whole
+ * value, so every other string remains a literal configuration value.
+ *
+ * The host environment is an argument rather than an implicit global so this
+ * policy stays deterministic and Docker decides when it is safe to read it.
+ */
+export function resolveContainerEnvironmentVariables(
+  environmentVariables: Readonly<Record<string, string>>,
+  hostEnvironment: Readonly<Record<string, string | undefined>>,
+): string[] {
+  return Object.entries(environmentVariables).map(([name, value]) => {
+    const match = hostEnvironmentReferencePattern.exec(value);
+    if (!match) return `${name}=${value}`;
+
+    const hostEnvironmentName = match[1]!;
+    const resolvedValue = hostEnvironment[hostEnvironmentName];
+    if (resolvedValue === undefined) {
+      throw new Error(
+        `Host environment variable '${hostEnvironmentName}' is not set`,
+      );
+    }
+    return `${name}=${resolvedValue}`;
+  });
 }
 
 /** Converts the config setting into a Docker build context and its Dockerfile. */

--- a/test/integration/docker.test.ts
+++ b/test/integration/docker.test.ts
@@ -11,9 +11,10 @@ import { getContainerConfigHash } from "../../src/dockerPlan.js";
 import type { Logger } from "../../src/logger.js";
 import type { PiploySettings } from "../../src/settings.js";
 
+const loggedMessages: string[] = [];
 const logger: Logger = {
   debug: () => {},
-  info: () => {},
+  info: (message) => loggedMessages.push(message),
   warn: () => {},
   error: () => {},
   child: () => logger,
@@ -24,6 +25,11 @@ const temporaryDirectory = await mkdtemp(
 );
 const originalConfigPath = process.env.PIPLOY_CONFIG;
 process.env.PIPLOY_CONFIG = path.join(temporaryDirectory, "piploy.json");
+const hostEnvironmentName = `PIPLOY_HOST_ENV_${crypto.randomUUID().replaceAll("-", "")}`;
+const hostEnvironmentSecret = "test-host-environment-secret";
+const originalHostEnvironmentValue = process.env[hostEnvironmentName];
+process.env[hostEnvironmentName] = hostEnvironmentSecret;
+const hostEnvironmentReference = `\${hostEnv:${hostEnvironmentName}}`;
 const applicationName = `integration${crypto.randomUUID().replaceAll("-", "")}`;
 const commit = { hash: crypto.randomUUID().replaceAll("-", "") };
 const application = {
@@ -31,7 +37,10 @@ const application = {
   GitRepositoryUrl: "https://example.invalid/integration.git",
   DockerfilePath: "Dockerfile",
   Volumes: [{ name: "sqlite", containerPath: "/app/data" }],
-  EnvironmentVariables: { DATABASE_PATH: "/app/data/app.db" },
+  EnvironmentVariables: {
+    DATABASE_PATH: "/app/data/app.db",
+    HOST_ENV_TOKEN: hostEnvironmentReference,
+  },
 };
 const crashingCommit = { hash: crypto.randomUUID().replaceAll("-", "") };
 const crashingApplication = {
@@ -51,6 +60,11 @@ afterAll(async () => {
   await rm(temporaryDirectory, { recursive: true, force: true });
   if (originalConfigPath === undefined) delete process.env.PIPLOY_CONFIG;
   else process.env.PIPLOY_CONFIG = originalConfigPath;
+  if (originalHostEnvironmentValue === undefined) {
+    delete process.env[hostEnvironmentName];
+  } else {
+    process.env[hostEnvironmentName] = originalHostEnvironmentValue;
+  }
 });
 
 describe("docker adapter", () => {
@@ -85,6 +99,9 @@ describe("docker adapter", () => {
       .getContainer(started.containerId)
       .inspect();
     expect(inspect.Config.Env).toContain("DATABASE_PATH=/app/data/app.db");
+    expect(inspect.Config.Env).toContain(
+      `HOST_ENV_TOKEN=${hostEnvironmentSecret}`,
+    );
     expect(inspect.HostConfig.Binds).toContain(
       `${path.join(temporaryDirectory, "data", application.Name, "sqlite")}:/app/data`,
     );
@@ -98,7 +115,10 @@ describe("docker adapter", () => {
     });
     expect(inspect.Config.Labels?.piploy_configHash).toBe(
       getContainerConfigHash({
-        environmentVariables: ["DATABASE_PATH=/app/data/app.db"],
+        environmentVariables: [
+          "DATABASE_PATH=/app/data/app.db",
+          `HOST_ENV_TOKEN=${hostEnvironmentReference}`,
+        ],
         volumes: [
           `${path.join(temporaryDirectory, "data", application.Name, "sqlite")}:/app/data`,
         ],
@@ -109,6 +129,7 @@ describe("docker adapter", () => {
       wasStarted: false,
       containerId: started.containerId,
     });
+    expect(loggedMessages.join("\n")).not.toContain(hostEnvironmentSecret);
     expect(await docker.getDockerStatus(application)).toEqual({
       latestImageHash: commit.hash,
       runningContainerHash: commit.hash,
@@ -119,6 +140,36 @@ describe("docker adapter", () => {
     expect(logs?.containerState).toBe("running");
     expect(logs?.text).toContain("hello-from-piploy");
     expect(logs?.truncated).toBe(false);
+
+    // Reuse and start make no host-environment read, while a failed recreate
+    // checks before removing the current container.
+    delete process.env[hostEnvironmentName];
+    expect(await docker.ensureContainerRunning(application, commit)).toEqual({
+      wasCreated: false,
+      wasStarted: false,
+      containerId: started.containerId,
+    });
+    await new Dockerode().getContainer(started.containerId).stop();
+    expect(await docker.ensureContainerRunning(application, commit)).toEqual({
+      wasCreated: false,
+      wasStarted: true,
+      containerId: started.containerId,
+    });
+    await expect(
+      docker.ensureContainerRunning(application, {
+        hash: crypto.randomUUID().replaceAll("-", ""),
+      }),
+    ).rejects.toThrow(
+      `Host environment variable '${hostEnvironmentName}' is not set`,
+    );
+    const afterFailedRecreation = await new Dockerode()
+      .getContainer(started.containerId)
+      .inspect();
+    expect(afterFailedRecreation.Id).toBe(started.containerId);
+    expect(loggedMessages.join("\n")).not.toContain(hostEnvironmentSecret);
+    expect(
+      JSON.stringify(await docker.getDockerStatus(application)),
+    ).not.toContain(hostEnvironmentSecret);
 
     await docker.cleanupTestCreated();
     expect(await docker.getDockerStatus(application)).toEqual({});

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -480,7 +480,7 @@ describe("parseRegisterOptions", () => {
       dockerfilePath: "Dockerfile",
       portMapping: ["8080:80", "8443:443"],
       volume: ["data:/var/lib/app"],
-      env: ["A=1", "B=x=y"],
+      env: ["A=1", "B=${hostEnv:CONTAINER_TOKEN}"],
     });
 
     expect(parsed).toEqual({
@@ -489,7 +489,7 @@ describe("parseRegisterOptions", () => {
         ...application,
         PortMappings: ["8080:80", "8443:443"],
         Volumes: ["data:/var/lib/app"],
-        EnvironmentVariables: { A: "1", B: "x=y" },
+        EnvironmentVariables: { A: "1", B: "${hostEnv:CONTAINER_TOKEN}" },
       },
     });
   });

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -375,6 +375,7 @@ describe("daemon", () => {
       GitRepositoryUrl: "https://example.com/app.git",
       DockerfilePath: "Dockerfile",
       PortMappings: ["8080:80"],
+      EnvironmentVariables: { TOKEN: "${hostEnv:CONTAINER_TOKEN}" },
     };
 
     async function startWithConfig(
@@ -433,6 +434,7 @@ describe("daemon", () => {
           GitRepositoryUrl: "https://example.com/app.git",
           DockerfilePath: "Dockerfile",
           PortMappings: [{ hostPort: 8080, containerPort: 80 }],
+          EnvironmentVariables: { TOKEN: "${hostEnv:CONTAINER_TOKEN}" },
         },
       });
 

--- a/test/unit/dockerPlan.test.ts
+++ b/test/unit/dockerPlan.test.ts
@@ -7,6 +7,7 @@ import {
   getDockerfilePathFromSetting,
   planContainer,
   planImage,
+  resolveContainerEnvironmentVariables,
   validateDockerfileImageReferences,
 } from "../../src/dockerPlan.js";
 
@@ -131,6 +132,25 @@ describe("planContainer", () => {
     );
   });
 
+  it("hashes a host-environment reference declaratively", () => {
+    const reference = "${hostEnv:CONTAINER_TOKEN}";
+    const hash = getContainerConfigHash({
+      environmentVariables: [`TOKEN=${reference}`],
+    });
+
+    expect(hash).toBe(
+      getContainerConfigHash({
+        environmentVariables: [`TOKEN=${reference}`],
+      }),
+    );
+    expect(hash).not.toBe(
+      getContainerConfigHash({
+        environmentVariables: ["TOKEN=test-secret"],
+      }),
+    );
+    expect(hash).not.toContain("test-secret");
+  });
+
   it("changes the hash of containers created before the restart policy", () => {
     const previousHash = createHash("sha256")
       .update(
@@ -147,6 +167,39 @@ describe("planContainer", () => {
       .digest("hex");
 
     expect(getContainerConfigHash({})).not.toBe(previousHash);
+  });
+});
+
+describe("resolveContainerEnvironmentVariables", () => {
+  it("resolves an exact host-environment reference", () => {
+    expect(
+      resolveContainerEnvironmentVariables(
+        { TOKEN: "${hostEnv:CONTAINER_TOKEN}" },
+        { CONTAINER_TOKEN: "test-secret" },
+      ),
+    ).toEqual(["TOKEN=test-secret"]);
+  });
+
+  it.each([
+    "${hostEnv:}",
+    "${hostEnv:1TOKEN}",
+    "${hostEnv:TOKEN-NAME}",
+    "before-${hostEnv:TOKEN}",
+    "${hostEnv:TOKEN}-after",
+    "${hostEnv:TOKEN",
+  ])("keeps an invalid or embedded reference literal: %s", (value) => {
+    expect(resolveContainerEnvironmentVariables({ TOKEN: value }, {})).toEqual([
+      `TOKEN=${value}`,
+    ]);
+  });
+
+  it("names an unset host variable without exposing a value", () => {
+    expect(() =>
+      resolveContainerEnvironmentVariables(
+        { TOKEN: "${hostEnv:CONTAINER_TOKEN}" },
+        {},
+      ),
+    ).toThrow("Host environment variable 'CONTAINER_TOKEN' is not set");
   });
 });
 

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -169,6 +169,7 @@ describe("mcp server", () => {
       GitRepositoryUrl: "https://example.com/app.git",
       DockerfilePath: "Dockerfile",
       PortMappings: ["8080:80"],
+      EnvironmentVariables: { TOKEN: "${hostEnv:CONTAINER_TOKEN}" },
     };
     const { client, requests } = await start((request) =>
       request.command === "register"

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -13,6 +13,7 @@ import {
   getVolumeDirectory,
   loadSettings,
   parseSettings,
+  registerApplication,
   resolveBundleDirectory,
   resolveConfigPath,
 } from "../../src/settings.js";
@@ -216,6 +217,44 @@ describe("parseSettings", () => {
     expect(settings.Applications[0]?.EnvironmentVariables).toEqual({
       DATABASE_PATH: "/app/data/app.db",
     });
+  });
+
+  it("preserves an exact host-environment reference in parsed settings", () => {
+    const settings = parseSettings({
+      Piploy: {
+        RootDirectory: "/root",
+        Applications: [
+          {
+            ...validApplication,
+            EnvironmentVariables: { TOKEN: "${hostEnv:CONTAINER_TOKEN}" },
+          },
+        ],
+      },
+    });
+
+    expect(settings.Applications[0]?.EnvironmentVariables).toEqual({
+      TOKEN: "${hostEnv:CONTAINER_TOKEN}",
+    });
+  });
+
+  it("persists a host-environment reference unchanged when registering", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "piploy-settings-"));
+    const configPath = path.join(directory, "piploy.json");
+    await writeFile(
+      configPath,
+      JSON.stringify({ Piploy: { RootDirectory: "/root", Applications: [] } }),
+    );
+    const rawApplication = {
+      ...validApplication,
+      EnvironmentVariables: { TOKEN: "${hostEnv:CONTAINER_TOKEN}" },
+    };
+
+    registerApplication(configPath, rawApplication);
+
+    const persisted = JSON.parse(await readFile(configPath, "utf8")) as {
+      Piploy: { Applications: unknown[] };
+    };
+    expect(persisted.Piploy.Applications).toEqual([rawApplication]);
   });
 });
 


### PR DESCRIPTION
Adds a strict declarative reference path that is resolved only when Docker creates a replacement container, while keeping configuration identity and diagnostics secret-safe.

Closes #114