### PR TITLE
Add safe GitHub repository access check

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,18 @@ tailnet and from nowhere else. There is no token and no other authentication:
 being on the tailnet is the whole of it. If the machine has no Tailscale
 address, the daemon logs a warning and starts anyway, without the endpoint.
 
-It exposes six tools — `status`, `logs`, `poll`, `register`, `service-start`,
-and `service-stop` — which run exactly what the matching CLI commands do.
+It exposes seven tools — `status`, `logs`, `poll`, `register`, `service-start`,
+`service-stop`, and `check-github-repository-access`. All except
+`service-start` pass through the daemon's command queue; `service-start`
+reports that the already-running daemon is available and enqueues nothing. The
+repository-access check accepts only one
+repository-name segment and always targets `alundgren` on GitHub. It performs a
+bounded, shallow temporary clone to verify access, then removes that checkout.
+It never registers an Application, changes `piploy.json`, runs Docker, or
+returns repository contents, paths, credentials, URLs with credentials, raw
+Git errors, or logs. Its safe result distinguishes missing credentials, an
+unset credential environment variable, rejected credentials, an inaccessible
+repository, and timeout or network failures.
 `wipeall` and `self-update` are deliberately not exposed. See
 [ADR-0008](docs/adr/0008-mcp-server-tailscale-only.md).
 

--- a/docs/adr/0008-mcp-server-tailscale-only.md
+++ b/docs/adr/0008-mcp-server-tailscale-only.md
@@ -22,8 +22,15 @@ deferred because they add a runtime dependency on the binary or local socket.
 
 ## Exposed tools
 
-The server registers exactly six tools: `status`, `logs`, `poll`, `register`,
-`service-start`, and `service-stop`. `logs` belongs here because it is
+The server registers exactly seven tools: `status`, `logs`, `poll`, `register`,
+`service-start`, `service-stop`, and `check-github-repository-access`. The
+repository-access check accepts one repository-name segment only, fixes the
+owner to `alundgren`, and constructs the GitHub URL inside the daemon. It uses
+a bounded shallow clone in an operating-system temporary directory and removes
+that checkout afterward. It returns only a typed, redacted access result: no
+checkout path, repository content, credentials, raw Git error, or logs. It
+does not register an Application, change configuration, build, or touch Docker.
+`logs` belongs here because it is
 read-only; it returns a bounded tail of one Application's container output,
 unredacted, so anything on the tailnet can read whatever that Application
 prints. `wipeall` and `self-update` are excluded,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -5,10 +5,12 @@ import path from "node:path";
 import { resolveTailLines } from "./containerLogs.js";
 import { createDockerService, type DockerStatus } from "./docker.js";
 import {
+  checkGitHubRepositoryAccess,
   getCommitStatus,
   GitOperationError,
   type GitCommitStatus,
   type GitDiagnostic,
+  type GitHubRepositoryAccessResult,
 } from "./git.js";
 import type { Logger } from "./logger.js";
 import { mcpPort, startMcpServer, type McpServerHandle } from "./mcp.js";
@@ -39,6 +41,7 @@ export type DaemonRequest =
   | { command: "poll" }
   | { command: "stop" }
   | { command: "logs"; application: string; tail?: number }
+  | { command: "check-github-repository-access"; repository: string }
   | { command: "register"; application: unknown };
 
 export type DaemonResponse =
@@ -46,6 +49,7 @@ export type DaemonResponse =
   | { ok: true; applications: PollApplicationResult[] }
   | { ok: true; application: Application }
   | { ok: true; logs: ApplicationLogs }
+  | { ok: true; repositoryAccess: GitHubRepositoryAccessResult }
   | { ok: true }
   | {
       ok: false;
@@ -125,6 +129,9 @@ export interface DaemonDeps {
   poll(): Promise<PollApplicationResult[]>;
   getStatus(): Promise<DaemonStatus>;
   getLogs(application: string, tail?: number): Promise<ApplicationLogsResult>;
+  checkGitHubRepositoryAccess(
+    repository: string,
+  ): Promise<GitHubRepositoryAccessResult>;
   attemptSelfUpdate(): Promise<SelfUpdateResult>;
 }
 
@@ -192,6 +199,10 @@ function parseRequest(value: unknown): DaemonRequest | undefined {
         : undefined;
     return { command: "logs", application: value.application, tail };
   }
+  if (command === "check-github-repository-access" && "repository" in value) {
+    if (typeof value.repository !== "string") return undefined;
+    return { command, repository: value.repository };
+  }
   return undefined;
 }
 
@@ -244,6 +255,8 @@ export function createDaemonDeps(
       ),
     }),
     getLogs,
+    checkGitHubRepositoryAccess: (repository) =>
+      checkGitHubRepositoryAccess(settings, repository),
     attemptSelfUpdate: () => attemptSelfUpdate(logger),
   };
 }
@@ -429,6 +442,13 @@ export async function startDaemon(
             ? { ok: true, logs: result.logs }
             : { ok: false, reason: result.reason };
         }
+        case "check-github-repository-access":
+          return {
+            ok: true,
+            repositoryAccess: await deps.checkGitHubRepositoryAccess(
+              request.repository,
+            ),
+          };
         case "stop":
           return { ok: true };
         case "register":

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 
 import git from "isomorphic-git";
@@ -29,6 +31,13 @@ export type GitFailureReason =
   | "credential-rejected"
   | "repository-inaccessible-or-not-found"
   | "transport-or-fetch-failure";
+
+export type GitHubRepositoryAccessResult =
+  | { accessible: true }
+  | {
+      accessible: false;
+      reason: GitFailureReason | "invalid-repository-name";
+    };
 
 export interface GitDiagnostic {
   reason: GitFailureReason;
@@ -207,7 +216,158 @@ async function runRemoteOperation<T>(
   }
 }
 
-type GitHttp = Parameters<typeof git.clone>[0]["http"];
+type GitHttp = NonNullable<Parameters<typeof git.clone>[0]["http"]>;
+type GitHttpRequest = Parameters<GitHttp["request"]>[0];
+type GitHttpResponse = Awaited<ReturnType<GitHttp["request"]>>;
+
+const githubRepositoryNamePattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$/;
+const githubAccessTemporaryDirectoryPrefix = "piploy-github-access-";
+const githubAccessTimeoutMilliseconds = 10_000;
+
+/** Accepts one GitHub repository-name segment, never a URL or path. */
+export function isGitHubRepositoryName(value: string): boolean {
+  return (
+    value !== "." && value !== ".." && githubRepositoryNamePattern.test(value)
+  );
+}
+
+async function bodyBuffer(
+  body: GitHttpRequest["body"],
+): Promise<Buffer | undefined> {
+  if (body === undefined) return undefined;
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of body) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+/**
+ * The bundled isomorphic-git Node adapter ignores `signal`. This small adapter
+ * makes the qualification clone cancellable so cleanup cannot race it.
+ */
+function createAbortableGitHttp(signal: AbortSignal): GitHttp {
+  return {
+    async request({ url, method = "GET", headers = {}, body }) {
+      const response = await fetch(url, {
+        method,
+        headers,
+        body: (await bodyBuffer(body)) as unknown as BodyInit | undefined,
+        signal,
+      });
+      const responseHeaders: Record<string, string> = {};
+      response.headers.forEach((value, name) => {
+        responseHeaders[name] = value;
+      });
+      return {
+        url: response.url,
+        method,
+        headers: responseHeaders,
+        statusCode: response.status,
+        statusMessage: response.statusText,
+        body:
+          response.body === null
+            ? undefined
+            : (async function* () {
+                for await (const chunk of response.body!) yield chunk;
+              })(),
+      } satisfies GitHttpResponse;
+    },
+  };
+}
+
+function withAbortSignal(http: GitHttp, signal: AbortSignal): GitHttp {
+  return {
+    request: (request) => http.request({ ...request, signal }),
+  };
+}
+
+function isGithubAccessTemporaryDirectory(directory: string): boolean {
+  return (
+    path.dirname(path.resolve(directory)) === path.resolve(os.tmpdir()) &&
+    path.basename(directory).startsWith(githubAccessTemporaryDirectoryPrefix)
+  );
+}
+
+export interface GitHubRepositoryAccessOptions {
+  /** Test seam for routing the fixed GitHub URL to a local fixture. */
+  http?: GitHttp;
+  /** Test seam; production always uses the bounded default. */
+  timeoutMilliseconds?: number;
+}
+
+/**
+ * Qualifies access to one fixed-owner GitHub repository without retaining its
+ * checkout or exposing any repository, credential, path, or adapter details.
+ */
+export async function checkGitHubRepositoryAccess(
+  settings: PiploySettings,
+  repository: string,
+  options: GitHubRepositoryAccessOptions = {},
+): Promise<GitHubRepositoryAccessResult> {
+  if (!isGitHubRepositoryName(repository)) {
+    return { accessible: false, reason: "invalid-repository-name" };
+  }
+
+  let directory: string | undefined;
+  let result: GitHubRepositoryAccessResult = {
+    accessible: false,
+    reason: "transport-or-fetch-failure",
+  };
+  try {
+    directory = await mkdtemp(
+      path.join(os.tmpdir(), githubAccessTemporaryDirectoryPrefix),
+    );
+    if (!isGithubAccessTemporaryDirectory(directory)) return result;
+    const temporaryDirectory = directory;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      options.timeoutMilliseconds ?? githubAccessTimeoutMilliseconds,
+    );
+    try {
+      const remoteHttp = withAbortSignal(
+        options.http ?? createAbortableGitHttp(controller.signal),
+        controller.signal,
+      );
+      await runRemoteOperation(settings, (authentication) =>
+        git.clone({
+          fs,
+          http: remoteHttp,
+          dir: temporaryDirectory,
+          url: `https://github.com/alundgren/${repository}.git`,
+          depth: 1,
+          singleBranch: true,
+          ...authentication,
+        }),
+      );
+      result = { accessible: true };
+    } catch (error) {
+      result =
+        error instanceof GitOperationError
+          ? { accessible: false, reason: error.diagnostic.reason }
+          : result;
+    } finally {
+      clearTimeout(timeout);
+    }
+  } catch {
+    // A temporary-directory failure is an operational failure, not a detail to
+    // log or return to a tailnet caller.
+  } finally {
+    if (
+      directory !== undefined &&
+      isGithubAccessTemporaryDirectory(directory)
+    ) {
+      try {
+        await rm(directory, { recursive: true, force: true });
+      } catch {
+        if (result.accessible) {
+          result = { accessible: false, reason: "transport-or-fetch-failure" };
+        }
+      }
+    }
+  }
+  return result;
+}
 
 function hasGitDirectory(repoDirectory: string): boolean {
   return fs.existsSync(path.join(repoDirectory, ".git"));

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -9,6 +9,7 @@ import {
   maxLogBytes,
   maxLogTailLines,
 } from "./containerLogs.js";
+import { isGitHubRepositoryName } from "./git.js";
 import type { DaemonRequest, DaemonResponse } from "./daemon.js";
 import type { ApplicationSchema } from "./settings.js";
 import { piployVersion } from "./version.js";
@@ -58,6 +59,13 @@ const registerInputSchema = {
   z.ZodType
 >;
 
+const githubRepositoryNameSchema = z
+  .string()
+  .refine(
+    isGitHubRepositoryName,
+    "Repository must be one GitHub name segment.",
+  );
+
 function toolResult(response: DaemonResponse) {
   return {
     content: [{ type: "text" as const, text: JSON.stringify(response) }],
@@ -66,7 +74,7 @@ function toolResult(response: DaemonResponse) {
 }
 
 /**
- * Registers the six commands that are safe to expose on the tailnet. The
+ * Registers the seven commands that are safe to expose on the tailnet. The
  * exclusion of `wipeall` and `self-update` is structural: they are simply
  * never registered here, so there is no block list to keep in sync.
  */
@@ -113,6 +121,22 @@ function createMcpServer(dispatch: McpDispatch): McpServer {
     },
     async (application) =>
       toolResult(await dispatch({ command: "register", application })),
+  );
+
+  server.registerTool(
+    "check-github-repository-access",
+    {
+      description:
+        "Check whether Piploy's configured GitHub credential can access one alundgren repository. This performs a shallow temporary clone and returns only a safe access result.",
+      inputSchema: { repository: githubRepositoryNameSchema },
+    },
+    async ({ repository }) =>
+      toolResult(
+        await dispatch({
+          command: "check-github-repository-access",
+          repository,
+        }),
+      ),
   );
 
   server.registerTool(

--- a/test/integration/git.test.ts
+++ b/test/integration/git.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import {
   existsSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -10,9 +11,10 @@ import os from "node:os";
 import path from "node:path";
 
 import gitHttp from "isomorphic-git/http/node";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  checkGitHubRepositoryAccess,
   credentialOwnerFromUrl,
   ensureLocalRepository,
   getCommitStatus,
@@ -31,14 +33,24 @@ const githubOwner = "alundgren";
 const tokenEnvironmentName = "PIPLOY_GITHUB_TOKEN";
 const sentinelToken = "sentinel-github-token";
 
-function githubFixtureHttp(remote: GitFixtureRemote) {
+function githubFixtureHttp(
+  remote: GitFixtureRemote,
+  onRequestBody: (body: string) => void = () => {},
+) {
   return {
-    request(request: Parameters<typeof gitHttp.request>[0]) {
+    async request(request: Parameters<typeof gitHttp.request>[0]) {
       const source = new URL(request.url);
       const fixturePath = source.pathname.replace(`/${githubOwner}`, "");
+      const chunks: Uint8Array[] = [];
+      if (request.body !== undefined) {
+        for await (const chunk of request.body) chunks.push(chunk);
+      }
+      const body = Buffer.concat(chunks);
+      onRequestBody(body.toString("utf8"));
       return gitHttp.request({
         ...request,
         url: `${remote.baseUrl}${fixturePath}${source.search}`,
+        body: request.body === undefined ? undefined : (chunks as never),
       });
     },
   };
@@ -338,6 +350,234 @@ describe("git", () => {
           delete process.env[tokenEnvironmentName];
         else process.env[tokenEnvironmentName] = originalToken;
         await authenticatedRemote.close();
+      }
+    });
+  });
+
+  describe("checkGitHubRepositoryAccess", () => {
+    it.each([
+      "",
+      ".",
+      "..",
+      "repository/name",
+      "repository\\name",
+      "https://github.com/alundgren/repository.git",
+      "repository?query",
+      "repository#fragment",
+      "a".repeat(101),
+    ])(
+      "rejects an unsafe repository input before making a request: %s",
+      async (repository) => {
+        let requested = false;
+
+        await expect(
+          checkGitHubRepositoryAccess(settings, repository, {
+            http: {
+              request: async () => {
+                requested = true;
+                throw new Error("network request should not occur");
+              },
+            },
+          }),
+        ).resolves.toEqual({
+          accessible: false,
+          reason: "invalid-repository-name",
+        });
+        expect(requested).toBe(false);
+      },
+    );
+
+    it("uses the shared credential boundary and removes its temporary checkout", async () => {
+      const authenticatedRemote = await startGitFixtureRemote({
+        credentials: { username: "x-access-token", password: sentinelToken },
+      });
+      const originalToken = process.env[tokenEnvironmentName];
+      const temporaryDirectories = () =>
+        readdirSync(os.tmpdir()).filter((name) =>
+          name.startsWith("piploy-github-access-"),
+        );
+      try {
+        process.env[tokenEnvironmentName] = sentinelToken;
+        authenticatedRemote.commit({ "index.html": "v1" }, "initial");
+        authenticatedRemote.commit({ "index.html": "v2" }, "next");
+        const accessSettings: PiploySettings = {
+          RootDirectory: rootDirectory,
+          Applications: [],
+          GitHubOwnerCredentials: {
+            [githubOwner]: `\${hostEnv:${tokenEnvironmentName}}`,
+          },
+        };
+        const before = temporaryDirectories();
+        const requestBodies: string[] = [];
+
+        await expect(
+          checkGitHubRepositoryAccess(accessSettings, "repo", {
+            http: githubFixtureHttp(authenticatedRemote, (body) => {
+              requestBodies.push(body);
+            }),
+          }),
+        ).resolves.toEqual({ accessible: true });
+
+        expect(authenticatedRemote.authenticatedRequests()).toBeGreaterThan(0);
+        expect(requestBodies).toContainEqual(
+          expect.stringContaining("deepen 1"),
+        );
+        expect(temporaryDirectories()).toEqual(before);
+        expect(accessSettings.Applications).toEqual([]);
+      } finally {
+        if (originalToken === undefined)
+          delete process.env[tokenEnvironmentName];
+        else process.env[tokenEnvironmentName] = originalToken;
+        await authenticatedRemote.close();
+      }
+    });
+
+    it("maps every shared credential and transport failure without retaining a checkout", async () => {
+      const authenticatedRemote = await startGitFixtureRemote({
+        credentials: { username: "x-access-token", password: sentinelToken },
+      });
+      const originalToken = process.env[tokenEnvironmentName];
+      const temporaryDirectories = () =>
+        readdirSync(os.tmpdir()).filter((name) =>
+          name.startsWith("piploy-github-access-"),
+        );
+      const before = temporaryDirectories();
+      const http = githubFixtureHttp(authenticatedRemote);
+      const credentials = {
+        [githubOwner]: `\${hostEnv:${tokenEnvironmentName}}`,
+      };
+      try {
+        authenticatedRemote.commit({ "index.html": "v1" }, "initial");
+
+        await expect(
+          checkGitHubRepositoryAccess(
+            { RootDirectory: rootDirectory, Applications: [] },
+            "repo",
+            { http },
+          ),
+        ).resolves.toEqual({
+          accessible: false,
+          reason: "credential-not-configured",
+        });
+        expect(temporaryDirectories()).toEqual(before);
+
+        delete process.env[tokenEnvironmentName];
+        await expect(
+          checkGitHubRepositoryAccess(
+            {
+              RootDirectory: rootDirectory,
+              Applications: [],
+              GitHubOwnerCredentials: credentials,
+            },
+            "repo",
+            { http },
+          ),
+        ).resolves.toEqual({
+          accessible: false,
+          reason: "credential-environment-missing",
+        });
+        expect(temporaryDirectories()).toEqual(before);
+
+        process.env[tokenEnvironmentName] = "wrong-token";
+        await expect(
+          checkGitHubRepositoryAccess(
+            {
+              RootDirectory: rootDirectory,
+              Applications: [],
+              GitHubOwnerCredentials: credentials,
+            },
+            "repo",
+            { http },
+          ),
+        ).resolves.toEqual({
+          accessible: false,
+          reason: "credential-rejected",
+        });
+        expect(temporaryDirectories()).toEqual(before);
+
+        process.env[tokenEnvironmentName] = sentinelToken;
+        await expect(
+          checkGitHubRepositoryAccess(
+            {
+              RootDirectory: rootDirectory,
+              Applications: [],
+              GitHubOwnerCredentials: credentials,
+            },
+            "missing",
+            { http },
+          ),
+        ).resolves.toEqual({
+          accessible: false,
+          reason: "repository-inaccessible-or-not-found",
+        });
+        expect(temporaryDirectories()).toEqual(before);
+
+        const rawAdapterError = "adapter error /tmp/private-checkout secret";
+        const result = await checkGitHubRepositoryAccess(settings, "repo", {
+          http: {
+            request: async () => {
+              throw new Error(rawAdapterError);
+            },
+          },
+        });
+        expect(result).toEqual({
+          accessible: false,
+          reason: "transport-or-fetch-failure",
+        });
+        expect(JSON.stringify(result)).not.toContain(rawAdapterError);
+        expect(temporaryDirectories()).toEqual(before);
+      } finally {
+        if (originalToken === undefined)
+          delete process.env[tokenEnvironmentName];
+        else process.env[tokenEnvironmentName] = originalToken;
+        await authenticatedRemote.close();
+      }
+    });
+
+    it("cancels the production HTTP adapter before cleaning its temporary directory", async () => {
+      const temporaryDirectories = () =>
+        readdirSync(os.tmpdir()).filter((name) =>
+          name.startsWith("piploy-github-access-"),
+        );
+      const before = temporaryDirectories();
+      let settled = false;
+      const rawAdapterError = "adapter error /tmp/private-checkout secret";
+      const fetch = vi.fn(
+        (_input: string | URL | Request, init?: RequestInit) =>
+          new Promise<Response>((_, reject) => {
+            const signal = init?.signal;
+            const abort = () => {
+              settled = true;
+              reject(new Error(rawAdapterError));
+            };
+            if (signal?.aborted) abort();
+            else signal?.addEventListener("abort", abort, { once: true });
+          }),
+      );
+      vi.stubGlobal("fetch", fetch);
+
+      try {
+        const result = await checkGitHubRepositoryAccess(
+          settings,
+          "repository",
+          {
+            timeoutMilliseconds: 1,
+          },
+        );
+
+        expect(result).toEqual({
+          accessible: false,
+          reason: "transport-or-fetch-failure",
+        });
+        expect(JSON.stringify(result)).not.toContain(rawAdapterError);
+        expect(fetch).toHaveBeenCalledWith(
+          "https://github.com/alundgren/repository.git/info/refs?service=git-upload-pack",
+          expect.objectContaining({ signal: expect.any(AbortSignal) }),
+        );
+        expect(settled).toBe(true);
+        expect(temporaryDirectories()).toEqual(before);
+      } finally {
+        vi.unstubAllGlobals();
       }
     });
   });

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -8,6 +8,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  createDaemonDeps,
   isDaemonListening,
   requestDaemon,
   startDaemon,
@@ -45,6 +46,19 @@ const noLogs: DaemonDeps["getLogs"] = async () => ({
   ok: false,
   reason: "unknown-application",
 });
+
+type TestDaemonDeps = Omit<DaemonDeps, "checkGitHubRepositoryAccess"> &
+  Partial<Pick<DaemonDeps, "checkGitHubRepositoryAccess">>;
+
+function completeDeps(deps: TestDaemonDeps): DaemonDeps {
+  return {
+    checkGitHubRepositoryAccess: async () => ({
+      accessible: false,
+      reason: "transport-or-fetch-failure",
+    }),
+    ...deps,
+  };
+}
 
 function sendRequest(
   socketPath: string,
@@ -101,7 +115,7 @@ describe("daemon", () => {
   });
 
   async function start(
-    deps: DaemonDeps,
+    deps: TestDaemonDeps,
     queueCapacity?: number,
   ): Promise<Daemon> {
     const socketPath = path.join(
@@ -112,7 +126,7 @@ describe("daemon", () => {
       socketPath,
       queueCapacity,
       pollIntervalMinutes: 60,
-      deps,
+      deps: completeDeps(deps),
       ...noTailscale,
     });
     daemons.push(daemon);
@@ -182,6 +196,87 @@ describe("daemon", () => {
       ),
     ).resolves.toEqual({ ok: true, logs });
     expect(requested).toEqual([{ application: "app", tail: 50 }]);
+  });
+
+  it("routes repository access checks through the daemon queue", async () => {
+    const requested: string[] = [];
+    const daemon = await start({
+      getLogs: noLogs,
+      checkGitHubRepositoryAccess: async (repository) => {
+        requested.push(repository);
+        return { accessible: false, reason: "credential-rejected" };
+      },
+      poll: async () => [],
+      getStatus: async () => ({ applications: [] }),
+      attemptSelfUpdate: async () => "up-to-date",
+    });
+
+    await expect(
+      sendRequest(daemon.socketPath, {
+        command: "check-github-repository-access",
+        repository: "repository",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      repositoryAccess: { accessible: false, reason: "credential-rejected" },
+    });
+    expect(requested).toEqual(["repository"]);
+  });
+
+  it("keeps actual repository-access failures out of daemon output and configuration", async () => {
+    const token = "sentinel-github-token";
+    const rawAdapterError = "adapter error /tmp/private-checkout secret";
+    const repositoryContent = "private repository content";
+    const messages: string[] = [];
+    const logger: Logger = {
+      debug: (message) => messages.push(message),
+      info: (message) => messages.push(message),
+      warn: (message) => messages.push(message),
+      error: (message) => messages.push(message),
+      child: () => logger,
+    };
+    const accessSettings: PiploySettings = {
+      RootDirectory: "/tmp/piploy",
+      Applications: [],
+      GitHubOwnerCredentials: {
+        alundgren: "${hostEnv:PIPLOY_GITHUB_TOKEN}",
+      },
+    };
+    const before = JSON.stringify(accessSettings);
+    vi.stubGlobal("fetch", () => Promise.reject(new Error(rawAdapterError)));
+    try {
+      const daemon = await startDaemon(accessSettings, logger, {
+        socketPath: path.join(
+          await mkdtemp(path.join(os.tmpdir(), "piploy-")),
+          "piploy.sock",
+        ),
+        pollIntervalMinutes: 60,
+        deps: createDaemonDeps(accessSettings, logger),
+        ...noTailscale,
+      });
+      daemons.push(daemon);
+
+      const response = await sendRequest(daemon.socketPath, {
+        command: "check-github-repository-access",
+        repository: "repository",
+      });
+
+      expect(response).toEqual({
+        ok: true,
+        repositoryAccess: {
+          accessible: false,
+          reason: "transport-or-fetch-failure",
+        },
+      });
+      const observable = `${JSON.stringify(response)}\n${messages.join("\n")}`;
+      expect(observable).not.toContain(token);
+      expect(observable).not.toContain(rawAdapterError);
+      expect(observable).not.toContain(repositoryContent);
+      expect(observable).not.toContain("piploy-github-access-");
+      expect(JSON.stringify(accessSettings)).toBe(before);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("reports an application with no container as a distinct logs rejection", async () => {
@@ -357,6 +452,10 @@ describe("daemon", () => {
         socketPath,
         pollIntervalMinutes: 1,
         deps: {
+          checkGitHubRepositoryAccess: async () => ({
+            accessible: false,
+            reason: "transport-or-fetch-failure",
+          }),
           attemptSelfUpdate: async () => {
             events.push("update");
             return updateResult;
@@ -414,7 +513,7 @@ describe("daemon", () => {
     };
 
     async function startWithConfig(
-      deps: DaemonDeps,
+      deps: TestDaemonDeps,
       registered: unknown[] = [],
     ): Promise<{
       daemon: Daemon;
@@ -437,14 +536,14 @@ describe("daemon", () => {
         socketPath: path.join(directory, "piploy.sock"),
         configPath,
         pollIntervalMinutes: 60,
-        deps,
+        deps: completeDeps(deps),
         ...noTailscale,
       });
       daemons.push(daemon);
       return { daemon, configPath, liveSettings };
     }
 
-    function idleDeps(): DaemonDeps {
+    function idleDeps(): TestDaemonDeps {
       return {
         getLogs: noLogs,
         poll: async () => [],
@@ -613,7 +712,7 @@ describe("daemon", () => {
 
     async function startWithAddress(
       address: string | undefined,
-      deps: DaemonDeps,
+      deps: TestDaemonDeps,
       // Port 0 keeps the test off the fixed v1 port.
       mcpPort = 0,
     ): Promise<{ daemon: Daemon; messages: string[] }> {
@@ -628,7 +727,7 @@ describe("daemon", () => {
         {
           socketPath,
           pollIntervalMinutes: 60,
-          deps,
+          deps: completeDeps(deps),
           mcpPort,
           getTailscaleAddress: () => address,
         },

--- a/test/unit/mcp.test.ts
+++ b/test/unit/mcp.test.ts
@@ -53,12 +53,13 @@ describe("mcp server", () => {
     return { client, requests };
   }
 
-  it("exposes exactly the six safe commands as tools", async () => {
+  it("exposes exactly the seven safe commands as tools", async () => {
     const { client } = await start();
 
     const { tools } = await client.listTools();
 
     expect(tools.map((tool) => tool.name).sort()).toEqual([
+      "check-github-repository-access",
       "logs",
       "poll",
       "register",
@@ -155,6 +156,41 @@ describe("mcp server", () => {
     expect(requests).toEqual([{ command: "poll" }]);
     expect(result.isError).toBeFalsy();
     expect(JSON.parse(textOf(result))).toEqual({ ok: true, applications });
+  });
+
+  it("routes a repository access check through the daemon dispatcher", async () => {
+    const repositoryAccess = {
+      accessible: false as const,
+      reason: "credential-rejected" as const,
+    };
+    const { client, requests } = await start(() => ({
+      ok: true,
+      repositoryAccess,
+    }));
+
+    const result = await client.callTool({
+      name: "check-github-repository-access",
+      arguments: { repository: "repository" },
+    });
+
+    expect(requests).toEqual([
+      { command: "check-github-repository-access", repository: "repository" },
+    ]);
+    expect(JSON.parse(textOf(result))).toEqual({ ok: true, repositoryAccess });
+  });
+
+  it("rejects a repository URL before dispatching it", async () => {
+    const repository = "https://github.com/alundgren/repository.git";
+    const { client, requests } = await start();
+
+    const result = await client.callTool({
+      name: "check-github-repository-access",
+      arguments: { repository },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).not.toContain(repository);
+    expect(requests).toEqual([]);
   });
 
   it("routes service-stop to the daemon stop command", async () => {


### PR DESCRIPTION
Adds a tailnet-only MCP qualification check for fixed-owner GitHub repository access. It reuses the existing credential boundary, uses a bounded temporary shallow clone, and returns only safe outcomes.

Closes #119