### PR TITLE
Authenticate configured GitHub owners safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,37 @@ in its ordinary diagnostics. Restart the daemon after changing its environment,
 then make a configuration or commit change that recreates the container for the
 new value to apply. Other interpolation-like values remain literal.
 
+### Private GitHub repositories
+
+`GitHubOwnerCredentials` is an optional root-level mapping for private HTTPS
+repositories. Each key is a canonical lowercase GitHub owner and each value is
+an exact daemon-environment reference. For example:
+
+```json
+{
+  "Piploy": {
+    "RootDirectory": "/home/irudd/Piploy/root",
+    "Applications": [],
+    "GitHubOwnerCredentials": {
+      "alundgren": "${hostEnv:PIPLOY_GITHUB_TOKEN}"
+    }
+  }
+}
+```
+
+Piploy reads the token only when Git asks to authenticate an HTTPS request for
+`github.com/alundgren/<repository>`. It never writes the token to
+`piploy.json`, a Git remote, a Docker context, normal logs, or CLI and MCP
+results. Other hosts, SSH URLs, URLs with userinfo, lookalike hosts, and other
+owners never receive it. Restart the daemon after setting or renewing the host
+environment variable.
+
+When a status fetch cannot complete, Piploy still reports Docker state and adds
+a safe Git diagnostic. It distinguishes a missing mapping, an unset host
+variable, a rejected credential, a repository that is missing or inaccessible,
+and a general fetch failure. GitHub's private-repository response is reported
+as "Repository not found or inaccessible", not as a bad token.
+
 ## MCP server
 
 While the daemon runs, it also serves an MCP endpoint over Streamable HTTP at:

--- a/docs/adr/0001-config-validation-and-logging.md
+++ b/docs/adr/0001-config-validation-and-logging.md
@@ -23,6 +23,25 @@ value to its normal diagnostics. A daemon-environment change takes effect only
 after restarting the daemon and a later configuration- or commit-driven
 container recreation; all other interpolation-like strings remain literal.
 
+`GitHubOwnerCredentials` is an optional root-level mapping of canonical
+lowercase GitHub owners to exact `${hostEnv:NAME}` references. Piploy retains
+only those references. It reads a mapped value only when isomorphic-git asks to
+authenticate an exact `https://github.com/<owner>/<repository>` request, then
+passes it only through that request's authentication callback. SSH URLs,
+userinfo, alternate ports, lookalike hosts, other owners, and non-GitHub hosts
+never receive a credential. Resolved GitHub values are absent from persisted
+configuration, Git remotes, Docker input and hashes, normal logs, errors, and
+CLI/MCP results. A token change takes effect after the daemon restarts.
+
+Git operations report only these safe failures across the adapter boundary:
+credential not configured, configured host variable missing, credential
+rejected, repository inaccessible or not found, and transport or fetch failure.
+Status keeps the application's Docker state when a Git fetch fails, sets
+`git` to `null`, and includes the safe diagnostic. A `null` Git value without a
+diagnostic still means the repository has not been cloned. GitHub's ambiguous
+private-repository 404 is reported as inaccessible or not found, never as a
+rejected credential.
+
 `RootDirectory` is rejected when it overlaps the data directory in either
 direction, because `wipeall` deletes `RootDirectory` recursively and
 Application data must survive it (see

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -87,6 +87,9 @@ function printStatus(status: DaemonStatus, daemonReachable: boolean): void {
     console.log(
       `  Latest remote commit: ${application.git?.remote.hash ?? "none"}`,
     );
+    if (application.gitError !== undefined) {
+      console.log(`  Git error: ${application.gitError.message}`);
+    }
     console.log(
       `  Latest image hash: ${application.docker.latestImageHash ?? "none"}`,
     );

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4,7 +4,12 @@ import path from "node:path";
 
 import { resolveTailLines } from "./containerLogs.js";
 import { createDockerService, type DockerStatus } from "./docker.js";
-import { getCommitStatus, type GitCommitStatus } from "./git.js";
+import {
+  getCommitStatus,
+  GitOperationError,
+  type GitCommitStatus,
+  type GitDiagnostic,
+} from "./git.js";
 import type { Logger } from "./logger.js";
 import { mcpPort, startMcpServer, type McpServerHandle } from "./mcp.js";
 import { getTailscaleAddress } from "./mcpTailscale.js";
@@ -72,12 +77,48 @@ export interface ApplicationDaemonStatus {
   /** Configured host-to-container mappings; empty means this Application exposes none. */
   portMappings: PortMapping[];
   git: GitCommitStatus | null;
+  /** Present only when Piploy could not safely fetch a cloned repository. */
+  gitError?: GitDiagnostic;
   docker: DockerStatus;
   isRunningLatestVersion: boolean;
 }
 
 export interface DaemonStatus {
   applications: ApplicationDaemonStatus[];
+}
+
+/** Combines one application's Git and Docker state without losing Docker on a safe Git failure. */
+export async function getApplicationStatus(
+  application: Application,
+  gitStatus: Promise<GitCommitStatus | null>,
+  dockerStatus: Promise<DockerStatus>,
+): Promise<ApplicationDaemonStatus> {
+  try {
+    const [git, resolvedDockerStatus] = await Promise.all([
+      gitStatus,
+      dockerStatus,
+    ]);
+    return {
+      application: application.Name,
+      // `PortMappings` is optional in configuration, but status is an agent
+      // API: make the no-mappings case unambiguous rather than omitting it.
+      portMappings: application.PortMappings ?? [],
+      git,
+      docker: resolvedDockerStatus,
+      isRunningLatestVersion: isRunningLatestVersion(git, resolvedDockerStatus),
+    };
+  } catch (error) {
+    if (!(error instanceof GitOperationError)) throw error;
+    const resolvedDockerStatus = await dockerStatus;
+    return {
+      application: application.Name,
+      portMappings: application.PortMappings ?? [],
+      git: null,
+      gitError: error.diagnostic,
+      docker: resolvedDockerStatus,
+      isRunningLatestVersion: false,
+    };
+  }
 }
 
 export interface DaemonDeps {
@@ -151,24 +192,6 @@ export function createDaemonDeps(
   const docker = createDockerService(settings, logger);
   const orchestrator = createOrchestrator(settings, logger);
 
-  async function getApplicationStatus(
-    application: Application,
-  ): Promise<ApplicationDaemonStatus> {
-    const [git, dockerStatus] = await Promise.all([
-      getCommitStatus(settings, application),
-      docker.getDockerStatus(application),
-    ]);
-    return {
-      application: application.Name,
-      // `PortMappings` is optional in configuration, but status is an agent
-      // API: make the no-mappings case unambiguous rather than omitting it.
-      portMappings: application.PortMappings ?? [],
-      git,
-      docker: dockerStatus,
-      isRunningLatestVersion: isRunningLatestVersion(git, dockerStatus),
-    };
-  }
-
   async function getLogs(
     name: string,
     tail?: number,
@@ -197,7 +220,13 @@ export function createDaemonDeps(
     poll: () => orchestrator.poll(),
     getStatus: async () => ({
       applications: await Promise.all(
-        settings.Applications.map(getApplicationStatus),
+        settings.Applications.map((application) =>
+          getApplicationStatus(
+            application,
+            getCommitStatus(settings, application),
+            docker.getDockerStatus(application),
+          ),
+        ),
       ),
     }),
     getLogs,

--- a/src/git.ts
+++ b/src/git.ts
@@ -7,6 +7,7 @@ import http from "isomorphic-git/http/node";
 import type { Logger } from "./logger.js";
 import {
   getApplicationRepoDirectory,
+  parseHostEnvironmentReference,
   type Application,
   type PiploySettings,
 } from "./settings.js";
@@ -21,6 +22,192 @@ export interface GitCommitStatus {
   local: GitCommit;
   remote: GitCommit;
 }
+
+export type GitFailureReason =
+  | "credential-not-configured"
+  | "credential-environment-missing"
+  | "credential-rejected"
+  | "repository-inaccessible-or-not-found"
+  | "transport-or-fetch-failure";
+
+export interface GitDiagnostic {
+  reason: GitFailureReason;
+  message: string;
+}
+
+export class GitOperationError extends Error {
+  constructor(readonly diagnostic: GitDiagnostic) {
+    super(diagnostic.message);
+    this.name = "GitOperationError";
+  }
+}
+
+class AuthenticationStoppedError extends Error {
+  constructor(readonly diagnostic: GitDiagnostic) {
+    super(diagnostic.message);
+    this.name = "AuthenticationStoppedError";
+  }
+}
+
+function diagnosticFor(
+  reason: GitFailureReason,
+  details: { environmentName?: string; owner?: string } = {},
+): GitDiagnostic {
+  switch (reason) {
+    case "credential-not-configured":
+      return {
+        reason,
+        message:
+          details.owner === undefined
+            ? "No credential is configured for this GitHub owner."
+            : `No credential is configured for GitHub owner '${details.owner}'.`,
+      };
+    case "credential-environment-missing":
+      return {
+        reason,
+        message: `Host environment variable '${details.environmentName}' is not set. Restart Piploy after setting it.`,
+      };
+    case "credential-rejected":
+      return {
+        reason,
+        message:
+          details.owner === undefined
+            ? "GitHub rejected the configured credential."
+            : `GitHub rejected the credential configured for owner '${details.owner}'.`,
+      };
+    case "repository-inaccessible-or-not-found":
+      return { reason, message: "Repository not found or inaccessible." };
+    case "transport-or-fetch-failure":
+      return { reason, message: "Git fetch failed." };
+  }
+}
+
+/** Returns the GitHub owner only for the HTTPS URL shape eligible for credentials. */
+export function credentialOwnerFromUrl(url: string): string | undefined {
+  // WHATWG URL drops an explicit default port, so the raw input must also be
+  // checked to keep this scope to exactly https://github.com.
+  if (!url.startsWith("https://github.com/")) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return undefined;
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.host !== "github.com" ||
+    parsed.username !== "" ||
+    parsed.password !== ""
+  ) {
+    return undefined;
+  }
+  if (parsed.search !== "" || parsed.hash !== "") return undefined;
+  const match = /^\/([^/]+)\/([^/]+)(?:\/.*)?$/.exec(parsed.pathname);
+  return match?.[1];
+}
+
+function httpStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const candidate = error as {
+    statusCode?: unknown;
+    data?: { statusCode?: unknown };
+  };
+  return typeof candidate.statusCode === "number"
+    ? candidate.statusCode
+    : typeof candidate.data?.statusCode === "number"
+      ? candidate.data.statusCode
+      : undefined;
+}
+
+type RemoteAuthOptions = Pick<
+  Parameters<typeof git.clone>[0],
+  "onAuth" | "onAuthFailure"
+>;
+
+/** Creates callbacks and safe error handling for one HTTPS remote operation. */
+function createGitRemoteAuthentication(settings: PiploySettings): {
+  callbacks: RemoteAuthOptions;
+  errorFor(error: unknown): GitOperationError;
+} {
+  let stopped: AuthenticationStoppedError | undefined;
+  let suppliedCredential = false;
+  let credentialOwner: string | undefined;
+
+  const stop = (
+    reason: GitFailureReason,
+    details: { environmentName?: string; owner?: string } = {},
+  ) => {
+    stopped = new AuthenticationStoppedError(diagnosticFor(reason, details));
+    return { cancel: true };
+  };
+
+  return {
+    callbacks: {
+      onAuth: (url) => {
+        const owner = credentialOwnerFromUrl(url);
+        const credentials = settings.GitHubOwnerCredentials;
+        const reference =
+          owner !== undefined &&
+          credentials !== undefined &&
+          Object.hasOwn(credentials, owner)
+            ? credentials[owner]
+            : undefined;
+        if (reference === undefined) {
+          return stop("credential-not-configured", { owner });
+        }
+
+        const environmentName = parseHostEnvironmentReference(reference);
+        if (environmentName === undefined) {
+          return stop("credential-not-configured", { owner });
+        }
+        const token = process.env[environmentName];
+        if (token === undefined) {
+          return stop("credential-environment-missing", { environmentName });
+        }
+        suppliedCredential = true;
+        credentialOwner = owner;
+        return { username: "x-access-token", password: token };
+      },
+      onAuthFailure: () => {
+        if (suppliedCredential) {
+          return stop("credential-rejected", { owner: credentialOwner });
+        }
+        return stop("credential-not-configured");
+      },
+    },
+    errorFor(error) {
+      const status = httpStatus(error);
+      if (status === 404) {
+        return new GitOperationError(
+          diagnosticFor("repository-inaccessible-or-not-found"),
+        );
+      }
+      if (stopped !== undefined)
+        return new GitOperationError(stopped.diagnostic);
+      if ((status === 401 || status === 403) && suppliedCredential) {
+        return new GitOperationError(
+          diagnosticFor("credential-rejected", { owner: credentialOwner }),
+        );
+      }
+      return new GitOperationError(diagnosticFor("transport-or-fetch-failure"));
+    },
+  };
+}
+
+/** Runs one HTTPS remote operation without retaining a resolved credential. */
+async function runRemoteOperation<T>(
+  settings: PiploySettings,
+  invoke: (authentication: RemoteAuthOptions) => Promise<T>,
+): Promise<T> {
+  const authentication = createGitRemoteAuthentication(settings);
+  try {
+    return await invoke(authentication.callbacks);
+  } catch (error) {
+    throw authentication.errorFor(error);
+  }
+}
+
+type GitHttp = Parameters<typeof git.clone>[0]["http"];
 
 function hasGitDirectory(repoDirectory: string): boolean {
   return fs.existsSync(path.join(repoDirectory, ".git"));
@@ -74,23 +261,37 @@ async function resetHard(
   await git.checkout({ fs, dir: repoDirectory, ref: branch, force: true });
 }
 
+async function fetchOrigin(
+  settings: PiploySettings,
+  repoDirectory: string,
+  gitHttp: GitHttp,
+): Promise<void> {
+  await runRemoteOperation(settings, (authentication) =>
+    git.fetch({
+      fs,
+      http: gitHttp,
+      dir: repoDirectory,
+      remote: "origin",
+      ...authentication,
+    }),
+  );
+}
+
 /** Clones `application`'s git repository if absent, otherwise fetches and hard-resets to the remote tip. */
 export async function ensureLocalRepository(
   settings: PiploySettings,
   application: Application,
   logger: Logger,
+  gitHttp: GitHttp = http,
 ): Promise<void> {
-  const log = logger.child({
-    operation: "ensureLocalRepository",
-    gitRepository: application.GitRepositoryUrl,
-  });
+  const log = logger.child({ operation: "ensureLocalRepository" });
   const repoDirectory = getApplicationRepoDirectory(settings, application);
   fs.mkdirSync(repoDirectory, { recursive: true });
 
   if (hasGitDirectory(repoDirectory)) {
     log.info("Local exists. Fetching origin");
     const branch = await resolveBranch(repoDirectory);
-    await git.fetch({ fs, http, dir: repoDirectory, remote: "origin" });
+    await fetchOrigin(settings, repoDirectory, gitHttp);
 
     const localOid = await git.resolveRef({
       fs,
@@ -113,12 +314,15 @@ export async function ensureLocalRepository(
     }
   } else {
     log.info("Cloning into remote");
-    await git.clone({
-      fs,
-      http,
-      dir: repoDirectory,
-      url: application.GitRepositoryUrl,
-    });
+    await runRemoteOperation(settings, (authentication) =>
+      git.clone({
+        fs,
+        http: gitHttp,
+        dir: repoDirectory,
+        url: application.GitRepositoryUrl,
+        ...authentication,
+      }),
+    );
   }
 }
 
@@ -139,6 +343,7 @@ export async function getLatestCommit(
 export async function getCommitStatus(
   settings: PiploySettings,
   application: Application,
+  gitHttp: GitHttp = http,
 ): Promise<GitCommitStatus | null> {
   const repoDirectory = getApplicationRepoDirectory(settings, application);
   if (!hasGitDirectory(repoDirectory)) {
@@ -146,7 +351,7 @@ export async function getCommitStatus(
   }
 
   const branch = await resolveBranch(repoDirectory);
-  await git.fetch({ fs, http, dir: repoDirectory, remote: "origin" });
+  await fetchOrigin(settings, repoDirectory, gitHttp);
 
   const localOid = await git.resolveRef({
     fs,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -77,7 +77,7 @@ function createMcpServer(dispatch: McpDispatch): McpServer {
     "status",
     {
       description:
-        "Report each registered application's configured host-to-container port mappings (an empty array means none), git commits, Docker image and container hashes, whether it runs the latest version, and its container's state, exit code, and restart count. A 'restarting' state with a non-zero exit code means the container is crash-looping.",
+        "Report each registered application's configured host-to-container port mappings (an empty array means none), git commits, Docker image and container hashes, whether it runs the latest version, and its container's state, exit code, and restart count. A 'restarting' state with a non-zero exit code means the container is crash-looping. `git: null` with `gitError` means the fetch failed; without `gitError`, the repository has not been cloned.",
     },
     async () => toolResult(await dispatch({ command: "status" })),
   );

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,5 +1,10 @@
 import { createDockerService, PortAlreadyInUseError } from "./docker.js";
-import { ensureLocalRepository, getLatestCommit } from "./git.js";
+import {
+  ensureLocalRepository,
+  getLatestCommit,
+  GitOperationError,
+  type GitDiagnostic,
+} from "./git.js";
 import type { Logger } from "./logger.js";
 import type { Application, PiploySettings } from "./settings.js";
 
@@ -29,6 +34,7 @@ export type PollApplicationResult =
       stage: PollFailureStage;
       message: string;
       code?: "portAlreadyInUse";
+      gitError?: GitDiagnostic;
     };
 
 export type PollFailureStage = "fetch" | "build" | "start";
@@ -89,12 +95,15 @@ export function createOrchestrator(
           await deps.ensureContainerRunning(application, commit);
           results.push({ application: application.Name, ok: true });
         } catch (error) {
-          logError(applicationLogger, error);
+          const gitError =
+            error instanceof GitOperationError ? error.diagnostic : undefined;
+          logError(applicationLogger, gitError?.message ?? error);
           results.push({
             application: application.Name,
             ok: false,
             stage,
-            message: errorMessage(error),
+            message: gitError?.message ?? errorMessage(error),
+            ...(gitError === undefined ? {} : { gitError }),
             ...(error instanceof PortAlreadyInUseError
               ? { code: error.code }
               : {}),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,6 +13,10 @@ import { getBuildContextPathFromSetting } from "./dockerPlan.js";
 import { isDuplicateApplicationName } from "./registerPolicy.js";
 
 const portMappingPattern = /^(\d+):(\d+)$/;
+const hostEnvironmentReferencePattern =
+  /^\$\{hostEnv:([A-Za-z_][A-Za-z0-9_]*)\}$/;
+const githubOwnerPattern =
+  /^(?=.{1,39}$)(?!.*--)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
 // The container path is a plain absolute path: no colons, because Docker reads
 // a third bind field as mount options, and at least one segment, because the
 // container root is not a mount point.
@@ -58,6 +62,32 @@ const BuildContextPathSchema = z.string().superRefine((value, ctx) => {
   }
 });
 
+/** Returns the referenced daemon environment-variable name for an exact reference. */
+export function parseHostEnvironmentReference(
+  value: string,
+): string | undefined {
+  return hostEnvironmentReferencePattern.exec(value)?.[1];
+}
+
+const HostEnvironmentReferenceSchema = z.string().superRefine((value, ctx) => {
+  if (parseHostEnvironmentReference(value) === undefined) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Must be an exact ${hostEnv:NAME} reference",
+    });
+  }
+});
+
+const GitHubOwnerCredentialsSchema = z.record(
+  z
+    .string()
+    .regex(
+      githubOwnerPattern,
+      "GitHub owner must be canonical lowercase letters, digits, or hyphens",
+    ),
+  HostEnvironmentReferenceSchema,
+);
+
 export const ApplicationSchema = z
   .object({
     Name: z.string().regex(/^[A-Za-z0-9_-]+$/),
@@ -85,6 +115,7 @@ const PiploySettingsSchema = z.object({
   RootDirectory: z.string(),
   MinutesBetweenBackgroundPolls: z.number().optional(),
   Applications: z.array(ApplicationSchema),
+  GitHubOwnerCredentials: GitHubOwnerCredentialsSchema.optional(),
   IsTestRun: z.boolean().optional(),
 });
 

--- a/test/integration/git.test.ts
+++ b/test/integration/git.test.ts
@@ -9,9 +9,11 @@ import {
 import os from "node:os";
 import path from "node:path";
 
+import gitHttp from "isomorphic-git/http/node";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  credentialOwnerFromUrl,
   ensureLocalRepository,
   getCommitStatus,
   getLatestCommit,
@@ -24,6 +26,23 @@ import type { Application, PiploySettings } from "../../src/settings.js";
 import { startGitFixtureRemote } from "./helpers/gitFixture.js";
 import type { GitFixtureRemote } from "./helpers/gitFixture.js";
 import { createSilentLogger } from "./helpers/testLogger.js";
+
+const githubOwner = "alundgren";
+const tokenEnvironmentName = "PIPLOY_GITHUB_TOKEN";
+const sentinelToken = "sentinel-github-token";
+
+function githubFixtureHttp(remote: GitFixtureRemote) {
+  return {
+    request(request: Parameters<typeof gitHttp.request>[0]) {
+      const source = new URL(request.url);
+      const fixturePath = source.pathname.replace(`/${githubOwner}`, "");
+      return gitHttp.request({
+        ...request,
+        url: `${remote.baseUrl}${fixturePath}${source.search}`,
+      });
+    },
+  };
+}
 
 describe("git", () => {
   const logger = createSilentLogger();
@@ -46,6 +65,26 @@ describe("git", () => {
   afterEach(async () => {
     await remote.close();
     rmSync(rootDirectory, { recursive: true, force: true });
+  });
+
+  describe("credential URL policy", () => {
+    it("accepts only an exact GitHub HTTPS owner repository URL", () => {
+      expect(
+        credentialOwnerFromUrl("https://github.com/alundgren/repository.git"),
+      ).toBe("alundgren");
+    });
+
+    it.each([
+      "http://github.com/alundgren/repository.git",
+      "https://github.com:443/alundgren/repository.git",
+      "https://github.com./alundgren/repository.git",
+      "https://github.com.evil.test/alundgren/repository.git",
+      "https://token@github.com/alundgren/repository.git",
+      "https://github.com/alundgren",
+      "https://github.com/alundgren/repository.git?token=secret",
+    ])("rejects a credential URL outside the exact scope: %s", (url) => {
+      expect(credentialOwnerFromUrl(url)).toBeUndefined();
+    });
   });
 
   describe("ensureLocalRepository", () => {
@@ -120,6 +159,186 @@ describe("git", () => {
       await expect(
         ensureLocalRepository(settings, application, logger),
       ).resolves.toBeUndefined();
+    });
+
+    it("normalizes a transport failure without retaining the adapter error", async () => {
+      application.GitRepositoryUrl = "http://127.0.0.1:1/repository.git";
+
+      await expect(
+        ensureLocalRepository(settings, application, logger),
+      ).rejects.toEqual(
+        expect.objectContaining({
+          name: "GitOperationError",
+          diagnostic: {
+            reason: "transport-or-fetch-failure",
+            message: "Git fetch failed.",
+          },
+        }),
+      );
+    });
+
+    it("authenticates clone and poll fetch through the GitHub callback without persisting a token", async () => {
+      const authenticatedRemote = await startGitFixtureRemote({
+        credentials: { username: "x-access-token", password: sentinelToken },
+      });
+      const originalToken = process.env[tokenEnvironmentName];
+      const messages: string[] = [];
+      const logging = {
+        debug: (message: string) => messages.push(message),
+        info: (message: string) => messages.push(message),
+        warn: (message: string) => messages.push(message),
+        error: (message: string) => messages.push(message),
+        child: () => logging,
+      };
+      try {
+        process.env[tokenEnvironmentName] = sentinelToken;
+        const authenticatedApplication: Application = {
+          Name: "authenticated",
+          GitRepositoryUrl: `https://github.com/${githubOwner}/repo.git`,
+          DockerfilePath: "Dockerfile",
+        };
+        const authenticatedSettings: PiploySettings = {
+          RootDirectory: rootDirectory,
+          Applications: [authenticatedApplication],
+          GitHubOwnerCredentials: {
+            [githubOwner]: `\${hostEnv:${tokenEnvironmentName}}`,
+          },
+        };
+        const http = githubFixtureHttp(authenticatedRemote);
+        const initialHash = authenticatedRemote.commit(
+          { "index.html": "v1" },
+          "initial",
+        );
+
+        await ensureLocalRepository(
+          authenticatedSettings,
+          authenticatedApplication,
+          logging,
+          http,
+        );
+        const nextHash = authenticatedRemote.commit(
+          { "index.html": "v2" },
+          "next",
+        );
+        await ensureLocalRepository(
+          authenticatedSettings,
+          authenticatedApplication,
+          logging,
+          http,
+        );
+        const status = await getCommitStatus(
+          authenticatedSettings,
+          authenticatedApplication,
+          http,
+        );
+
+        expect(initialHash).not.toBe(nextHash);
+        expect(status?.remote.hash).toBe(nextHash);
+        expect(
+          authenticatedRemote.authenticatedRequests(),
+        ).toBeGreaterThanOrEqual(3);
+        expect(
+          readFileSync(
+            path.join(
+              getApplicationRepoDirectory(
+                authenticatedSettings,
+                authenticatedApplication,
+              ),
+              ".git",
+              "config",
+            ),
+            "utf8",
+          ),
+        ).not.toContain(sentinelToken);
+        expect(JSON.stringify(authenticatedSettings)).not.toContain(
+          sentinelToken,
+        );
+        expect(JSON.stringify(status)).not.toContain(sentinelToken);
+        expect(messages.join("\n")).not.toContain(sentinelToken);
+      } finally {
+        if (originalToken === undefined)
+          delete process.env[tokenEnvironmentName];
+        else process.env[tokenEnvironmentName] = originalToken;
+        await authenticatedRemote.close();
+      }
+    });
+
+    it("normalizes missing, rejected, and ambiguous GitHub credential failures through real clone requests", async () => {
+      const authenticatedRemote = await startGitFixtureRemote({
+        credentials: { username: "x-access-token", password: sentinelToken },
+      });
+      const originalToken = process.env[tokenEnvironmentName];
+      const failedApplication: Application = {
+        Name: "failed-authentication",
+        GitRepositoryUrl: `https://github.com/${githubOwner}/repo.git`,
+        DockerfilePath: "Dockerfile",
+      };
+      const failedSettings: PiploySettings = {
+        RootDirectory: rootDirectory,
+        Applications: [failedApplication],
+        GitHubOwnerCredentials: {
+          [githubOwner]: `\${hostEnv:${tokenEnvironmentName}}`,
+        },
+      };
+      const http = githubFixtureHttp(authenticatedRemote);
+      authenticatedRemote.commit({ "index.html": "v1" }, "initial");
+      try {
+        delete process.env[tokenEnvironmentName];
+        await expect(
+          ensureLocalRepository(
+            failedSettings,
+            failedApplication,
+            logger,
+            http,
+          ),
+        ).rejects.toMatchObject({
+          diagnostic: {
+            reason: "credential-environment-missing",
+            message: `Host environment variable '${tokenEnvironmentName}' is not set. Restart Piploy after setting it.`,
+          },
+        });
+
+        process.env[tokenEnvironmentName] = "wrong-token";
+        await expect(
+          ensureLocalRepository(
+            failedSettings,
+            failedApplication,
+            logger,
+            http,
+          ),
+        ).rejects.toMatchObject({
+          diagnostic: {
+            reason: "credential-rejected",
+            message:
+              "GitHub rejected the credential configured for owner 'alundgren'.",
+          },
+        });
+
+        process.env[tokenEnvironmentName] = sentinelToken;
+        const missingApplication = {
+          ...failedApplication,
+          Name: "missing",
+          GitRepositoryUrl: `https://github.com/${githubOwner}/missing.git`,
+        };
+        await expect(
+          ensureLocalRepository(
+            { ...failedSettings, Applications: [missingApplication] },
+            missingApplication,
+            logger,
+            http,
+          ),
+        ).rejects.toMatchObject({
+          diagnostic: {
+            reason: "repository-inaccessible-or-not-found",
+            message: "Repository not found or inaccessible.",
+          },
+        });
+      } finally {
+        if (originalToken === undefined)
+          delete process.env[tokenEnvironmentName];
+        else process.env[tokenEnvironmentName] = originalToken;
+        await authenticatedRemote.close();
+      }
     });
   });
 

--- a/test/integration/helpers/gitFixture.ts
+++ b/test/integration/helpers/gitFixture.ts
@@ -26,9 +26,16 @@ function runGit(cwd: string, args: string[]): string {
 export interface GitFixtureRemote {
   /** The clone URL of the served fixture repository. */
   url: string;
+  /** The base URL used when a test proxy rewrites a production GitHub URL. */
+  baseUrl: string;
   /** Writes `files`, commits, and pushes to the served remote. Returns the new commit hash. */
   commit(files: Record<string, string>, message?: string): string;
+  authenticatedRequests(): number;
   close(): Promise<void>;
+}
+
+interface GitFixtureOptions {
+  credentials?: { username: string; password: string };
 }
 
 /**
@@ -37,7 +44,9 @@ export interface GitFixtureRemote {
  * communicates with remotes over HTTP(S), so a plain local-directory remote
  * cannot exercise the clone path.
  */
-export async function startGitFixtureRemote(): Promise<GitFixtureRemote> {
+export async function startGitFixtureRemote(
+  options: GitFixtureOptions = {},
+): Promise<GitFixtureRemote> {
   const root = mkdtempSync(path.join(os.tmpdir(), "piploy-git-fixture-"));
   const reposDirectory = path.join(root, "repos");
   const workDirectory = path.join(root, "work");
@@ -59,7 +68,26 @@ export async function startGitFixtureRemote(): Promise<GitFixtureRemote> {
     path.join(reposDirectory, "repo.git"),
   ]);
 
-  const server = new GitServer(reposDirectory, { autoCreate: false });
+  let authenticatedRequestCount = 0;
+  const server = new GitServer(reposDirectory, {
+    autoCreate: false,
+    ...(options.credentials === undefined
+      ? {}
+      : {
+          authenticate: ({ user }, next) =>
+            user((username, password) => {
+              if (
+                username === options.credentials!.username &&
+                password === options.credentials!.password
+              ) {
+                authenticatedRequestCount += 1;
+                next();
+                return;
+              }
+              next(new Error("Authentication rejected"));
+            }),
+        }),
+  });
   await new Promise<void>((resolve) => {
     server.listen(0, undefined, () => resolve());
   });
@@ -72,7 +100,8 @@ export async function startGitFixtureRemote(): Promise<GitFixtureRemote> {
   ) {
     throw new Error("Expected the git fixture server to bind to a TCP port");
   }
-  const url = `http://127.0.0.1:${address.port}/repo.git`;
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const url = `${baseUrl}/repo.git`;
 
   function commit(
     files: Record<string, string>,
@@ -92,5 +121,11 @@ export async function startGitFixtureRemote(): Promise<GitFixtureRemote> {
     rmSync(root, { recursive: true, force: true });
   }
 
-  return { url, commit, close };
+  return {
+    url,
+    baseUrl,
+    commit,
+    authenticatedRequests: () => authenticatedRequestCount,
+    close,
+  };
 }

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -85,6 +85,31 @@ describe("commands", () => {
     expect(output).toHaveBeenCalledWith("  Port mappings: none");
   });
 
+  it("prints a safe Git diagnostic only when the fetch failed", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => ({
+      ok: true as const,
+      status: {
+        applications: [
+          {
+            ...daemonStatus.applications[0]!,
+            gitError: {
+              reason: "repository-inaccessible-or-not-found" as const,
+              message: "Repository not found or inaccessible.",
+            },
+          },
+        ],
+      },
+    }));
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await status(deps);
+
+    expect(output).toHaveBeenCalledWith(
+      "  Git error: Repository not found or inaccessible.",
+    );
+  });
+
   it("prints the container state, exit code, and restart count", async () => {
     const deps = createDeps();
     deps.requestDaemon = vi.fn(async () => ({

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -10,11 +10,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   requestDaemon,
   startDaemon,
+  getApplicationStatus,
   type Daemon,
   type DaemonDeps,
   type DaemonResponse,
 } from "../../src/daemon.js";
 import type { Logger } from "../../src/logger.js";
+import { GitOperationError } from "../../src/git.js";
 import { loadSettings, type PiploySettings } from "../../src/settings.js";
 
 const settings: PiploySettings = {
@@ -63,6 +65,38 @@ describe("daemon", () => {
   afterEach(async () => {
     await Promise.all(daemons.splice(0).map((daemon) => daemon.stop()));
     vi.useRealTimers();
+  });
+
+  it("keeps Docker status when Git status returns a safe diagnostic", async () => {
+    const application = {
+      Name: "app",
+      GitRepositoryUrl: "https://github.com/alundgren/app.git",
+      DockerfilePath: "Dockerfile",
+    };
+
+    await expect(
+      getApplicationStatus(
+        application,
+        Promise.reject(
+          new GitOperationError({
+            reason: "credential-not-configured",
+            message:
+              "No credential is configured for GitHub owner 'alundgren'.",
+          }),
+        ),
+        Promise.resolve({ runningContainerHash: "current" }),
+      ),
+    ).resolves.toEqual({
+      application: "app",
+      portMappings: [],
+      git: null,
+      gitError: {
+        reason: "credential-not-configured",
+        message: "No credential is configured for GitHub owner 'alundgren'.",
+      },
+      docker: { runningContainerHash: "current" },
+      isRunningLatestVersion: false,
+    });
   });
 
   async function start(

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -76,6 +76,9 @@ describe("mcp server", () => {
     expect(tools.find((tool) => tool.name === "status")?.description).toContain(
       "host-to-container port mappings",
     );
+    expect(tools.find((tool) => tool.name === "status")?.description).toContain(
+      "gitError",
+    );
   });
 
   it("warns that logs are returned unredacted", async () => {

--- a/test/unit/orchestrator.test.ts
+++ b/test/unit/orchestrator.test.ts
@@ -5,6 +5,7 @@ import {
   type OrchestratorDeps,
 } from "../../src/orchestrator.js";
 import { PortAlreadyInUseError } from "../../src/docker.js";
+import { GitOperationError } from "../../src/git.js";
 import type { Logger } from "../../src/logger.js";
 import type { Application, PiploySettings } from "../../src/settings.js";
 
@@ -140,6 +141,53 @@ describe("orchestrator", () => {
         stage: "fetch",
         message: "clone failed",
       },
+    ]);
+  });
+
+  it("keeps a normalized Git failure safe in the poll result and logs", async () => {
+    const deps = createDeps();
+    const errors: string[] = [];
+    const logger = createLogger();
+    logger.error = (message) => errors.push(message);
+    deps.ensureLocalRepository = vi.fn(async () => {
+      throw new GitOperationError({
+        reason: "credential-environment-missing",
+        message:
+          "Host environment variable 'PIPLOY_GITHUB_TOKEN' is not set. Restart Piploy after setting it.",
+      });
+    });
+
+    await expect(
+      createOrchestrator(settings, logger, deps).poll(),
+    ).resolves.toEqual([
+      {
+        application: "first",
+        ok: false,
+        stage: "fetch",
+        message:
+          "Host environment variable 'PIPLOY_GITHUB_TOKEN' is not set. Restart Piploy after setting it.",
+        gitError: {
+          reason: "credential-environment-missing",
+          message:
+            "Host environment variable 'PIPLOY_GITHUB_TOKEN' is not set. Restart Piploy after setting it.",
+        },
+      },
+      {
+        application: "second",
+        ok: false,
+        stage: "fetch",
+        message:
+          "Host environment variable 'PIPLOY_GITHUB_TOKEN' is not set. Restart Piploy after setting it.",
+        gitError: {
+          reason: "credential-environment-missing",
+          message:
+            "Host environment variable 'PIPLOY_GITHUB_TOKEN' is not set. Restart Piploy after setting it.",
+        },
+      },
+    ]);
+    expect(errors).toEqual([
+      "Host environment variable 'PIPLOY_GITHUB_TOKEN' is not set. Restart Piploy after setting it.",
+      "Host environment variable 'PIPLOY_GITHUB_TOKEN' is not set. Restart Piploy after setting it.",
     ]);
   });
 

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -12,6 +12,7 @@ import {
   getDataDirectory,
   getVolumeDirectory,
   loadSettings,
+  parseHostEnvironmentReference,
   parseSettings,
   registerApplication,
   resolveBundleDirectory,
@@ -99,6 +100,50 @@ describe("parseSettings", () => {
     expect(settings.Applications[0]?.PortMappings).toBeUndefined();
     expect(settings.Applications[0]?.Volumes).toBeUndefined();
     expect(settings.Applications[0]?.EnvironmentVariables).toBeUndefined();
+    expect(settings.GitHubOwnerCredentials).toBeUndefined();
+  });
+
+  it("accepts canonical GitHub owner credential references without resolving them", () => {
+    const settings = parseSettings({
+      Piploy: {
+        RootDirectory: "/root",
+        Applications: [validApplication],
+        GitHubOwnerCredentials: {
+          alundgren: "${hostEnv:PIPLOY_GITHUB_TOKEN}",
+        },
+      },
+    });
+
+    expect(settings.GitHubOwnerCredentials).toEqual({
+      alundgren: "${hostEnv:PIPLOY_GITHUB_TOKEN}",
+    });
+  });
+
+  it.each([
+    ["Alundgren", "${hostEnv:PIPLOY_GITHUB_TOKEN}"],
+    ["alundgren--team", "${hostEnv:PIPLOY_GITHUB_TOKEN}"],
+    ["alundgren", "token"],
+    ["alundgren", "${hostEnv:1TOKEN}"],
+  ])(
+    "rejects an invalid GitHub owner credential mapping",
+    (owner, reference) => {
+      expect(() =>
+        parseSettings({
+          Piploy: {
+            RootDirectory: "/root",
+            Applications: [validApplication],
+            GitHubOwnerCredentials: { [owner]: reference },
+          },
+        }),
+      ).toThrow();
+    },
+  );
+
+  it("recognizes only an exact host environment reference", () => {
+    expect(parseHostEnvironmentReference("${hostEnv:NAME}")).toBe("NAME");
+    expect(
+      parseHostEnvironmentReference("before-${hostEnv:NAME}"),
+    ).toBeUndefined();
   });
 
   it("rejects a config missing the Piploy wrapper key", () => {


### PR DESCRIPTION
Adds an owner-scoped, callback-only GitHub credential path and safe Git diagnostics while retaining Docker status on fetch failures.

Closes #118