### PR TITLE
Keep re-included files in Docker build contexts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "build": "tsup && node scripts/verifyBundle.mjs"
   },
   "dependencies": {
+    "@balena/dockerignore": "^1.0.2",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "commander": "^14.0.0",
     "dockerode": "^5.0.1",
     "isomorphic-git": "^1.40.0",
+    "tar-fs": "^2.1.5",
     "pino": "^10.3.1",
     "zod": "^4.4.3"
   },
@@ -25,6 +27,7 @@
     "@eslint/js": "^9.39.1",
     "@types/dockerode": "^4.0.1",
     "@types/node": "^24.10.1",
+    "@types/tar-fs": "^2.0.4",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
     "node-git-server": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@balena/dockerignore':
+        specifier: ^1.0.2
+        version: 1.0.2
       '@modelcontextprotocol/sdk':
         specifier: ^1.30.0
         version: 1.30.0(supports-color@7.2.0)(zod@4.4.3)
@@ -26,6 +29,9 @@ importers:
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      tar-fs:
+        specifier: ^2.1.5
+        version: 2.1.5
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -39,6 +45,9 @@ importers:
       '@types/node':
         specifier: ^24.10.1
         version: 24.13.3
+      '@types/tar-fs':
+        specifier: ^2.0.4
+        version: 2.0.4
       eslint:
         specifier: ^9.39.1
         version: 9.39.5(supports-color@7.2.0)
@@ -646,6 +655,12 @@ packages:
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
+  '@types/tar-fs@2.0.4':
+    resolution: {integrity: sha512-ipPec0CjTmVDWE+QKr9cTmIIoTl7dFG/yARCM5MqK8i6CNLIG1P8x4kwDsOQY1ChZOZjH0wO9nvfgBvWl4R3kA==}
+
+  '@types/tar-stream@3.1.4':
+    resolution: {integrity: sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==}
+
   '@typescript-eslint/eslint-plugin@8.65.0':
     resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1064,6 +1079,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -2534,6 +2550,15 @@ snapshots:
   '@types/ssh2@1.15.5':
     dependencies:
       '@types/node': 18.19.130
+
+  '@types/tar-fs@2.0.4':
+    dependencies:
+      '@types/node': 24.13.3
+      '@types/tar-stream': 3.1.4
+
+  '@types/tar-stream@3.1.4':
+    dependencies:
+      '@types/node': 24.13.3
 
   '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -2,13 +2,15 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
-  readdirSync,
   realpathSync,
   statSync,
 } from "node:fs";
 import path from "node:path";
+import { createGzip } from "node:zlib";
 
+import DockerIgnore from "@balena/dockerignore";
 import Dockerode from "dockerode";
+import { pack } from "tar-fs";
 
 import { decodeContainerLog, limitLogBytes } from "./containerLogs.js";
 import {
@@ -222,7 +224,7 @@ function followBuildProgress(
 
 function buildImage(
   docker: Dockerode,
-  context: Dockerode.ImageBuildContext,
+  context: NodeJS.ReadableStream,
   options: PiployImageBuildOptions,
 ): Promise<NodeJS.ReadableStream> {
   // @types/dockerode incorrectly only permits one tag, while the daemon API
@@ -237,6 +239,45 @@ interface DockerBuildPaths {
   contextDirectory: string;
   dockerfilePath: string;
   absoluteDockerfilePath: string;
+}
+
+function createBuildContext(
+  buildPaths: DockerBuildPaths,
+): NodeJS.ReadableStream {
+  const dockerfileIgnorePath = `${buildPaths.absoluteDockerfilePath}.dockerignore`;
+  const ignorePath = existsSync(dockerfileIgnorePath)
+    ? dockerfileIgnorePath
+    : path.join(buildPaths.contextDirectory, ".dockerignore");
+  const protectedPaths = [
+    path.relative(
+      buildPaths.contextDirectory,
+      buildPaths.absoluteDockerfilePath,
+    ),
+    path.relative(buildPaths.contextDirectory, ignorePath),
+  ].map((filePath) => filePath.replaceAll(path.sep, "/"));
+  const dockerIgnore = existsSync(ignorePath)
+    ? DockerIgnore.default({ ignorecase: false }).add(
+        readFileSync(ignorePath, "utf8"),
+      )
+    : undefined;
+
+  return pack(buildPaths.contextDirectory, {
+    ignore(filePath) {
+      const relativePath = path
+        .relative(buildPaths.contextDirectory, filePath)
+        .replaceAll(path.sep, "/");
+      const mustInclude = protectedPaths.some(
+        (protectedPath) =>
+          relativePath === protectedPath ||
+          protectedPath.startsWith(`${relativePath}/`),
+      );
+      return (
+        relativePath !== "" &&
+        !mustInclude &&
+        dockerIgnore?.ignores(relativePath) === true
+      );
+    },
+  }).pipe(createGzip());
 }
 
 function isContainedBy(parent: string, child: string): boolean {
@@ -431,10 +472,7 @@ export function createDockerService(
     logger.info(`Building docker image for commit ${commit.hash}`);
     const buildStream = await buildImage(
       docker,
-      {
-        context: buildPaths.contextDirectory,
-        src: readdirSync(buildPaths.contextDirectory),
-      },
+      createBuildContext(buildPaths),
       {
         dockerfile: buildPaths.dockerfilePath,
         t: [

--- a/test/integration/docker.test.ts
+++ b/test/integration/docker.test.ts
@@ -54,6 +54,11 @@ const contextApplication = {
   DockerfilePath: "context/Dockerfile",
   BuildContextPath: "context",
 };
+const dockerIgnoreApplication = {
+  Name: `${applicationName}dockerignore`,
+  GitRepositoryUrl: "https://example.invalid/integration.git",
+  DockerfilePath: "Dockerfile",
+};
 const raceApplication = {
   Name: `${applicationName}race`,
   GitRepositoryUrl: "https://example.invalid/integration.git",
@@ -65,6 +70,7 @@ const settings: PiploySettings = {
     application,
     crashingApplication,
     contextApplication,
+    dockerIgnoreApplication,
     raceApplication,
   ],
   IsTestRun: true,
@@ -260,6 +266,32 @@ describe("docker adapter", () => {
         }),
       ).rejects.toThrow();
     }
+
+    await docker.cleanupTestCreated();
+  });
+
+  it("keeps re-included files in a dockerignore build context", async () => {
+    const repoDirectory = path.join(
+      settings.RootDirectory,
+      dockerIgnoreApplication.Name,
+      "repo",
+    );
+    await mkdir(path.join(repoDirectory, "src"), { recursive: true });
+    await writeFile(
+      path.join(repoDirectory, ".dockerignore"),
+      "*\n!Dockerfile\n!src/\n!src/**\n",
+    );
+    await writeFile(path.join(repoDirectory, "src", "probe.txt"), "present\n");
+    await writeFile(
+      path.join(repoDirectory, "Dockerfile"),
+      'FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc\nCOPY src/probe.txt /probe.txt\nRUN test "$(cat /probe.txt)" = present\n',
+    );
+
+    await expect(
+      docker.ensureImageExists(dockerIgnoreApplication, {
+        hash: crypto.randomUUID().replaceAll("-", ""),
+      }),
+    ).resolves.toMatchObject({ wasCreated: true });
 
     await docker.cleanupTestCreated();
   });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
   // Piploy ships only this bundle. Keep every runtime dependency in it rather
   // than relying on a node_modules directory beside the deployed artifact.
   noExternal: [
-    /^(commander|dockerode|isomorphic-git|pino|zod)(\/.*)?$/,
+    /^(@balena\/dockerignore|commander|dockerode|isomorphic-git|pino|tar-fs|zod)(\/.*)?$/,
     // The MCP SDK reaches ajv through its JSON Schema validation, and ajv
     // requires its runtime helpers by subpath.
     /^(@modelcontextprotocol\/sdk|ajv|ajv-formats)(\/.*)?$/,


### PR DESCRIPTION
Piploy now creates its Docker build archive with Docker-compatible ignore matching before sending it to the daemon. The bundled CLI includes the archive dependencies, and a real-Docker regression covers re-included source files.

Closes #124