### PR TITLE
Remove mattpocock skills plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,3 @@
 {
-  "enabledPlugins": {
-    "mattpocock-skills@claude-plugins-official": true
-  }
+  "enabledPlugins": {}
 }


### PR DESCRIPTION
## Summary

- remove the team-shared mattpocock-skills plugin enablement
- leave personal Claude settings untouched

## Validation

- jq empty .claude/settings.json
- git diff --check