### PR TITLE
status: distinguish a busy daemon from a missing one

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -127,6 +127,15 @@ function printStatus(status: DaemonStatus, daemonReachable: boolean): void {
 export async function status(deps: CommandDeps): Promise<void> {
   const response = await deps.requestDaemon({ command: "status" });
   if (response === undefined) {
+    // An unanswered request is only proof of "not running" when nothing is
+    // listening on the socket, matching how poll reads the same signal.
+    // A listening-but-slow daemon must not be reported as absent.
+    if (await deps.isDaemonListening()) {
+      console.log(`Piploy version: ${piployVersion}`);
+      console.log("Background service: busy");
+      console.log("\nIt did not respond in time. Try again shortly.");
+      return;
+    }
     printStatus(await deps.computeStatusInline(), false);
     return;
   }

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -164,6 +164,25 @@ describe("commands", () => {
     expect(output).toHaveBeenCalledWith("Background service: not running");
   });
 
+  it("reports a listening-but-unresponsive daemon as busy instead of not running", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => undefined);
+    deps.isDaemonListening = vi.fn(async () => true);
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await status(deps);
+
+    expect(deps.isDaemonListening).toHaveBeenCalledOnce();
+    expect(deps.computeStatusInline).not.toHaveBeenCalled();
+    expect(output).toHaveBeenCalledWith("Background service: busy");
+    expect(output).toHaveBeenCalledWith(
+      "\nIt did not respond in time. Try again shortly.",
+    );
+    expect(error).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+
   it("reports a failed daemon status request without an inline fallback", async () => {
     const deps = createDeps();
     deps.requestDaemon = vi.fn(async () => ({


### PR DESCRIPTION
Fixes #128

## What changed

`piploy status` now uses the same `isDaemonListening()` connect probe that `piploy poll` already relies on when its request goes unanswered. When the probe finds something listening on the daemon socket but the status request did not complete in time, `status` prints:

```
Piploy version: <version>
Background service: busy

It did not respond in time. Try again shortly.
```

instead of the previous inline fallback, which reported the same situation as "Background service: not running". With nothing listening on the socket, `status` still falls back to computing local git/Docker state and prints "not running", unchanged.

The busy output mirrors the existing `poll-in-progress` block in format (version line, service line, advice line) and exits 0, consistent with how poll reports a slow-but-alive daemon.

## Verification

- `pnpm lint` passes
- `pnpm test`: 227 passed (13 files), including a new unit test covering the listening-but-unresponsive path: inline fallback is skipped, exit code stays clean, and no error output is emitted.