### PR TITLE
Bind application ports to Pi loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ reach it. Another user gets the offline fallback described under `status`.
 
 | Command         | What it does                                                                                                                                                                                                                  |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `status`        | Prints the Piploy version, whether the background service is reachable, and per-application configured host-to-container port mappings, Git, and Docker state, including the container's state, exit code, and restart count. |
+| `status`        | Prints the Piploy version, whether the background service is reachable, and per-application localhost-only host-to-container port mappings, Git, and Docker state, including the container's state, exit code, and restart count. |
 | `logs`          | Prints one application's recent container output, running or exited. `--tail <lines>` sets how much. Requires the daemon to be running.                                                                                       |
 | `poll`          | Runs one reconciliation now instead of waiting for the poll timer.                                                                                                                                                            |
 | `service-start` | Runs the daemon in the foreground. This is what systemd invokes; do not run it by hand while the service is up.                                                                                                               |
@@ -139,6 +139,13 @@ node piploy.cjs register \
 `--port-mapping`, `--volume`, and `--env` may each be repeated. For scripting,
 `--json '<application-json>'` passes the whole application instead; it cannot be
 combined with the individual flags.
+
+Each port mapping uses `hostPort:containerPort`. Piploy binds the host port to
+localhost on the Pi, so `8080:80` is reachable there at `localhost:8080`. It
+is not directly reachable through the Pi's LAN address, Tailscale IP address,
+or public IP address. To reach an Application from another machine, configure
+Tailscale Serve or Cloudflare Tunnel on the Pi and point it at
+`localhost:<hostPort>`.
 
 `--build-context-path` optionally selects the repository-relative directory to
 send to Docker as the build context. It accepts `.` for the repository root and

--- a/docs/agents/registering-an-application.md
+++ b/docs/agents/registering-an-application.md
@@ -22,7 +22,9 @@ registered Applications, their configured host-to-container `portMappings`,
 and their Git and Docker state. `portMappings` is always an array: an empty
 array means that Application has no configured host ports. Each entry has a
 `hostPort` and `containerPort`, corresponding to the `"hostPort:containerPort"`
-form in an Application payload.
+form in an Application payload. Every configured host port is local to the Pi
+and reachable through `localhost`, not directly through a LAN, Tailscale, or
+public IP address.
 
 Use those configured host ports to avoid a conflict with another Piploy
 Application when proposing `PortMappings`. This is not a host-wide port scan:
@@ -38,8 +40,8 @@ Before proposing a change, inspect the application repository and confirm:
 - that every `COPY` and `ADD` source in that Dockerfile resolves inside the
   Dockerfile's own directory, because that directory, not the repository root,
   is the build context Piploy sends to Docker;
-- which ports the container listens on and which, if any, should be exposed on
-  the host;
+- which ports the container listens on and which, if any, need a Pi-local
+  endpoint;
 - the environment variables the container needs, including their literal
   values; and
 - which writable paths need to survive a container replacement.
@@ -62,7 +64,7 @@ the persisted form: `PortMappings` and `Volumes` remain strings in
 | `Name` | Yes | A string containing only letters, numbers, `_`, and `-`. It must not exactly match an already registered Application name; comparison is case-sensitive. | Stored as submitted and used to identify the Application and its data directory. |
 | `GitRepositoryUrl` | Yes | Any string at payload validation; it must identify a repository Piploy can clone when it polls. | Stored as submitted. A Poll clones it when absent, otherwise fetches it and resets the local clone to the remote tip. |
 | `DockerfilePath` | Yes | Any string at payload validation. During a Poll it must identify a Dockerfile relative to the repository root; a path ending in `/` is rejected. Piploy trims whitespace, accepts `\\` as separators, and strips one leading `/`; examples include `Dockerfile`, `SubDirectory/Dockerfile`, and `Dockerfile.custom`. | Stored as submitted. Its parent path, not the repository root, is the Docker build context: a Dockerfile in a subdirectory can only `COPY` from that subdirectory. |
-| `PortMappings` | No | An array of strings, each exactly `<hostPort>:<containerPort>` with digits on both sides, for example `"8080:80"`. | Stored as submitted; parsed into host/container port pairs for the container. Omit it when no host port should be exposed. |
+| `PortMappings` | No | An array of strings, each exactly `<hostPort>:<containerPort>` with digits on both sides, for example `"8080:80"`. | Stored as submitted; parsed into host/container port pairs and bound only to localhost on the Pi. Omit it when the Application needs no Pi-local endpoint. |
 | `Volumes` | No | An array of strings, each `<name>:/container/path`. `name` uses letters, numbers, `_`, or `-`. The container path is absolute, has at least one segment, contains neither `:` nor `..`, and cannot be `/`. Two Volumes for one Application cannot target the same container path. | Stored as submitted; parsed into a named Volume and its container path for the container. |
 | `EnvironmentVariables` | No | An object whose keys and values are strings. Values are literal except an entire `${hostEnv:NAME}` reference, where `NAME` starts with a letter or `_` and otherwise contains only letters, digits, or `_`. Other interpolation-like values remain literal. | Stored as submitted. Piploy uses a host-environment reference itself in the container identity, then resolves it when creating or recreating the container. Piploy has no secret store, so a literal credential is written to `piploy.json` in plaintext. See the production-change gate for how to keep one out of the approval record without weakening the gate. |
 
@@ -157,7 +159,9 @@ ask for explicit human permission before falling back to SSH.
 Cloudflare Tunnel configuration is currently manual. After the Application is
 running, use the chosen **host** side of its `PortMappings` entry as the tunnel
 service port — not the container port. For example, a mapping of
-`"8080:80"` means Piploy publishes container port `80` on host port `8080`,
-so the Cloudflare Tunnel public-hostname service must point to
+`"8080:80"` means Piploy publishes container port `80` on localhost port
+`8080` on the Pi, so the Cloudflare Tunnel public-hostname service must point to
 `http://localhost:8080` (or the equivalent local-host service address for the
-tunnel process). State this mapping to the human who maintains the tunnel.
+tunnel process). The tunnel process must run on the Pi or have an explicit
+route to that loopback endpoint. State this mapping to the human who maintains
+the tunnel.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,7 +49,7 @@ function addRegisterOptions(command: Command): Command {
     )
     .option(
       "--port-mapping <hostPort:containerPort>",
-      "port mapping, repeatable",
+      "localhost-only port mapping on this Pi, repeatable",
       collect,
       [],
     )

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -99,8 +99,18 @@ function printStatus(status: DaemonStatus, daemonReachable: boolean): void {
     console.log(
       `  Running container hash: ${application.docker.runningContainerHash ?? "none"}`,
     );
+    const portMappings =
+      application.portMappings.length === 0
+        ? "none"
+        : application.portMappings
+            .map(
+              ({ hostPort, containerPort }) => `${hostPort}:${containerPort}`,
+            )
+            .join(", ");
     console.log(
-      `  Port mappings: ${application.portMappings.length === 0 ? "none" : application.portMappings.map(({ hostPort, containerPort }) => `${hostPort}:${containerPort}`).join(", ")}`,
+      application.portMappings.length === 0
+        ? `  Port mappings: ${portMappings}`
+        : `  Port mappings (localhost on this Pi only): ${portMappings}`,
     );
     const container = application.docker.container;
     console.log(`  Container state: ${container?.state ?? "none"}`);

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -15,6 +15,7 @@ import { pack } from "tar-fs";
 import { decodeContainerLog, limitLogBytes } from "./containerLogs.js";
 import {
   containerLogConfig,
+  containerPortBindingHostIps,
   containerRestartPolicy,
   getBuildContextPathFromSetting,
   getContainerConfigHash,
@@ -576,11 +577,17 @@ export function createDockerService(
       }
     }
 
-    const portBindings: Record<string, Array<{ HostPort: string }>> = {};
+    const portBindings: Record<
+      string,
+      Array<{ HostIp: string; HostPort: string }>
+    > = {};
     const exposedPorts: Record<string, object> = {};
     for (const portMapping of application.PortMappings ?? []) {
       const port = `${portMapping.containerPort}/tcp`;
-      portBindings[port] = [{ HostPort: String(portMapping.hostPort) }];
+      const bindings = (portBindings[port] ??= []);
+      for (const HostIp of containerPortBindingHostIps) {
+        bindings.push({ HostIp, HostPort: String(portMapping.hostPort) });
+      }
       exposedPorts[port] = {};
     }
 

--- a/src/dockerPlan.ts
+++ b/src/dockerPlan.ts
@@ -71,6 +71,9 @@ export const containerLogConfig = {
  */
 export const containerRestartPolicy = { Name: "unless-stopped" } as const;
 
+/** Every published application port stays reachable only from this Pi. */
+export const containerPortBindingHostIps = ["127.0.0.1", "::1"] as const;
+
 export function planImage(existingImage?: DockerImage): ImagePlan {
   return existingImage
     ? { action: "reuse", imageId: existingImage.id }
@@ -144,16 +147,20 @@ export function planRacedContainer(
 export function getContainerConfigHash(
   configuration: ContainerConfiguration,
 ): string {
+  const portMappings = [...(configuration.portMappings ?? [])].sort(
+    (left, right) =>
+      left.hostPort - right.hostPort ||
+      left.containerPort - right.containerPort,
+  );
   const normalized = {
     environmentVariables: [
       ...(configuration.environmentVariables ?? []),
     ].sort(),
     volumes: [...(configuration.volumes ?? [])].sort(),
-    portMappings: [...(configuration.portMappings ?? [])].sort(
-      (left, right) =>
-        left.hostPort - right.hostPort ||
-        left.containerPort - right.containerPort,
-    ),
+    portMappings,
+    ...(portMappings.length > 0
+      ? { portBindingHostIps: containerPortBindingHostIps }
+      : {}),
     logConfig: containerLogConfig,
     restartPolicy: containerRestartPolicy,
   };

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -85,7 +85,7 @@ function createMcpServer(dispatch: McpDispatch): McpServer {
     "status",
     {
       description:
-        "Report each registered application's configured host-to-container port mappings (an empty array means none), git commits, Docker image and container hashes, whether it runs the latest version, and its container's state, exit code, and restart count. A 'restarting' state with a non-zero exit code means the container is crash-looping. `git: null` with `gitError` means the fetch failed; without `gitError`, the repository has not been cloned.",
+        "Report each registered application's configured localhost-only host-to-container port mappings on this Pi (an empty array means none), git commits, Docker image and container hashes, whether it runs the latest version, and its container's state, exit code, and restart count. A 'restarting' state with a non-zero exit code means the container is crash-looping. `git: null` with `gitError` means the fetch failed; without `gitError`, the repository has not been cloned.",
     },
     async () => toolResult(await dispatch({ command: "status" })),
   );

--- a/test/integration/docker.test.ts
+++ b/test/integration/docker.test.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -77,6 +78,22 @@ const settings: PiploySettings = {
 };
 const docker = createDockerService(settings, logger);
 
+async function getAvailableHostPort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen({ host: "127.0.0.1", port: 0 }, resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Could not allocate a host port");
+  }
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return address.port;
+}
+
 afterAll(async () => {
   await docker.cleanupTestCreated();
   await rm(temporaryDirectory, { recursive: true, force: true });
@@ -90,6 +107,65 @@ afterAll(async () => {
 });
 
 describe("docker adapter", () => {
+  it("binds every mapped port to IPv4 and IPv6 loopback only", async () => {
+    const firstHostPort = await getAvailableHostPort();
+    const secondHostPort = await getAvailableHostPort();
+    const portApplication = {
+      Name: `${applicationName}ports`,
+      GitRepositoryUrl: "https://example.invalid/integration.git",
+      DockerfilePath: "Dockerfile",
+      PortMappings: [
+        { hostPort: firstHostPort, containerPort: 8080 },
+        { hostPort: secondHostPort, containerPort: 8080 },
+      ],
+    };
+    const repoDirectory = path.join(
+      settings.RootDirectory,
+      portApplication.Name,
+      "repo",
+    );
+    await mkdir(repoDirectory, { recursive: true });
+    await writeFile(
+      path.join(repoDirectory, "Dockerfile"),
+      'FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc\nRUN printf \'%s\\n\' \'#!/bin/sh\' \'printf "HTTP/1.1 200 OK\\\\r\\\\nContent-Length: 14\\\\r\\\\n\\\\r\\\\nloopback-only\\\\n"\' > /response && chmod +x /response\nCMD ["nc", "-lk", "-p", "8080", "-e", "/response"]\n',
+    );
+
+    await docker.ensureImageExists(portApplication, commit);
+    const started = await docker.ensureContainerRunning(
+      portApplication,
+      commit,
+    );
+    const inspect = await new Dockerode()
+      .getContainer(started.containerId)
+      .inspect();
+    const expectedBindings = [
+      { HostIp: "127.0.0.1", HostPort: String(firstHostPort) },
+      { HostIp: "::1", HostPort: String(firstHostPort) },
+      { HostIp: "127.0.0.1", HostPort: String(secondHostPort) },
+      { HostIp: "::1", HostPort: String(secondHostPort) },
+    ];
+
+    expect(inspect.HostConfig.PortBindings?.["8080/tcp"]).toEqual(
+      expectedBindings,
+    );
+    await vi.waitFor(async () => {
+      const current = await new Dockerode()
+        .getContainer(started.containerId)
+        .inspect();
+      const effectiveBindings = current.NetworkSettings.Ports["8080/tcp"];
+      expect(effectiveBindings).toHaveLength(expectedBindings.length);
+      expect(effectiveBindings).toEqual(
+        expect.arrayContaining(expectedBindings),
+      );
+      expect(
+        await (await fetch(`http://127.0.0.1:${firstHostPort}`)).text(),
+      ).toBe("loopback-only\n");
+      expect(await (await fetch(`http://[::1]:${firstHostPort}`)).text()).toBe(
+        "loopback-only\n",
+      );
+    });
+  });
+
   it("builds, runs, reports, and cleans up a marked container", async () => {
     const repoDirectory = path.join(
       settings.RootDirectory,

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -68,7 +68,9 @@ describe("commands", () => {
     expect(deps.requestDaemon).toHaveBeenCalledWith({ command: "status" });
     expect(deps.computeStatusInline).not.toHaveBeenCalled();
     expect(output).toHaveBeenCalledWith("Background service: running");
-    expect(output).toHaveBeenCalledWith("  Port mappings: 8080:80");
+    expect(output).toHaveBeenCalledWith(
+      "  Port mappings (localhost on this Pi only): 8080:80",
+    );
   });
 
   it("prints an explicit no-port-mappings state", async () => {

--- a/test/unit/dockerPlan.test.ts
+++ b/test/unit/dockerPlan.test.ts
@@ -134,6 +134,55 @@ describe("planContainer", () => {
     );
   });
 
+  it("recreates mapped containers while preserving legacy hashes without mappings", () => {
+    const legacyUnmappedHash = createHash("sha256")
+      .update(
+        JSON.stringify({
+          environmentVariables: [],
+          volumes: [],
+          portMappings: [],
+          logConfig: {
+            Type: "json-file",
+            Config: { "max-size": "10m", "max-file": "3" },
+          },
+          restartPolicy: { Name: "unless-stopped" },
+        }),
+      )
+      .digest("hex");
+    const mappings = [{ hostPort: 8080, containerPort: 80 }];
+    const legacyMappedHash = createHash("sha256")
+      .update(
+        JSON.stringify({
+          environmentVariables: [],
+          volumes: [],
+          portMappings: mappings,
+          logConfig: {
+            Type: "json-file",
+            Config: { "max-size": "10m", "max-file": "3" },
+          },
+          restartPolicy: { Name: "unless-stopped" },
+        }),
+      )
+      .digest("hex");
+
+    expect(getContainerConfigHash({})).toBe(legacyUnmappedHash);
+    expect(getContainerConfigHash({ portMappings: mappings })).not.toBe(
+      legacyMappedHash,
+    );
+    expect(
+      planContainer(
+        {
+          id: "container",
+          state: "running",
+          gitTipCommit: "commit",
+          configHash: legacyMappedHash,
+        },
+        "commit",
+        getContainerConfigHash({ portMappings: mappings }),
+      ),
+    ).toEqual({ action: "recreate", existingContainerId: "container" });
+  });
+
   it("hashes a host-environment reference declaratively", () => {
     const reference = "${hostEnv:CONTAINER_TOKEN}";
     const hash = getContainerConfigHash({


### PR DESCRIPTION
Application port mappings now produce IPv4 and IPv6 loopback bindings and drive a selective recreation of existing mapped containers. Operator-facing status, registration guidance, and MCP metadata make the local-only access model explicit.

Closes #70