### PR TITLE
Bound Docker build contexts to each application

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,18 +94,18 @@ The daemon's control socket is created with `0600` permissions and owned by the
 user the daemon runs as, so the commands below must run as that same user to
 reach it. Another user gets the offline fallback described under `status`.
 
-| Command         | What it does                                                                                                                                       |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Command         | What it does                                                                                                                                                                                                                  |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `status`        | Prints the Piploy version, whether the background service is reachable, and per-application configured host-to-container port mappings, Git, and Docker state, including the container's state, exit code, and restart count. |
-| `logs`          | Prints one application's recent container output, running or exited. `--tail <lines>` sets how much. Requires the daemon to be running.            |
-| `poll`          | Runs one reconciliation now instead of waiting for the poll timer.                                                                                 |
-| `service-start` | Runs the daemon in the foreground. This is what systemd invokes; do not run it by hand while the service is up.                                    |
-| `service-stop`  | Asks the running daemon to shut down.                                                                                                              |
-| `register`      | Adds one application to `piploy.json` and to the running daemon, so the next poll deploys it without a restart. Requires the daemon to be running. |
-| `wipeall`       | Removes all Piploy containers and images and deletes the root directory. Application data is preserved and its paths are printed.                  |
-| `self-update`   | Checks GitHub for a newer release, installs it, then restarts the running daemon through its control socket.                                      |
-| `--version`     | Prints the running bundle's version.                                                                                                               |
-| `--help`        | Lists the commands.                                                                                                                                |
+| `logs`          | Prints one application's recent container output, running or exited. `--tail <lines>` sets how much. Requires the daemon to be running.                                                                                       |
+| `poll`          | Runs one reconciliation now instead of waiting for the poll timer.                                                                                                                                                            |
+| `service-start` | Runs the daemon in the foreground. This is what systemd invokes; do not run it by hand while the service is up.                                                                                                               |
+| `service-stop`  | Asks the running daemon to shut down.                                                                                                                                                                                         |
+| `register`      | Adds one application to `piploy.json` and to the running daemon, so the next poll deploys it without a restart. Requires the daemon to be running.                                                                            |
+| `wipeall`       | Removes all Piploy containers and images and deletes the root directory. Application data is preserved and its paths are printed.                                                                                             |
+| `self-update`   | Checks GitHub for a newer release, installs it, then restarts the running daemon through its control socket.                                                                                                                  |
+| `--version`     | Prints the running bundle's version.                                                                                                                                                                                          |
+| `--help`        | Lists the commands.                                                                                                                                                                                                           |
 
 ### `status`
 
@@ -139,6 +139,25 @@ node piploy.cjs register \
 `--port-mapping`, `--volume`, and `--env` may each be repeated. For scripting,
 `--json '<application-json>'` passes the whole application instead; it cannot be
 combined with the individual flags.
+
+`--build-context-path` optionally selects the repository-relative directory to
+send to Docker as the build context. It accepts `.` for the repository root and
+defaults to the parent directory of `DockerfilePath`, preserving existing
+registrations. When it is set, Piploy rejects paths that escape the checkout,
+contexts or Dockerfiles reached through escaping symlinks, and Dockerfiles
+outside the selected context. Docker receives only that context, so `COPY` and
+`ADD` cannot use files outside it.
+
+For example, a nested Dockerfile can deliberately build with the repository
+root as its context:
+
+```bash
+node piploy.cjs register \
+  --name api \
+  --git-repository-url https://github.com/me/monorepo.git \
+  --dockerfile-path services/api/Dockerfile \
+  --build-context-path .
+```
 
 ## MCP server
 

--- a/docs/adr/0001-config-validation-and-logging.md
+++ b/docs/adr/0001-config-validation-and-logging.md
@@ -5,8 +5,8 @@
 `piploy.json` is Piploy's supported configuration contract. It contains a
 top-level `Piploy` object with `RootDirectory`, `Applications`, optional
 `MinutesBetweenBackgroundPolls`, and optional `IsTestRun`. Each application
-has `Name`, `GitRepositoryUrl`, `DockerfilePath`, optional `PortMappings`,
-optional `Volumes`, and optional `EnvironmentVariables`. Names may contain
+has `Name`, `GitRepositoryUrl`, `DockerfilePath`, optional `BuildContextPath`,
+optional `PortMappings`, optional `Volumes`, and optional `EnvironmentVariables`. Names may contain
 letters, numbers, underscores, and hyphens. Port mappings are validated as
 `<hostPort>:<containerPort>` and converted to typed port pairs while the
 configuration is parsed. Volumes are validated as

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,10 @@ function addRegisterOptions(command: Command): Command {
     .option("--git-repository-url <url>", "git repository to deploy from")
     .option("--dockerfile-path <path>", "Dockerfile path within the repository")
     .option(
+      "--build-context-path <path>",
+      "Docker build context directory within the repository",
+    )
+    .option(
       "--port-mapping <hostPort:containerPort>",
       "port mapping, repeatable",
       collect,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -241,6 +241,7 @@ export interface RegisterOptions {
   name?: string;
   gitRepositoryUrl?: string;
   dockerfilePath?: string;
+  buildContextPath?: string;
   portMapping?: string[];
   volume?: string[];
   env?: string[];
@@ -283,6 +284,9 @@ function buildApplicationFromFlags(
     GitRepositoryUrl: options.gitRepositoryUrl,
     DockerfilePath: options.dockerfilePath,
   };
+  if (options.buildContextPath !== undefined) {
+    application.BuildContextPath = options.buildContextPath;
+  }
   if (options.portMapping?.length) {
     application.PortMappings = options.portMapping;
   }
@@ -303,6 +307,7 @@ export function parseRegisterOptions(
     options.name !== undefined ||
     options.gitRepositoryUrl !== undefined ||
     options.dockerfilePath !== undefined ||
+    options.buildContextPath !== undefined ||
     (options.portMapping?.length ?? 0) > 0 ||
     (options.volume?.length ?? 0) > 0 ||
     (options.env?.length ?? 0) > 0;

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,4 +1,11 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
 import path from "node:path";
 
 import Dockerode from "dockerode";
@@ -7,6 +14,7 @@ import { decodeContainerLog, limitLogBytes } from "./containerLogs.js";
 import {
   containerLogConfig,
   containerRestartPolicy,
+  getBuildContextPathFromSetting,
   getContainerConfigHash,
   getDockerfilePathFromSetting,
   planContainer,
@@ -189,6 +197,128 @@ function buildImage(
   );
 }
 
+interface DockerBuildPaths {
+  contextDirectory: string;
+  dockerfilePath: string;
+  absoluteDockerfilePath: string;
+}
+
+function isContainedBy(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return (
+    relative === "" ||
+    (!relative.startsWith(`..${path.sep}`) &&
+      relative !== ".." &&
+      !path.isAbsolute(relative))
+  );
+}
+
+function assertContainedBy(
+  parent: string,
+  child: string,
+  description: string,
+): void {
+  if (!isContainedBy(parent, child)) {
+    throw new Error(
+      `${description} must remain inside the repository build context.`,
+    );
+  }
+}
+
+/**
+ * Resolves the files Docker receives. The optional setting enables the strict
+ * containment checks; omitting it deliberately retains the legacy behavior.
+ */
+export function resolveDockerBuildPaths(
+  repoDirectory: string,
+  application: Application,
+): DockerBuildPaths {
+  const dockerfilePath = getDockerfilePathFromSetting(
+    application.DockerfilePath,
+  );
+  if (application.BuildContextPath === undefined) {
+    const contextDirectory = path.join(
+      repoDirectory,
+      dockerfilePath.contextDirectory,
+    );
+    const absoluteDockerfilePath = path.join(
+      contextDirectory,
+      dockerfilePath.dockerfileName,
+    );
+    if (!existsSync(absoluteDockerfilePath)) {
+      throw new Error(
+        `Dockerfile '${application.DockerfilePath}' does not exist. Expected location: '${absoluteDockerfilePath}'`,
+      );
+    }
+    return {
+      contextDirectory,
+      dockerfilePath: dockerfilePath.dockerfileName,
+      absoluteDockerfilePath,
+    };
+  }
+
+  const buildContextPath = getBuildContextPathFromSetting(
+    application.BuildContextPath,
+  );
+  const absoluteRepoDirectory = path.resolve(repoDirectory);
+  const contextDirectory = path.resolve(
+    absoluteRepoDirectory,
+    buildContextPath,
+  );
+  const absoluteDockerfilePath = path.resolve(
+    absoluteRepoDirectory,
+    dockerfilePath.contextDirectory,
+    dockerfilePath.dockerfileName,
+  );
+  assertContainedBy(
+    absoluteRepoDirectory,
+    contextDirectory,
+    "BuildContextPath",
+  );
+  assertContainedBy(
+    absoluteRepoDirectory,
+    absoluteDockerfilePath,
+    "DockerfilePath",
+  );
+  assertContainedBy(contextDirectory, absoluteDockerfilePath, "DockerfilePath");
+
+  if (
+    !existsSync(contextDirectory) ||
+    !statSync(contextDirectory).isDirectory()
+  ) {
+    throw new Error(
+      `BuildContextPath '${application.BuildContextPath}' does not exist or is not a directory.`,
+    );
+  }
+  if (!existsSync(absoluteDockerfilePath)) {
+    throw new Error(
+      `Dockerfile '${application.DockerfilePath}' does not exist. Expected location: '${absoluteDockerfilePath}'`,
+    );
+  }
+
+  const resolvedRepoDirectory = realpathSync(absoluteRepoDirectory);
+  const resolvedContextDirectory = realpathSync(contextDirectory);
+  const resolvedDockerfilePath = realpathSync(absoluteDockerfilePath);
+  assertContainedBy(
+    resolvedRepoDirectory,
+    resolvedContextDirectory,
+    "BuildContextPath",
+  );
+  assertContainedBy(
+    resolvedContextDirectory,
+    resolvedDockerfilePath,
+    "DockerfilePath",
+  );
+
+  return {
+    contextDirectory: resolvedContextDirectory,
+    dockerfilePath: path
+      .relative(resolvedContextDirectory, resolvedDockerfilePath)
+      .replaceAll("\\", "/"),
+    absoluteDockerfilePath: resolvedDockerfilePath,
+  };
+}
+
 export function createDockerService(
   settings: PiploySettings,
   logger: Logger,
@@ -224,25 +354,10 @@ export function createDockerService(
       return { wasCreated: false, imageId: imagePlan.imageId };
     }
 
-    const dockerfilePath = getDockerfilePathFromSetting(
-      application.DockerfilePath,
-    );
     const repoDirectory = getApplicationRepoDirectory(settings, application);
-    const contextDirectory = path.join(
-      repoDirectory,
-      dockerfilePath.contextDirectory,
-    );
-    const absoluteDockerfilePath = path.join(
-      contextDirectory,
-      dockerfilePath.dockerfileName,
-    );
-    if (!existsSync(absoluteDockerfilePath)) {
-      throw new Error(
-        `Dockerfile '${application.DockerfilePath}' does not exist. Expected location: '${absoluteDockerfilePath}'`,
-      );
-    }
+    const buildPaths = resolveDockerBuildPaths(repoDirectory, application);
     const violations = validateDockerfileImageReferences(
-      readFileSync(absoluteDockerfilePath, "utf8"),
+      readFileSync(buildPaths.absoluteDockerfilePath, "utf8"),
     );
     if (violations.length > 0) {
       throw new Error(
@@ -256,9 +371,12 @@ export function createDockerService(
     logger.info(`Building docker image for commit ${commit.hash}`);
     const buildStream = await buildImage(
       docker,
-      { context: contextDirectory, src: readdirSync(contextDirectory) },
       {
-        dockerfile: dockerfilePath.dockerfileName,
+        context: buildPaths.contextDirectory,
+        src: readdirSync(buildPaths.contextDirectory),
+      },
+      {
+        dockerfile: buildPaths.dockerfilePath,
         t: [
           getImageVersionTagLatest(application.Name),
           commitTag,

--- a/src/dockerPlan.ts
+++ b/src/dockerPlan.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import path from "node:path";
 
 export interface DockerImage {
   id: string;
@@ -40,6 +41,9 @@ export interface DockerfileImageReferenceViolation {
 
 const invalidDockerfilePathMessage =
   "Invalid DockerfilePath. It must point to a dockerfile relative to the repository root. Examples: 'Dockerfile' or 'SubDirectory/Dockerfile' or Dockerfile.custom'";
+
+const invalidBuildContextPathMessage =
+  "Invalid BuildContextPath. It must be a nonempty directory relative to the repository root and cannot escape it.";
 
 /**
  * Bounds the container log files so a long running application cannot fill the
@@ -133,6 +137,21 @@ export function getDockerfilePathFromSetting(
     contextDirectory: segments.slice(0, -1).join("/"),
     dockerfileName,
   };
+}
+
+/** Normalizes the explicitly supplied Docker build context without accepting escapes. */
+export function getBuildContextPathFromSetting(
+  buildContextPath: string,
+): string {
+  const normalized = buildContextPath.replaceAll("\\", "/").trim();
+  if (
+    !normalized ||
+    path.posix.isAbsolute(normalized) ||
+    normalized.split("/").some((segment) => segment === "..")
+  ) {
+    throw new Error(invalidBuildContextPathMessage);
+  }
+  return path.posix.normalize(normalized);
 }
 
 /**

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -49,6 +49,7 @@ const registerInputSchema = {
   Name: z.string(),
   GitRepositoryUrl: z.string(),
   DockerfilePath: z.string(),
+  BuildContextPath: z.string().optional(),
   PortMappings: z.array(z.string()).optional(),
   Volumes: z.array(z.string()).optional(),
   EnvironmentVariables: z.record(z.string(), z.string()).optional(),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 
 import { z } from "zod";
 
+import { getBuildContextPathFromSetting } from "./dockerPlan.js";
 import { isDuplicateApplicationName } from "./registerPolicy.js";
 
 const portMappingPattern = /^(\d+):(\d+)$/;
@@ -46,11 +47,23 @@ const VolumeSchema = z.string().transform((value, ctx) => {
   return { name: match[1]!, containerPath: match[2]! };
 });
 
+const BuildContextPathSchema = z.string().superRefine((value, ctx) => {
+  try {
+    getBuildContextPathFromSetting(value);
+  } catch (error) {
+    ctx.addIssue({
+      code: "custom",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+});
+
 export const ApplicationSchema = z
   .object({
     Name: z.string().regex(/^[A-Za-z0-9_-]+$/),
     GitRepositoryUrl: z.string(),
     DockerfilePath: z.string(),
+    BuildContextPath: BuildContextPathSchema.optional(),
     PortMappings: z.array(PortMappingSchema).optional(),
     Volumes: z.array(VolumeSchema).optional(),
     EnvironmentVariables: z.record(z.string(), z.string()).optional(),

--- a/test/integration/docker.test.ts
+++ b/test/integration/docker.test.ts
@@ -39,9 +39,15 @@ const crashingApplication = {
   GitRepositoryUrl: "https://example.invalid/integration.git",
   DockerfilePath: "Dockerfile",
 };
+const contextApplication = {
+  Name: `${applicationName}context`,
+  GitRepositoryUrl: "https://example.invalid/integration.git",
+  DockerfilePath: "context/Dockerfile",
+  BuildContextPath: "context",
+};
 const settings: PiploySettings = {
   RootDirectory: path.join(temporaryDirectory, "root"),
-  Applications: [application, crashingApplication],
+  Applications: [application, crashingApplication, contextApplication],
   IsTestRun: true,
 };
 const docker = createDockerService(settings, logger);
@@ -152,6 +158,47 @@ describe("docker adapter", () => {
 
     const logs = await docker.getContainerLogs(crashingApplication, 10);
     expect(logs?.text).toContain("crashing-on-boot");
+
+    await docker.cleanupTestCreated();
+  });
+
+  it("builds only from the selected context", async () => {
+    const repoDirectory = path.join(
+      settings.RootDirectory,
+      contextApplication.Name,
+      "repo",
+    );
+    const contextDirectory = path.join(repoDirectory, "context");
+    await mkdir(contextDirectory, { recursive: true });
+    await writeFile(path.join(contextDirectory, "inside.txt"), "inside\n");
+    await writeFile(path.join(repoDirectory, "outside.txt"), "outside\n");
+    const base =
+      "alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc";
+
+    await writeFile(
+      path.join(contextDirectory, "Dockerfile"),
+      `FROM ${base}\nCOPY inside.txt /inside.txt\n`,
+    );
+    await expect(
+      docker.ensureImageExists(contextApplication, {
+        hash: crypto.randomUUID().replaceAll("-", ""),
+      }),
+    ).resolves.toMatchObject({ wasCreated: true });
+
+    for (const instruction of [
+      "COPY ../outside.txt /outside.txt",
+      "ADD ../outside.txt /outside.txt",
+    ]) {
+      await writeFile(
+        path.join(contextDirectory, "Dockerfile"),
+        `FROM ${base}\n${instruction}\n`,
+      );
+      await expect(
+        docker.ensureImageExists(contextApplication, {
+          hash: crypto.randomUUID().replaceAll("-", ""),
+        }),
+      ).rejects.toThrow();
+    }
 
     await docker.cleanupTestCreated();
   });

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -478,6 +478,7 @@ describe("parseRegisterOptions", () => {
       name: "app",
       gitRepositoryUrl: "https://example.com/app.git",
       dockerfilePath: "Dockerfile",
+      buildContextPath: "services/app",
       portMapping: ["8080:80", "8443:443"],
       volume: ["data:/var/lib/app"],
       env: ["A=1", "B=x=y"],
@@ -487,6 +488,7 @@ describe("parseRegisterOptions", () => {
       ok: true,
       application: {
         ...application,
+        BuildContextPath: "services/app",
         PortMappings: ["8080:80", "8443:443"],
         Volumes: ["data:/var/lib/app"],
         EnvironmentVariables: { A: "1", B: "x=y" },
@@ -499,22 +501,34 @@ describe("parseRegisterOptions", () => {
       name: "app",
       gitRepositoryUrl: "https://example.com/app.git",
       dockerfilePath: "Dockerfile",
+      buildContextPath: "services/app",
       portMapping: [],
       volume: [],
       env: [],
     });
 
-    expect(parsed).toEqual({ ok: true, application });
+    expect(parsed).toEqual({
+      ok: true,
+      application: { ...application, BuildContextPath: "services/app" },
+    });
   });
 
   it("accepts a whole application as JSON", () => {
     const parsed = parseRegisterOptions({
-      json: JSON.stringify({ ...application, PortMappings: ["8080:80"] }),
+      json: JSON.stringify({
+        ...application,
+        BuildContextPath: "services/app",
+        PortMappings: ["8080:80"],
+      }),
     });
 
     expect(parsed).toEqual({
       ok: true,
-      application: { ...application, PortMappings: ["8080:80"] },
+      application: {
+        ...application,
+        BuildContextPath: "services/app",
+        PortMappings: ["8080:80"],
+      },
     });
   });
 
@@ -577,4 +591,21 @@ describe("parseRegisterOptions", () => {
       "Invalid port mappings",
     );
   });
+
+  it.each(["", "/outside", "../outside"])(
+    "rejects an invalid build context path from flags before contacting the daemon: %s",
+    (buildContextPath) => {
+      const parsed = parseRegisterOptions({
+        name: "app",
+        gitRepositoryUrl: "https://example.com/app.git",
+        dockerfilePath: "Dockerfile",
+        buildContextPath,
+      });
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.ok ? "" : parsed.message).toContain(
+        "Invalid BuildContextPath",
+      );
+    },
+  );
 });

--- a/test/unit/dockerBuildPaths.test.ts
+++ b/test/unit/dockerBuildPaths.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveDockerBuildPaths } from "../../src/docker.js";
+import type { Application } from "../../src/settings.js";
+
+const directories: string[] = [];
+
+async function repository(): Promise<string> {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "piploy-build-paths-"),
+  );
+  directories.push(directory);
+  return directory;
+}
+
+function application(
+  DockerfilePath: string,
+  BuildContextPath?: string,
+): Application {
+  return {
+    Name: "app",
+    GitRepositoryUrl: "https://example.test/app.git",
+    DockerfilePath,
+    ...(BuildContextPath === undefined ? {} : { BuildContextPath }),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    directories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("resolveDockerBuildPaths", () => {
+  it("keeps the legacy Dockerfile-parent context when BuildContextPath is absent", () => {
+    const repo = "/checkout";
+    expect(() =>
+      resolveDockerBuildPaths(repo, application(" /Dockerfile.custom ")),
+    ).toThrow(
+      "Dockerfile ' /Dockerfile.custom ' does not exist. Expected location: '/checkout/Dockerfile.custom'",
+    );
+  });
+
+  it("preserves the legacy Dockerfile-parent context when the Dockerfile exists", async () => {
+    const repo = await repository();
+    await writeFile(path.join(repo, "Dockerfile.custom"), "FROM scratch\n");
+
+    expect(
+      resolveDockerBuildPaths(repo, application(" /Dockerfile.custom ")),
+    ).toEqual({
+      contextDirectory: repo,
+      dockerfilePath: "Dockerfile.custom",
+      absoluteDockerfilePath: path.join(repo, "Dockerfile.custom"),
+    });
+  });
+
+  it("uses the explicit root or nested context and a Dockerfile path relative to it", async () => {
+    const repo = await repository();
+    await mkdir(path.join(repo, "services", "api"), { recursive: true });
+    await writeFile(path.join(repo, "Dockerfile"), "FROM scratch\n");
+    await writeFile(
+      path.join(repo, "services", "api", "Dockerfile"),
+      "FROM scratch\n",
+    );
+
+    expect(
+      resolveDockerBuildPaths(repo, application("Dockerfile", ".")),
+    ).toMatchObject({
+      contextDirectory: repo,
+      dockerfilePath: "Dockerfile",
+    });
+    expect(
+      resolveDockerBuildPaths(
+        repo,
+        application("services/api/Dockerfile", "services"),
+      ),
+    ).toMatchObject({
+      contextDirectory: path.join(repo, "services"),
+      dockerfilePath: "api/Dockerfile",
+    });
+  });
+
+  it("rejects a Dockerfile outside the selected context", async () => {
+    const repo = await repository();
+    await mkdir(path.join(repo, "allowed"), { recursive: true });
+    await writeFile(path.join(repo, "Dockerfile"), "FROM scratch\n");
+
+    expect(() =>
+      resolveDockerBuildPaths(repo, application("Dockerfile", "allowed")),
+    ).toThrow("DockerfilePath must remain inside the repository build context");
+  });
+
+  it("rejects a selected context symlink that escapes the checkout", async () => {
+    const repo = await repository();
+    const outside = await repository();
+    await writeFile(path.join(outside, "Dockerfile"), "FROM scratch\n");
+    await symlink(outside, path.join(repo, "context"));
+
+    expect(() =>
+      resolveDockerBuildPaths(
+        repo,
+        application("context/Dockerfile", "context"),
+      ),
+    ).toThrow(
+      "BuildContextPath must remain inside the repository build context",
+    );
+  });
+
+  it("rejects a Dockerfile symlink that escapes the selected context", async () => {
+    const repo = await repository();
+    await mkdir(path.join(repo, "context"), { recursive: true });
+    await writeFile(path.join(repo, "outside.Dockerfile"), "FROM scratch\n");
+    await symlink(
+      "../outside.Dockerfile",
+      path.join(repo, "context", "Dockerfile"),
+    );
+
+    expect(() =>
+      resolveDockerBuildPaths(
+        repo,
+        application("context/Dockerfile", "context"),
+      ),
+    ).toThrow("DockerfilePath must remain inside the repository build context");
+  });
+});

--- a/test/unit/dockerPlan.test.ts
+++ b/test/unit/dockerPlan.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   getContainerConfigHash,
+  getBuildContextPathFromSetting,
   getDockerfilePathFromSetting,
   planContainer,
   planImage,
@@ -172,6 +173,29 @@ describe("getDockerfilePathFromSetting", () => {
   it("rejects a path that points at a directory", () => {
     expect(() => getDockerfilePathFromSetting("api/")).toThrow(
       "Invalid DockerfilePath",
+    );
+  });
+});
+
+describe("getBuildContextPathFromSetting", () => {
+  it.each([
+    [".", "."],
+    [" services/api ", "services/api"],
+    ["services\\api", "services/api"],
+  ])("normalizes %s", (setting, expected) => {
+    expect(getBuildContextPathFromSetting(setting)).toBe(expected);
+  });
+
+  it.each([
+    "",
+    "   ",
+    "/tmp",
+    "../outside",
+    "app/../../outside",
+    "..\\outside",
+  ])("rejects an empty, absolute, or escaping path: %s", (setting) => {
+    expect(() => getBuildContextPathFromSetting(setting)).toThrow(
+      "Invalid BuildContextPath",
     );
   });
 });

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -168,6 +168,7 @@ describe("mcp server", () => {
       Name: "app",
       GitRepositoryUrl: "https://example.com/app.git",
       DockerfilePath: "Dockerfile",
+      BuildContextPath: "services/app",
       PortMappings: ["8080:80"],
     };
     const { client, requests } = await start((request) =>

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -217,6 +217,33 @@ describe("parseSettings", () => {
       DATABASE_PATH: "/app/data/app.db",
     });
   });
+
+  it("preserves a valid BuildContextPath", () => {
+    const settings = parseSettings({
+      Piploy: {
+        RootDirectory: "/root",
+        Applications: [
+          { ...validApplication, BuildContextPath: "services/api" },
+        ],
+      },
+    });
+
+    expect(settings.Applications[0]?.BuildContextPath).toBe("services/api");
+  });
+
+  it.each(["", "/outside", "../outside", "services/../../outside"])(
+    "rejects an invalid BuildContextPath during configuration validation: %s",
+    (BuildContextPath) => {
+      expect(() =>
+        parseSettings({
+          Piploy: {
+            RootDirectory: "/root",
+            Applications: [{ ...validApplication, BuildContextPath }],
+          },
+        }),
+      ).toThrow("Invalid BuildContextPath");
+    },
+  );
 });
 
 describe("resolveConfigPath", () => {


### PR DESCRIPTION
Adds an optional BuildContextPath across registration and configuration, with strict checkout and realpath containment when it is set. Docker now receives only the selected context while preserving legacy Dockerfile-parent behavior for existing applications.

Closes #113