### PR TITLE
Fix container-name conflict flakiness on concurrent poll

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,6 +3,7 @@ import { rmSync } from "node:fs";
 import { maxLogTailLines } from "./containerLogs.js";
 import {
   createDaemonDeps,
+  isDaemonListening,
   requestDaemon,
   startDaemon,
   type Daemon,
@@ -26,6 +27,7 @@ export type RegisterResult = DaemonResponse | undefined;
 
 export interface CommandDeps {
   requestDaemon(request: DaemonRequest): Promise<DaemonResponse | undefined>;
+  isDaemonListening(): Promise<boolean>;
   computeStatusInline(): Promise<DaemonStatus>;
   pollInline(): Promise<PollApplicationResult[]>;
   register(application: unknown): Promise<RegisterResult>;
@@ -42,6 +44,7 @@ export function createCommandDeps(
   const daemonDeps = createDaemonDeps(settings, logger);
   return {
     requestDaemon,
+    isDaemonListening,
     computeStatusInline: daemonDeps.getStatus,
     pollInline: daemonDeps.poll,
     register: (application) =>
@@ -207,6 +210,16 @@ export async function logs(
 export async function poll(deps: CommandDeps): Promise<void> {
   const response = await deps.requestDaemon({ command: "poll" });
   if (response === undefined) {
+    // An unanswered request only means "run inline" when there is no daemon
+    // to race against. A daemon that is actually listening but did not
+    // reply in time is not a green light to become a second, independent
+    // poller.
+    if (await deps.isDaemonListening()) {
+      commandFailed(
+        "Background service did not respond in time. It may be busy; try 'piploy poll' again shortly.",
+      );
+      return;
+    }
     printPollResult(await deps.pollInline());
     return;
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -116,6 +116,20 @@ function getSocketPath(options: DaemonOptions): string {
   return options.socketPath ?? defaultSocketPath();
 }
 
+/**
+ * Probes whether a daemon is actually listening at the socket, as opposed to
+ * merely checking whether the socket file exists: a file can outlive a
+ * daemon that crashed or lost power, which must still fall back to
+ * reconciling inline rather than being mistaken for a live daemon that is
+ * just slow to answer. Reuses the same connect probe `removeStaleSocket`
+ * already trusts for that same distinction.
+ */
+export function isDaemonListening(
+  socketPath: string = defaultSocketPath(),
+): Promise<boolean> {
+  return canConnect(socketPath);
+}
+
 function parseRequest(value: unknown): DaemonRequest | undefined {
   if (typeof value !== "object" || value === null || !("command" in value)) {
     return undefined;

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -184,6 +184,19 @@ function isContainerAlreadyStarted(error: unknown): boolean {
   );
 }
 
+function isContainerNotFound(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error as { reason?: string }).reason === "no such container"
+  );
+}
+
+function isContainerRemovalInProgress(error: unknown): boolean {
+  return (
+    error instanceof Error && error.message.includes("is already in progress")
+  );
+}
+
 const containerConflictRecheckAttempts = 10;
 const containerConflictRecheckDelayMilliseconds = 150;
 
@@ -364,6 +377,30 @@ export function createDockerService(
     )[0];
   }
 
+  /**
+   * Waits for a container a concurrent poll is already removing to actually
+   * disappear, so this call does not try to create its replacement while the
+   * old name is still reserved. Gives up after the same bounded window used
+   * for the create-conflict recheck rather than waiting indefinitely; the
+   * subsequent create attempt surfaces a real failure if the name is still
+   * taken by then.
+   */
+  async function waitForContainerRemoval(containerId: string): Promise<void> {
+    for (
+      let attempt = 0;
+      attempt < containerConflictRecheckAttempts;
+      attempt++
+    ) {
+      try {
+        await docker.getContainer(containerId).inspect();
+      } catch (inspectError) {
+        if (isContainerNotFound(inspectError)) return;
+        throw inspectError;
+      }
+      await delay(containerConflictRecheckDelayMilliseconds);
+    }
+  }
+
   async function ensureImageExists(
     application: Application,
     commit: GitCommit,
@@ -482,9 +519,21 @@ export function createDockerService(
 
     if (containerPlan.existingContainerId) {
       logger.info(`Removing container ${containerName}`);
-      await docker
-        .getContainer(containerPlan.existingContainerId)
-        .remove({ force: true });
+      // A concurrent poll cycle can be removing (or have already removed)
+      // this same container, e.g. two pollers upgrading the same
+      // application at once. Neither outcome is a failure: the container is
+      // gone, or on its way out, either way.
+      try {
+        await docker
+          .getContainer(containerPlan.existingContainerId)
+          .remove({ force: true });
+      } catch (removeError) {
+        if (isContainerRemovalInProgress(removeError)) {
+          await waitForContainerRemoval(containerPlan.existingContainerId);
+        } else if (!isContainerNotFound(removeError)) {
+          throw removeError;
+        }
+      }
     }
 
     const portBindings: Record<string, Array<{ HostPort: string }>> = {};

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -19,6 +19,7 @@ import {
   getDockerfilePathFromSetting,
   planContainer,
   planImage,
+  planRacedContainer,
   resolveContainerEnvironmentVariables,
   type DockerContainer,
   validateDockerfileImageReferences,
@@ -167,6 +168,27 @@ function isPortAlreadyAllocated(error: unknown): boolean {
     error instanceof Error &&
     error.message.includes("port is already allocated")
   );
+}
+
+function isContainerNameConflict(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes("is already in use by container")
+  );
+}
+
+function isContainerAlreadyStarted(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error as { reason?: string }).reason === "container already started"
+  );
+}
+
+const containerConflictRecheckAttempts = 10;
+const containerConflictRecheckDelayMilliseconds = 150;
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 function followBuildProgress(
@@ -435,7 +457,14 @@ export function createDockerService(
     }
     if (containerPlan.action === "start") {
       logger.info(`Starting container ${containerName}`);
-      await docker.getContainer(containerPlan.containerId).start();
+      // A concurrent poll can independently reach the same "start" decision
+      // for this container and win the race to start it first; that is the
+      // desired end state, not a failure.
+      try {
+        await docker.getContainer(containerPlan.containerId).start();
+      } catch (startError) {
+        if (!isContainerAlreadyStarted(startError)) throw startError;
+      }
       return {
         wasCreated: false,
         wasStarted: true,
@@ -471,19 +500,70 @@ export function createDockerService(
     }
 
     logger.info(`Creating container ${containerName}`);
-    const createdContainer = await docker.createContainer({
-      Image: getImageVersionTagCommit(application.Name, commit),
-      name: containerName,
-      Env: environment,
-      ExposedPorts: exposedPorts,
-      HostConfig: {
-        PortBindings: portBindings,
-        Binds: binds,
-        LogConfig: containerLogConfig,
-        RestartPolicy: containerRestartPolicy,
-      },
-      Labels: { [containerConfigLabelName]: configHash },
-    });
+    let createdContainer: Dockerode.Container;
+    try {
+      createdContainer = await docker.createContainer({
+        Image: getImageVersionTagCommit(application.Name, commit),
+        name: containerName,
+        Env: environment,
+        ExposedPorts: exposedPorts,
+        HostConfig: {
+          PortBindings: portBindings,
+          Binds: binds,
+          LogConfig: containerLogConfig,
+          RestartPolicy: containerRestartPolicy,
+        },
+        Labels: { [containerConfigLabelName]: configHash },
+      });
+    } catch (error) {
+      if (!isContainerNameConflict(error)) throw error;
+
+      // Another poll cycle created the container between our findContainer
+      // check and this create call. Docker reserves the container name
+      // before it registers the container where listContainers can see it,
+      // so the winner can briefly be invisible even though the name is
+      // already taken; poll for it a few times rather than failing on the
+      // first miss.
+      let racedContainer = await findContainer(containerName);
+      for (
+        let attempt = 0;
+        !racedContainer && attempt < containerConflictRecheckAttempts;
+        attempt++
+      ) {
+        await delay(containerConflictRecheckDelayMilliseconds);
+        racedContainer = await findContainer(containerName);
+      }
+      const racedPlan = planRacedContainer(
+        racedContainer ? asDockerContainer(racedContainer) : undefined,
+        commit.hash,
+        configHash,
+      );
+      if (racedPlan.action === "fail") throw error;
+
+      if (racedPlan.action === "adopt") {
+        logger.info(
+          `Container ${containerName} was already created by a concurrent poll; reusing it`,
+        );
+        return {
+          wasCreated: false,
+          wasStarted: false,
+          containerId: racedPlan.containerId,
+        };
+      }
+      logger.info(
+        `Container ${containerName} was already created by a concurrent poll; starting it`,
+      );
+      try {
+        await docker.getContainer(racedPlan.containerId).start();
+      } catch (startError) {
+        if (!isContainerAlreadyStarted(startError)) throw startError;
+      }
+      return {
+        wasCreated: false,
+        wasStarted: true,
+        containerId: racedPlan.containerId,
+      };
+    }
     try {
       logger.info(`Starting container ${containerName}`);
       await createdContainer.start();

--- a/src/dockerPlan.ts
+++ b/src/dockerPlan.ts
@@ -32,6 +32,11 @@ export type ContainerPlan =
   | { action: "start"; containerId: string }
   | { action: "recreate"; existingContainerId?: string };
 
+export type RacedContainerPlan =
+  | { action: "adopt"; containerId: string }
+  | { action: "start"; containerId: string }
+  | { action: "fail" };
+
 export interface DockerfilePath {
   contextDirectory: string;
   dockerfileName: string;
@@ -97,6 +102,38 @@ export function planContainer(
   }
 
   return { action: "recreate", existingContainerId: existingContainer.id };
+}
+
+/**
+ * Decides what to do with a container that a concurrent poll created after a
+ * name-conflict create failure. Unlike planContainer, an unusable state here
+ * does not mean "recreate": the caller has already lost the create race, so
+ * removing this container would only invite another conflict. A container
+ * whose labels match the requested commit and config is exactly the one this
+ * call wanted, and is started (a race winner is not yet running the instant
+ * after Docker registers its name) unless it already is. A mismatch, or no
+ * container at all, means the name conflict was real, not benign.
+ */
+export function planRacedContainer(
+  existingContainer: DockerContainer | undefined,
+  gitTipCommit: string,
+  configHash: string,
+): RacedContainerPlan {
+  if (
+    !existingContainer ||
+    existingContainer.gitTipCommit !== gitTipCommit ||
+    existingContainer.configHash !== configHash
+  ) {
+    return { action: "fail" };
+  }
+
+  if (
+    existingContainer.state === "running" ||
+    existingContainer.state === "restarting"
+  ) {
+    return { action: "adopt", containerId: existingContainer.id };
+  }
+  return { action: "start", containerId: existingContainer.id };
 }
 
 /**

--- a/test/integration/docker.test.ts
+++ b/test/integration/docker.test.ts
@@ -54,9 +54,19 @@ const contextApplication = {
   DockerfilePath: "context/Dockerfile",
   BuildContextPath: "context",
 };
+const raceApplication = {
+  Name: `${applicationName}race`,
+  GitRepositoryUrl: "https://example.invalid/integration.git",
+  DockerfilePath: "Dockerfile",
+};
 const settings: PiploySettings = {
   RootDirectory: path.join(temporaryDirectory, "root"),
-  Applications: [application, crashingApplication, contextApplication],
+  Applications: [
+    application,
+    crashingApplication,
+    contextApplication,
+    raceApplication,
+  ],
   IsTestRun: true,
 };
 const docker = createDockerService(settings, logger);
@@ -250,6 +260,58 @@ describe("docker adapter", () => {
         }),
       ).rejects.toThrow();
     }
+
+    await docker.cleanupTestCreated();
+  });
+
+  it("resolves a concurrent create race for the same version but not a mismatched one", async () => {
+    const repoDirectory = path.join(
+      settings.RootDirectory,
+      raceApplication.Name,
+      "repo",
+    );
+    await mkdir(repoDirectory, { recursive: true });
+    await writeFile(
+      path.join(repoDirectory, "Dockerfile"),
+      'FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc\nCMD ["sh", "-c", "while true; do sleep 3600; done"]\n',
+    );
+
+    const raceCommit = { hash: crypto.randomUUID().replaceAll("-", "") };
+    await docker.ensureImageExists(raceApplication, raceCommit);
+
+    // Two pollers racing to create the SAME version: the loser must detect
+    // that the winner already created exactly the container it wanted, and
+    // adopt it instead of failing.
+    const sameVersionResults = await Promise.all([
+      docker.ensureContainerRunning(raceApplication, raceCommit),
+      docker.ensureContainerRunning(raceApplication, raceCommit),
+    ]);
+    expect(sameVersionResults[0].containerId).toBe(
+      sameVersionResults[1].containerId,
+    );
+    expect(sameVersionResults.filter((r) => r.wasCreated)).toHaveLength(1);
+
+    await docker.cleanupTestCreated();
+
+    // Two pollers racing to create DIFFERENT versions: the loser must not
+    // silently adopt the winner's container, since that would leave the
+    // wrong version running while reporting success.
+    const otherCommit = { hash: crypto.randomUUID().replaceAll("-", "") };
+    await docker.ensureImageExists(raceApplication, raceCommit);
+    await docker.ensureImageExists(raceApplication, otherCommit);
+
+    const mismatchedResults = await Promise.allSettled([
+      docker.ensureContainerRunning(raceApplication, raceCommit),
+      docker.ensureContainerRunning(raceApplication, otherCommit),
+    ]);
+    expect(
+      mismatchedResults.filter((r) => r.status === "fulfilled"),
+    ).toHaveLength(1);
+    const rejected = mismatchedResults.find((r) => r.status === "rejected");
+    expect(rejected).toBeDefined();
+    expect(String((rejected as PromiseRejectedResult).reason)).toContain(
+      "already in use by container",
+    );
 
     await docker.cleanupTestCreated();
   });

--- a/test/integration/docker.test.ts
+++ b/test/integration/docker.test.ts
@@ -314,5 +314,31 @@ describe("docker adapter", () => {
     );
 
     await docker.cleanupTestCreated();
+
+    // Two pollers racing to upgrade the SAME existing container to the SAME
+    // new version: both plan "recreate" against the same
+    // existingContainerId, so one's remove() can hit the other's already
+    // completed (or in-progress) removal. Neither should surface as a
+    // failure, and both must land on the same replacement container.
+    const upgradeFromCommit = { hash: crypto.randomUUID().replaceAll("-", "") };
+    const upgradeToCommit = { hash: crypto.randomUUID().replaceAll("-", "") };
+    await docker.ensureImageExists(raceApplication, upgradeFromCommit);
+    await docker.ensureImageExists(raceApplication, upgradeToCommit);
+    const upgradeFromResult = await docker.ensureContainerRunning(
+      raceApplication,
+      upgradeFromCommit,
+    );
+    expect(upgradeFromResult.wasCreated).toBe(true);
+
+    const upgradeResults = await Promise.all([
+      docker.ensureContainerRunning(raceApplication, upgradeToCommit),
+      docker.ensureContainerRunning(raceApplication, upgradeToCommit),
+    ]);
+    expect(upgradeResults[0].containerId).toBe(upgradeResults[1].containerId);
+    expect(upgradeResults[0].containerId).not.toBe(
+      upgradeFromResult.containerId,
+    );
+
+    await docker.cleanupTestCreated();
   });
 });

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -36,6 +36,7 @@ const daemonStatus: DaemonStatus = {
 function createDeps(): CommandDeps {
   return {
     requestDaemon: vi.fn(),
+    isDaemonListening: vi.fn(async () => false),
     computeStatusInline: vi.fn(async () => daemonStatus),
     pollInline: vi.fn(async () => []),
     register: vi.fn(),
@@ -300,6 +301,21 @@ describe("commands", () => {
     await poll(deps);
 
     expect(deps.pollInline).toHaveBeenCalledOnce();
+  });
+
+  it("does not become a second poller when a live daemon just did not answer in time", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => undefined);
+    deps.isDaemonListening = vi.fn(async () => true);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await poll(deps);
+
+    expect(deps.pollInline).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      "Background service did not respond in time. It may be busy; try 'piploy poll' again shortly.",
+    );
+    expect(process.exitCode).toBe(1);
   });
 
   it("reports a failed daemon poll request without an inline fallback", async () => {

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -8,6 +8,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  isDaemonListening,
   requestDaemon,
   startDaemon,
   type Daemon,
@@ -651,6 +652,29 @@ describe("daemon", () => {
       await client.close();
 
       expect(events).toEqual(["poll", "poll"]);
+    });
+  });
+
+  describe("isDaemonListening", () => {
+    it("is true while a daemon is listening at the socket", async () => {
+      const daemon = await start({
+        getLogs: noLogs,
+        poll: async () => [],
+        getStatus: async () => ({ applications: [] }),
+        attemptSelfUpdate: async () => "up-to-date",
+      });
+
+      await expect(isDaemonListening(daemon.socketPath)).resolves.toBe(true);
+    });
+
+    it("is false for a stale socket file left behind by a daemon that crashed", async () => {
+      const socketPath = path.join(
+        await mkdtemp(path.join(os.tmpdir(), "piploy-")),
+        "piploy.sock",
+      );
+      await writeFile(socketPath, "");
+
+      await expect(isDaemonListening(socketPath)).resolves.toBe(false);
     });
   });
 });

--- a/test/unit/dockerPlan.test.ts
+++ b/test/unit/dockerPlan.test.ts
@@ -8,6 +8,7 @@ import {
   getDockerfilePathFromSetting,
   planContainer,
   planImage,
+  planRacedContainer,
   resolveContainerEnvironmentVariables,
   validateDockerfileImageReferences,
 } from "../../src/dockerPlan.js";
@@ -169,6 +170,91 @@ describe("planContainer", () => {
 
     expect(getContainerConfigHash({})).not.toBe(previousHash);
   });
+});
+
+describe("planRacedContainer", () => {
+  const configHash = getContainerConfigHash({});
+
+  it("fails when no container won the race", () => {
+    expect(planRacedContainer(undefined, "commit", configHash)).toEqual({
+      action: "fail",
+    });
+  });
+
+  it("fails when the container that won the race is a different commit", () => {
+    expect(
+      planRacedContainer(
+        {
+          id: "container",
+          state: "running",
+          gitTipCommit: "other",
+          configHash,
+        },
+        "commit",
+        configHash,
+      ),
+    ).toEqual({ action: "fail" });
+  });
+
+  it("fails when the container that won the race has a different config", () => {
+    expect(
+      planRacedContainer(
+        {
+          id: "container",
+          state: "running",
+          gitTipCommit: "commit",
+          configHash: getContainerConfigHash({
+            portMappings: [{ hostPort: 8080, containerPort: 80 }],
+          }),
+        },
+        "commit",
+        configHash,
+      ),
+    ).toEqual({ action: "fail" });
+  });
+
+  it("adopts a running container that matches the requested commit and config", () => {
+    expect(
+      planRacedContainer(
+        {
+          id: "container",
+          state: "running",
+          gitTipCommit: "commit",
+          configHash,
+        },
+        "commit",
+        configHash,
+      ),
+    ).toEqual({ action: "adopt", containerId: "container" });
+  });
+
+  it("adopts a restarting container that matches the requested commit and config", () => {
+    expect(
+      planRacedContainer(
+        {
+          id: "container",
+          state: "restarting",
+          gitTipCommit: "commit",
+          configHash,
+        },
+        "commit",
+        configHash,
+      ),
+    ).toEqual({ action: "adopt", containerId: "container" });
+  });
+
+  it.each(["created", "exited", "paused"] as const)(
+    "starts a matching container still in the %s state",
+    (state) => {
+      expect(
+        planRacedContainer(
+          { id: "container", state, gitTipCommit: "commit", configHash },
+          "commit",
+          configHash,
+        ),
+      ).toEqual({ action: "start", containerId: "container" });
+    },
+  );
 });
 
 describe("resolveContainerEnvironmentVariables", () => {


### PR DESCRIPTION
## Summary
- Fixes #125: `node piploy.cjs poll` occasionally failed with a Docker 409 "container name already in use" error that always succeeded on the very next call. Two pollers racing to reconcile the same application could both create/start/remove the same container at once.
- **First-deploy race:** `ensureContainerRunning` in `src/docker.ts` does a check-then-act (`findContainer` then `createContainer`/`start`) with no locking. Added a pure policy function `planRacedContainer` (`src/dockerPlan.ts`) that, after a name conflict, decides whether to adopt the container that won the race — but only when its commit and config labels match what this call wanted. A genuine mismatch (a different version) is never silently swallowed. Also tolerates the "already started" 304 a lost start race produces, in both the plain start path and the raced-adopt path.
- **Upgrade race:** two pollers upgrading the same application at once both plan to remove the old container, so the loser's `remove()` can hit a 404 ("no such container") or a 409 ("removal already in progress"). Both are now tolerated: a missing container is treated as already gone, and an in-progress removal is waited out before creating the replacement.
- **Root cause in the CLI:** `poll` fell back to an independent inline reconciliation whenever the daemon didn't answer within the connect probe window — exactly how two pollers could exist in the first place. It now only takes that fallback when no daemon is actually listening at the socket (a real connect probe, the same one the daemon's own stale-socket cleanup already trusts), not whenever a request goes unanswered. A stale socket file left behind by a crashed daemon still falls back correctly, so an unattended host keeps self-healing.
- Reproduced the original 409 deterministically with a real-Docker integration test before fixing it, and added permanent regression tests for all three race scenarios (first-deploy same/different version, upgrade race) plus daemon-listening-probe tests against a real daemon and a real stale socket file.
- Filed #127 separately for a related, pre-existing bug found during review (`findContainer`'s name filter matches by substring, so one application's name being a prefix of another's can hand `remove({force: true})` the wrong container) — out of scope for this PR.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (212/212 unit tests)
- [x] `pnpm test:integration -- docker.test.ts` (4/4, run repeatedly with no flakes, covers all three race scenarios)
- [x] Reviewed by the tech-lead teammate across three rounds; all blocking feedback addressed (304/404/409 tolerance, moving the raced-container decision into `dockerPlan.ts` under unit test, using a real connect probe instead of socket-file existence so a crashed daemon's stale socket doesn't permanently disable poll)

Note: `test/integration/pnpmPolicy.test.ts` fails in this sandbox because `pnpm` isn't a directly spawnable binary here — confirmed pre-existing and unrelated via `git stash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)