### PR TITLE
Report stale Piploy configuration before polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ reach it. Another user gets the offline fallback described under `status`.
 
 | Command         | What it does                                                                                                                                                                                                                  |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `status`        | Prints the Piploy version, whether the background service is reachable, and per-application localhost-only host-to-container port mappings, Git, and Docker state, including the container's state, exit code, and restart count. |
+| `status`        | Prints whether the service loaded the current `piploy.json`, plus per-Application port mappings, Git state, Docker state, exit code, and restart count.                                                                             |
 | `logs`          | Prints one application's recent container output, running or exited. `--tail <lines>` sets how much. Requires the daemon to be running.                                                                                       |
-| `poll`          | Runs one reconciliation now instead of waiting for the poll timer.                                                                                                                                                            |
+| `poll`          | Runs one Poll now. If `piploy.json` changed after service startup, it stops and asks for a service restart.                                                                                                                    |
 | `service-start` | Runs the daemon in the foreground. This is what systemd invokes; do not run it by hand while the service is up.                                                                                                               |
 | `service-stop`  | Asks the running daemon to shut down.                                                                                                                                                                                         |
 | `register`      | Adds one application to `piploy.json` and to the running daemon, so the next poll deploys it without a restart. Requires the daemon to be running.                                                                            |
@@ -112,6 +112,16 @@ reach it. Another user gets the offline fallback described under `status`.
 ```bash
 node piploy.cjs status
 ```
+
+The service reads `piploy.json` at startup. After editing the file, `status`
+reports that a restart is required and does not report any Application as
+running the latest version. `poll` also refuses to run until the service has
+restarted. This recovery message remains available when the edited file is
+invalid, since `status` and `poll` contact the running service before trying to
+load the file themselves. A successful manual Poll says whether it used the
+current file directly or the copy loaded by the service. `register` remains the
+exception: it updates both the file and the running service, so it does not
+require a restart.
 
 ### `logs`
 

--- a/docs/adr/0001-config-validation-and-logging.md
+++ b/docs/adr/0001-config-validation-and-logging.md
@@ -50,6 +50,14 @@ Application data must survive it (see
 The daemon reads and validates configuration once at startup. Restart Piploy
 after changing `piploy.json`.
 
+The daemon records a one-way revision of the exact configuration file it read.
+`status` compares that revision with the current file. When they differ, status
+reports that a restart is required and never reports an Application as running
+the latest version. A Poll also checks the revision before and after doing work.
+It refuses to start when the file already differs, and reports a failed Poll if
+the file changes while the Poll is running. The revision and diagnostic never
+contain configuration values.
+
 The one exception is `register`, which adds a single Application. It validates
 the payload, rejects a duplicate `Name`, re-validates the whole resulting
 configuration, writes `piploy.json` through a temporary file and a rename, and
@@ -58,6 +66,12 @@ deploys it without a restart (see
 [ADR-0007](0007-live-config-mutation-for-register.md)). Every other change to
 `piploy.json` — editing or removing an Application, `RootDirectory`,
 `MinutesBetweenBackgroundPolls` — still requires a restart.
+
+`register` compares the exact file it reads with the daemon's loaded revision.
+If they differ, it refuses the request. After writing, it calculates the next
+revision from the same serialized bytes and advances the live Applications and
+revision together. It never re-reads the file and assigns that later content to
+the in-memory settings.
 
 Piploy uses pino for level filtering and contextual child loggers. It writes
 human-readable text lines in the form `timestamp [key=value, ...] message`;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,8 +18,8 @@ import {
 } from "./commands.js";
 import { defaultLogTailLines, maxLogTailLines } from "./containerLogs.js";
 import { requestDaemon } from "./daemon.js";
-import { createLogger, type Logger } from "./logger.js";
-import { loadSettings, resolveConfigPath } from "./settings.js";
+import type { Logger } from "./logger.js";
+import { resolveConfigPath } from "./settings.js";
 import { attemptSelfUpdate } from "./selfUpdate.js";
 import { piployVersion } from "./version.js";
 
@@ -84,8 +84,7 @@ const plainActions: Record<
 async function runCommand(
   run: (deps: CommandDeps) => Promise<void>,
 ): Promise<void> {
-  const settings = loadSettings(resolveConfigPath());
-  await run(createCommandDeps(settings, createLogger(settings)));
+  await run(createCommandDeps(resolveConfigPath()));
 }
 
 function defineCommand(

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,5 @@
 import { rmSync } from "node:fs";
+import path from "node:path";
 
 import { maxLogTailLines } from "./containerLogs.js";
 import {
@@ -12,24 +13,29 @@ import {
   type DaemonStatus,
 } from "./daemon.js";
 import { createDockerService } from "./docker.js";
-import type { Logger } from "./logger.js";
+import { createLogger } from "./logger.js";
 import type { PollApplicationResult } from "./orchestrator.js";
-import type { PiploySettings } from "./settings.js";
 import {
   getApplicationDataDirectory,
+  loadConfiguration,
   parseApplication,
+  readConfigurationRevision,
   RegisterApplicationError,
+  resolveConfigPath,
 } from "./settings.js";
 import { piployVersion } from "./version.js";
 
 /** A daemon register response, or `undefined` when no daemon answered. */
 export type RegisterResult = DaemonResponse | undefined;
+export type InlinePollResult =
+  | { ok: true; applications: PollApplicationResult[] }
+  | { ok: false; message: string };
 
 export interface CommandDeps {
   requestDaemon(request: DaemonRequest): Promise<DaemonResponse | undefined>;
   isDaemonListening(): Promise<boolean>;
   computeStatusInline(): Promise<DaemonStatus>;
-  pollInline(): Promise<PollApplicationResult[]>;
+  pollInline(): Promise<InlinePollResult>;
   register(application: unknown): Promise<RegisterResult>;
   wipeAll(): Promise<void>;
   getPreservedApplicationDataDirectories(): string[];
@@ -38,18 +44,79 @@ export interface CommandDeps {
 
 /** Wires CLI commands to the one real daemon, orchestration, and Docker adapters. */
 export function createCommandDeps(
-  settings: PiploySettings,
-  logger: Logger,
+  configPath: string = resolveConfigPath(),
+  createDeps: typeof createDaemonDeps = createDaemonDeps,
 ): CommandDeps {
-  const daemonDeps = createDaemonDeps(settings, logger);
+  let context:
+    | {
+        settings: ReturnType<typeof loadConfiguration>["settings"];
+        revision: string;
+        logger: ReturnType<typeof createLogger>;
+        daemonDeps: ReturnType<typeof createDaemonDeps>;
+      }
+    | undefined;
+
+  function loadContext() {
+    if (context !== undefined) return context;
+    const { settings, revision } = loadConfiguration(configPath);
+    const logger = createLogger(settings);
+    context = {
+      settings,
+      revision,
+      logger,
+      daemonDeps: createDeps(settings, logger),
+    };
+    return context;
+  }
+
+  function configurationIsCurrent(revision: string): boolean {
+    return readConfigurationRevision(configPath) === revision;
+  }
+
+  const socketPath = path.join(path.dirname(configPath), "piploy.sock");
   return {
-    requestDaemon,
-    isDaemonListening,
-    computeStatusInline: daemonDeps.getStatus,
-    pollInline: daemonDeps.poll,
+    requestDaemon: (request) => requestDaemon(request, socketPath),
+    isDaemonListening: () => isDaemonListening(socketPath),
+    computeStatusInline: async () => {
+      const { daemonDeps, revision } = loadContext();
+      const status = await daemonDeps.getStatus();
+      const configuration = configurationIsCurrent(revision)
+        ? "current"
+        : "changed-during-command";
+      return {
+        configuration,
+        applications:
+          configuration === "current"
+            ? status.applications
+            : status.applications.map((application) => ({
+                ...application,
+                isRunningLatestVersion: false,
+              })),
+      };
+    },
+    pollInline: async () => {
+      const { daemonDeps, revision } = loadContext();
+      if (!configurationIsCurrent(revision)) {
+        return {
+          ok: false,
+          message:
+            "piploy.json changed before the Poll started. Run the command again.",
+        };
+      }
+      const applications = await daemonDeps.poll();
+      if (!configurationIsCurrent(revision)) {
+        return {
+          ok: false,
+          message:
+            "piploy.json changed while the Poll was running. Run the command again.",
+        };
+      }
+      return { ok: true, applications };
+    },
     register: (application) =>
-      requestDaemon({ command: "register", application }),
+      requestDaemon({ command: "register", application }, socketPath),
     async wipeAll() {
+      const { settings, logger } = loadContext();
       try {
         await createDockerService(settings, logger).cleanupAll();
       } finally {
@@ -57,10 +124,18 @@ export function createCommandDeps(
       }
     },
     getPreservedApplicationDataDirectories: () =>
-      settings.Applications.filter(
-        (application) => (application.Volumes?.length ?? 0) > 0,
-      ).map(getApplicationDataDirectory),
-    startDaemon: () => startDaemon(settings, logger),
+      loadContext()
+        .settings.Applications.filter(
+          (application) => (application.Volumes?.length ?? 0) > 0,
+        )
+        .map(getApplicationDataDirectory),
+    startDaemon: () => {
+      const { settings, logger, revision } = loadContext();
+      return startDaemon(settings, logger, {
+        configPath,
+        loadedConfigurationRevision: revision,
+      });
+    },
   };
 }
 
@@ -78,6 +153,13 @@ function printStatus(status: DaemonStatus, daemonReachable: boolean): void {
   console.log(`Piploy version: ${piployVersion}`);
   console.log(
     `Background service: ${daemonReachable ? "running" : "not running"}`,
+  );
+  console.log(
+    status.configuration === "current"
+      ? `Configuration: current piploy.json${daemonReachable ? " loaded by service" : ""}`
+      : status.configuration === "restart-required"
+        ? "Configuration: piploy.json differs from the service; restart the service"
+        : "Configuration: piploy.json changed while status was running; run status again",
   );
   for (const application of status.applications) {
     console.log(`\n${application.application}`);
@@ -242,21 +324,36 @@ export async function poll(deps: CommandDeps): Promise<void> {
       );
       return;
     }
-    printPollResult(await deps.pollInline());
+    const inlineResult = await deps.pollInline();
+    if (!inlineResult.ok) {
+      commandFailed(inlineResult.message);
+      return;
+    }
+    printPollResult(inlineResult.applications);
     return;
   }
   if (!response.ok) {
-    commandFailed(`Daemon poll request failed: ${response.reason}`);
+    commandFailed(
+      response.message ?? `Daemon poll request failed: ${response.reason}`,
+    );
     return;
   }
   if ("applications" in response) {
-    printPollResult(response.applications);
+    printPollResult(response.applications, true);
     return;
   }
   console.log("Poll completed.");
 }
 
-function printPollResult(applications: PollApplicationResult[]): void {
+function printPollResult(
+  applications: PollApplicationResult[],
+  usedCurrentDaemonConfiguration = false,
+): void {
+  if (usedCurrentDaemonConfiguration) {
+    console.log("Poll used the current piploy.json loaded by the service.");
+  } else {
+    console.log("Poll used the current piploy.json directly.");
+  }
   const failures = applications.filter((application) => !application.ok);
   if (failures.length === 0) {
     console.log("Poll completed.");

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -22,6 +22,8 @@ import {
 import { decideQueueAdmission, type QueueSource } from "./queuePolicy.js";
 import { attemptSelfUpdate, type SelfUpdateResult } from "./selfUpdate.js";
 import {
+  ConfigurationChangedError,
+  readConfigurationRevision,
   registerApplication,
   RegisterApplicationError,
   resolveConfigPath,
@@ -35,6 +37,8 @@ import { isRunningLatestVersion } from "./status.js";
 const defaultQueueCapacity = 1000;
 const defaultPollIntervalMinutes = 60;
 const socketProbeTimeoutMilliseconds = 750;
+export const configurationChangedMessage =
+  "piploy.json differs from the configuration loaded by the service. Restart the service before continuing.";
 
 export type DaemonRequest =
   | { command: "status" }
@@ -46,7 +50,11 @@ export type DaemonRequest =
 
 export type DaemonResponse =
   | { ok: true; status: DaemonStatus }
-  | { ok: true; applications: PollApplicationResult[] }
+  | {
+      ok: true;
+      applications: PollApplicationResult[];
+      configuration: "current";
+    }
   | { ok: true; application: Application }
   | { ok: true; logs: ApplicationLogs }
   | { ok: true; repositoryAccess: GitHubRepositoryAccessResult }
@@ -57,9 +65,11 @@ export type DaemonResponse =
         | "busy"
         | "invalid-request"
         | "failed"
+        | "configuration-changed"
         | "poll-in-progress"
         | "unknown-application"
         | "no-container";
+      message?: string;
     }
   | { ok: false; reason: RegisterApplicationFailure; message: string };
 
@@ -88,6 +98,11 @@ export interface ApplicationDaemonStatus {
 }
 
 export interface DaemonStatus {
+  applications: ApplicationDaemonStatus[];
+  configuration: "current" | "restart-required" | "changed-during-command";
+}
+
+interface ApplicationStatusSnapshot {
   applications: ApplicationDaemonStatus[];
 }
 
@@ -127,7 +142,7 @@ export async function getApplicationStatus(
 
 export interface DaemonDeps {
   poll(): Promise<PollApplicationResult[]>;
-  getStatus(): Promise<DaemonStatus>;
+  getStatus(): Promise<ApplicationStatusSnapshot>;
   getLogs(application: string, tail?: number): Promise<ApplicationLogsResult>;
   checkGitHubRepositoryAccess(
     repository: string,
@@ -138,6 +153,7 @@ export interface DaemonDeps {
 export interface DaemonOptions {
   socketPath?: string;
   configPath?: string;
+  loadedConfigurationRevision?: string;
   queueCapacity?: number;
   pollIntervalMinutes?: number;
   deps?: DaemonDeps;
@@ -387,6 +403,9 @@ export async function startDaemon(
 
   const configPath = options.configPath ?? resolveConfigPath();
   const deps = options.deps ?? createDaemonDeps(settings, logger);
+  let loadedConfigurationRevision =
+    options.loadedConfigurationRevision ??
+    readConfigurationRevision(configPath);
   const queue: QueuedRequest[] = [];
   const sockets = new Set<net.Socket>();
   let workerRunning = false;
@@ -394,6 +413,18 @@ export async function startDaemon(
   let pollInProgress = false;
   let shutdownPromise: Promise<void> | undefined;
   let mcpServer: McpServerHandle | undefined;
+
+  function isConfigurationCurrent(): boolean {
+    return (
+      readConfigurationRevision(configPath) === loadedConfigurationRevision
+    );
+  }
+
+  function configurationChangedResponse(): DaemonResponse {
+    const message = configurationChangedMessage;
+    logger.warn(message);
+    return { ok: false, reason: "configuration-changed", message };
+  }
 
   function shutdown(): Promise<void> {
     if (shutdownPromise) return shutdownPromise;
@@ -417,12 +448,22 @@ export async function startDaemon(
    * only trigger, and nothing pushes work to it.
    */
   function runRegister(rawApplication: unknown): DaemonResponse {
+    if (!isConfigurationCurrent()) return configurationChangedResponse();
     try {
-      const application = registerApplication(configPath, rawApplication);
+      const registered = registerApplication(
+        configPath,
+        rawApplication,
+        loadedConfigurationRevision ?? "",
+      );
+      const { application } = registered;
       settings.Applications.push(application);
+      loadedConfigurationRevision = registered.revision;
       logger.info(`Registered application ${application.Name}`);
       return { ok: true, application };
     } catch (error) {
+      if (error instanceof ConfigurationChangedError) {
+        return configurationChangedResponse();
+      }
       if (!(error instanceof RegisterApplicationError)) throw error;
       logger.warn(`Rejected register request. ${error.message}`);
       return { ok: false, reason: error.reason, message: error.message };
@@ -434,8 +475,25 @@ export async function startDaemon(
       // Every command is matched explicitly: a fallthrough here would run
       // something other than what the client asked for.
       switch (request.command) {
-        case "status":
-          return { ok: true, status: await deps.getStatus() };
+        case "status": {
+          const status = await deps.getStatus();
+          const configuration = isConfigurationCurrent()
+            ? "current"
+            : "restart-required";
+          return {
+            ok: true,
+            status: {
+              configuration,
+              applications:
+                configuration === "current"
+                  ? status.applications
+                  : status.applications.map((application) => ({
+                      ...application,
+                      isRunningLatestVersion: false,
+                    })),
+            },
+          };
+        }
         case "logs": {
           const result = await deps.getLogs(request.application, request.tail);
           return result.ok
@@ -454,9 +512,16 @@ export async function startDaemon(
         case "register":
           return runRegister(request.application);
         case "poll":
+          if (!isConfigurationCurrent()) {
+            return configurationChangedResponse();
+          }
           pollInProgress = true;
           try {
-            return { ok: true, applications: await deps.poll() };
+            const applications = await deps.poll();
+            if (!isConfigurationCurrent()) {
+              return configurationChangedResponse();
+            }
+            return { ok: true, applications, configuration: "current" };
           } finally {
             pollInProgress = false;
           }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -85,7 +85,7 @@ function createMcpServer(dispatch: McpDispatch): McpServer {
     "status",
     {
       description:
-        "Report each registered application's configured localhost-only host-to-container port mappings on this Pi (an empty array means none), git commits, Docker image and container hashes, whether it runs the latest version, and its container's state, exit code, and restart count. A 'restarting' state with a non-zero exit code means the container is crash-looping. `git: null` with `gitError` means the fetch failed; without `gitError`, the repository has not been cloned.",
+        "Report whether the daemon loaded the current piploy.json, plus each registered application's configured localhost-only host-to-container port mappings on this Pi (an empty array means none), git commits, Docker image and container hashes, whether it runs the latest version, and its container's state, exit code, and restart count. A changed configuration requires a daemon restart and makes every latest-version result false. A 'restarting' state with a non-zero exit code means the container is crash-looping. `git: null` with `gitError` means the fetch failed; without `gitError`, the repository has not been cloned.",
     },
     async () => toolResult(await dispatch({ command: "status" })),
   );
@@ -107,7 +107,7 @@ function createMcpServer(dispatch: McpDispatch): McpServer {
     "poll",
     {
       description:
-        "Run one reconciliation pass now: fetch each application's repository, rebuild, and restart what is out of date.",
+        "Run one reconciliation pass now using the current piploy.json loaded by the daemon: fetch each application's repository, rebuild, and restart what is out of date. If piploy.json changed after daemon startup, the Poll fails and requires a daemon restart.",
     },
     async () => toolResult(await dispatch({ command: "poll" })),
   );

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   readFileSync,
   renameSync,
@@ -127,16 +128,40 @@ export type PortMapping = { hostPort: number; containerPort: number };
 export type Volume = { name: string; containerPath: string };
 export type Application = z.infer<typeof ApplicationSchema>;
 export type PiploySettings = z.infer<typeof PiploySettingsSchema>;
+export interface LoadedConfiguration {
+  settings: PiploySettings;
+  revision: string;
+}
 
 export function parseSettings(json: unknown): PiploySettings {
   return ConfigFileSchema.parse(json).Piploy;
 }
 
-export function loadSettings(configPath: string): PiploySettings {
+export function calculateConfigurationRevision(raw: string | Buffer): string {
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+export function readConfigurationRevision(configPath: string): string | null {
+  try {
+    return calculateConfigurationRevision(readFileSync(configPath));
+  } catch {
+    return null;
+  }
+}
+
+/** Reads once so the revision identifies the exact bytes that produced the settings. */
+export function loadConfiguration(configPath: string): LoadedConfiguration {
   const raw = readFileSync(configPath, "utf8");
   const settings = parseSettings(JSON.parse(raw));
   assertDataDirectoryIsSeparateFromRootDirectory(settings, configPath);
-  return settings;
+  return {
+    settings,
+    revision: calculateConfigurationRevision(raw),
+  };
+}
+
+export function loadSettings(configPath: string): PiploySettings {
+  return loadConfiguration(configPath).settings;
 }
 
 export type RegisterApplicationFailure =
@@ -150,6 +175,13 @@ export class RegisterApplicationError extends Error {
   ) {
     super(message);
     this.name = "RegisterApplicationError";
+  }
+}
+
+export class ConfigurationChangedError extends Error {
+  constructor() {
+    super("piploy.json differs from the configuration loaded by the service");
+    this.name = "ConfigurationChangedError";
   }
 }
 
@@ -188,10 +220,15 @@ export function parseApplication(rawApplication: unknown): Application {
 export function registerApplication(
   configPath: string,
   rawApplication: unknown,
-): Application {
+  expectedRevision: string,
+): { application: Application; revision: string } {
   const application = parseApplication(rawApplication);
 
-  const currentConfig = JSON.parse(readFileSync(configPath, "utf8")) as unknown;
+  const currentRaw = readFileSync(configPath, "utf8");
+  if (calculateConfigurationRevision(currentRaw) !== expectedRevision) {
+    throw new ConfigurationChangedError();
+  }
+  const currentConfig = JSON.parse(currentRaw) as unknown;
   // An invalid file here is a broken installation, not a bad request, so it
   // propagates rather than becoming a register-specific rejection.
   const currentSettings = parseSettings(currentConfig);
@@ -227,8 +264,12 @@ export function registerApplication(
     );
   }
 
-  writeConfigAtomically(configPath, nextConfig);
-  return application;
+  const nextRaw = JSON.stringify(nextConfig, null, 2) + "\n";
+  writeConfigAtomically(configPath, nextRaw);
+  return {
+    application,
+    revision: calculateConfigurationRevision(nextRaw),
+  };
 }
 
 /**
@@ -236,10 +277,13 @@ export function registerApplication(
  * mid-write leaves the previous `piploy.json` intact rather than a truncated
  * one the daemon would refuse to start from.
  */
-function writeConfigAtomically(configPath: string, config: unknown): void {
+function writeConfigAtomically(
+  configPath: string,
+  serializedConfig: string,
+): void {
   const temporaryPath = `${configPath}.tmp-${process.pid.toString()}`;
   try {
-    writeFileSync(temporaryPath, JSON.stringify(config, null, 2) + "\n", {
+    writeFileSync(temporaryPath, serializedConfig, {
       // Keep whatever the operator set on the existing file: a rename replaces
       // the inode, so the mode has to be carried over explicitly.
       mode: statSync(configPath).mode & 0o777,

--- a/test/unit/commands.test.ts
+++ b/test/unit/commands.test.ts
@@ -1,6 +1,11 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  createCommandDeps,
   logs,
   parseRegisterOptions,
   parseTailOption,
@@ -13,7 +18,12 @@ import {
   wipeAll,
   type CommandDeps,
 } from "../../src/commands.js";
-import type { DaemonResponse, DaemonStatus } from "../../src/daemon.js";
+import {
+  startDaemon,
+  type DaemonResponse,
+  type DaemonStatus,
+} from "../../src/daemon.js";
+import type { Logger } from "../../src/logger.js";
 
 const application = {
   Name: "app",
@@ -22,6 +32,7 @@ const application = {
 };
 
 const daemonStatus: DaemonStatus = {
+  configuration: "current",
   applications: [
     {
       application: "app",
@@ -38,7 +49,7 @@ function createDeps(): CommandDeps {
     requestDaemon: vi.fn(),
     isDaemonListening: vi.fn(async () => false),
     computeStatusInline: vi.fn(async () => daemonStatus),
-    pollInline: vi.fn(async () => []),
+    pollInline: vi.fn(async () => ({ ok: true as const, applications: [] })),
     register: vi.fn(),
     wipeAll: vi.fn(),
     getPreservedApplicationDataDirectories: vi.fn(() => []),
@@ -69,8 +80,133 @@ describe("commands", () => {
     expect(deps.computeStatusInline).not.toHaveBeenCalled();
     expect(output).toHaveBeenCalledWith("Background service: running");
     expect(output).toHaveBeenCalledWith(
+      "Configuration: current piploy.json loaded by service",
+    );
+    expect(output).toHaveBeenCalledWith(
       "  Port mappings (localhost on this Pi only): 8080:80",
     );
+  });
+
+  it("reports a changed configuration and does not print an unqualified current result", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => ({
+      ok: true as const,
+      status: {
+        ...daemonStatus,
+        configuration: "restart-required" as const,
+      },
+    }));
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await status(deps);
+
+    expect(output).toHaveBeenCalledWith(
+      "Configuration: piploy.json differs from the service; restart the service",
+    );
+  });
+
+  it("gets stale status from a live daemon even when piploy.json is invalid", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "piploy-command-"));
+    const configPath = path.join(directory, "piploy.json");
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        Piploy: {
+          RootDirectory: path.join(directory, "root"),
+          Applications: [],
+        },
+      }),
+    );
+    const logger: Logger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      child: () => logger,
+    };
+    const daemon = await startDaemon(
+      { RootDirectory: path.join(directory, "root"), Applications: [] },
+      logger,
+      {
+        socketPath: path.join(directory, "piploy.sock"),
+        configPath,
+        pollIntervalMinutes: 60,
+        deps: {
+          poll: async () => [],
+          getStatus: async () => ({
+            applications: [daemonStatus.applications[0]!],
+          }),
+          getLogs: async () => ({
+            ok: false as const,
+            reason: "unknown-application" as const,
+          }),
+          checkGitHubRepositoryAccess: async () => ({
+            accessible: false as const,
+            reason: "transport-or-fetch-failure" as const,
+          }),
+          attemptSelfUpdate: async () => "up-to-date" as const,
+        },
+        getTailscaleAddress: () => undefined,
+      },
+    );
+    try {
+      await writeFile(configPath, "{");
+      const output = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await status(createCommandDeps(configPath));
+
+      expect(output).toHaveBeenCalledWith("Background service: running");
+      expect(output).toHaveBeenCalledWith(
+        "Configuration: piploy.json differs from the service; restart the service",
+      );
+      expect(output).toHaveBeenCalledWith("  Running latest version: no");
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it("does not report current inline status when piploy.json changes during the check", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "piploy-command-"));
+    const configPath = path.join(directory, "piploy.json");
+    const initialConfig = {
+      Piploy: {
+        RootDirectory: path.join(directory, "root"),
+        Applications: [],
+      },
+    };
+    await writeFile(configPath, JSON.stringify(initialConfig));
+    const deps = createCommandDeps(configPath, () => ({
+      poll: async () => [],
+      getStatus: async () => {
+        await writeFile(
+          configPath,
+          JSON.stringify({
+            Piploy: {
+              ...initialConfig.Piploy,
+              MinutesBetweenBackgroundPolls: 5,
+            },
+          }),
+        );
+        return { applications: [daemonStatus.applications[0]!] };
+      },
+      getLogs: async () => ({
+        ok: false as const,
+        reason: "unknown-application" as const,
+      }),
+      checkGitHubRepositoryAccess: async () => ({
+        accessible: false as const,
+        reason: "transport-or-fetch-failure" as const,
+      }),
+      attemptSelfUpdate: async () => "up-to-date" as const,
+    }));
+    const output = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await status(deps);
+
+    expect(output).toHaveBeenCalledWith(
+      "Configuration: piploy.json changed while status was running; run status again",
+    );
+    expect(output).toHaveBeenCalledWith("  Running latest version: no");
   });
 
   it("prints an explicit no-port-mappings state", async () => {
@@ -319,6 +455,7 @@ describe("commands", () => {
     const deps = createDeps();
     const response: DaemonResponse = {
       ok: true,
+      configuration: "current",
       applications: [
         {
           application: "app",
@@ -335,6 +472,9 @@ describe("commands", () => {
 
     expect(deps.requestDaemon).toHaveBeenCalledWith({ command: "poll" });
     expect(deps.pollInline).not.toHaveBeenCalled();
+    expect(output).toHaveBeenCalledWith(
+      "Poll used the current piploy.json loaded by the service.",
+    );
     expect(output).toHaveBeenCalledWith("Poll completed with failures:");
     expect(output).toHaveBeenCalledWith("  app (build): Dockerfile is invalid");
   });
@@ -347,6 +487,50 @@ describe("commands", () => {
     await poll(deps);
 
     expect(deps.pollInline).toHaveBeenCalledOnce();
+  });
+
+  it("fails an inline Poll when piploy.json changes while it runs", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "piploy-command-"));
+    const configPath = path.join(directory, "piploy.json");
+    const initialConfig = {
+      Piploy: {
+        RootDirectory: path.join(directory, "root"),
+        Applications: [],
+      },
+    };
+    await writeFile(configPath, JSON.stringify(initialConfig));
+    const deps = createCommandDeps(configPath, () => ({
+      poll: async () => {
+        await writeFile(
+          configPath,
+          JSON.stringify({
+            Piploy: {
+              ...initialConfig.Piploy,
+              MinutesBetweenBackgroundPolls: 5,
+            },
+          }),
+        );
+        return [];
+      },
+      getStatus: async () => ({ applications: [] }),
+      getLogs: async () => ({
+        ok: false as const,
+        reason: "unknown-application" as const,
+      }),
+      checkGitHubRepositoryAccess: async () => ({
+        accessible: false as const,
+        reason: "transport-or-fetch-failure" as const,
+      }),
+      attemptSelfUpdate: async () => "up-to-date" as const,
+    }));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await poll(deps);
+
+    expect(error).toHaveBeenCalledWith(
+      "piploy.json changed while the Poll was running. Run the command again.",
+    );
+    expect(process.exitCode).toBe(1);
   });
 
   it("does not become a second poller when a live daemon just did not answer in time", async () => {
@@ -376,6 +560,25 @@ describe("commands", () => {
 
     expect(deps.pollInline).not.toHaveBeenCalled();
     expect(error).toHaveBeenCalledWith("Daemon poll request failed: failed");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("prints the daemon's restart instruction when configuration changed", async () => {
+    const deps = createDeps();
+    deps.requestDaemon = vi.fn(async () => ({
+      ok: false as const,
+      reason: "configuration-changed" as const,
+      message:
+        "piploy.json differs from the configuration loaded by the service. Restart the service before continuing.",
+    }));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await poll(deps);
+
+    expect(error).toHaveBeenCalledWith(
+      "piploy.json differs from the configuration loaded by the service. Restart the service before continuing.",
+    );
+    expect(deps.pollInline).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(1);
   });
 

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -19,7 +19,11 @@ import {
 } from "../../src/daemon.js";
 import type { Logger } from "../../src/logger.js";
 import { GitOperationError } from "../../src/git.js";
-import { loadSettings, type PiploySettings } from "../../src/settings.js";
+import {
+  loadConfiguration,
+  loadSettings,
+  type PiploySettings,
+} from "../../src/settings.js";
 
 const settings: PiploySettings = {
   RootDirectory: "/tmp/piploy",
@@ -157,6 +161,7 @@ describe("daemon", () => {
     ).resolves.toEqual({
       ok: true,
       status: {
+        configuration: "current",
         applications: [
           {
             application: "app",
@@ -168,6 +173,162 @@ describe("daemon", () => {
         ],
       },
     });
+  });
+
+  it("marks status stale and refuses to poll after piploy.json changes", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "piploy-"));
+    const configPath = path.join(directory, "piploy.json");
+    const socketPath = path.join(directory, "piploy.sock");
+    const config = (environmentValue: string) => ({
+      Piploy: {
+        RootDirectory: path.join(directory, "root"),
+        Applications: [
+          {
+            Name: "app",
+            GitRepositoryUrl: "https://example.com/app.git",
+            DockerfilePath: "Dockerfile",
+            EnvironmentVariables: { VALUE: environmentValue },
+          },
+        ],
+      },
+    });
+    await writeFile(configPath, JSON.stringify(config("initial")));
+    const loaded = loadConfiguration(configPath);
+    let polls = 0;
+    const deps = completeDeps({
+      getLogs: noLogs,
+      poll: async () => {
+        polls += 1;
+        return [];
+      },
+      getStatus: async () => ({
+        applications: [
+          {
+            application: "app",
+            portMappings: [],
+            git: null,
+            docker: {},
+            isRunningLatestVersion: true,
+          },
+        ],
+      }),
+      attemptSelfUpdate: async () => "up-to-date",
+    });
+    const daemon = await startDaemon(loaded.settings, createLogger(), {
+      socketPath,
+      configPath,
+      loadedConfigurationRevision: loaded.revision,
+      pollIntervalMinutes: 60,
+      deps,
+      ...noTailscale,
+    });
+    daemons.push(daemon);
+    await vi.waitFor(() => expect(polls).toBe(1));
+
+    const secret = "must-not-appear";
+    await writeFile(configPath, JSON.stringify(config(secret)));
+
+    const statusResponse = await requestDaemon(
+      { command: "status" },
+      daemon.socketPath,
+    );
+    expect(statusResponse).toMatchObject({
+      ok: true,
+      status: {
+        configuration: "restart-required",
+        applications: [{ isRunningLatestVersion: false }],
+      },
+    });
+    const pollResponse = await requestDaemon(
+      { command: "poll" },
+      daemon.socketPath,
+    );
+    expect(pollResponse).toEqual({
+      ok: false,
+      reason: "configuration-changed",
+      message:
+        "piploy.json differs from the configuration loaded by the service. Restart the service before continuing.",
+    });
+    expect(polls).toBe(1);
+    expect(JSON.stringify({ statusResponse, pollResponse })).not.toContain(
+      secret,
+    );
+
+    await daemon.stop();
+    daemons.splice(daemons.indexOf(daemon), 1);
+    const reloaded = loadConfiguration(configPath);
+    expect(reloaded.settings.Applications[0]?.EnvironmentVariables).toEqual({
+      VALUE: secret,
+    });
+    const restartedDaemon = await startDaemon(
+      reloaded.settings,
+      createLogger(),
+      {
+        socketPath,
+        configPath,
+        loadedConfigurationRevision: reloaded.revision,
+        pollIntervalMinutes: 60,
+        deps,
+        ...noTailscale,
+      },
+    );
+    daemons.push(restartedDaemon);
+    await vi.waitFor(() => expect(polls).toBe(2));
+    await expect(
+      requestDaemon({ command: "poll" }, restartedDaemon.socketPath),
+    ).resolves.toEqual({
+      ok: true,
+      applications: [],
+      configuration: "current",
+    });
+    expect(polls).toBe(3);
+  });
+
+  it("keeps the loaded revision when piploy.json changes before daemon startup", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "piploy-"));
+    const configPath = path.join(directory, "piploy.json");
+    const initialConfig = {
+      Piploy: {
+        RootDirectory: path.join(directory, "root"),
+        Applications: [],
+      },
+    };
+    await writeFile(configPath, JSON.stringify(initialConfig));
+    const loaded = loadConfiguration(configPath);
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        ...initialConfig,
+        Piploy: { ...initialConfig.Piploy, MinutesBetweenBackgroundPolls: 5 },
+      }),
+    );
+    let polls = 0;
+    const daemon = await startDaemon(loaded.settings, createLogger(), {
+      socketPath: path.join(directory, "piploy.sock"),
+      configPath,
+      loadedConfigurationRevision: loaded.revision,
+      pollIntervalMinutes: 60,
+      deps: completeDeps({
+        getLogs: noLogs,
+        poll: async () => {
+          polls += 1;
+          return [];
+        },
+        getStatus: async () => ({ applications: [] }),
+        attemptSelfUpdate: async () => "up-to-date",
+      }),
+      ...noTailscale,
+    });
+    daemons.push(daemon);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    await expect(
+      requestDaemon({ command: "status" }, daemon.socketPath),
+    ).resolves.toEqual({
+      ok: true,
+      status: { applications: [], configuration: "restart-required" },
+    });
+    expect(polls).toBe(0);
   });
 
   it("returns container logs for one application over the private socket", async () => {
@@ -323,7 +484,11 @@ describe("daemon", () => {
 
     await expect(
       requestDaemon({ command: "poll" }, daemon.socketPath),
-    ).resolves.toEqual({ ok: true, applications });
+    ).resolves.toEqual({
+      ok: true,
+      applications,
+      configuration: "current",
+    });
   });
 
   it("runs poll requests serially and rejects a client when its queue is full", async () => {
@@ -358,8 +523,16 @@ describe("daemon", () => {
     });
 
     releaseFirstPoll!();
-    await expect(first).resolves.toEqual({ ok: true, applications: [] });
-    await expect(second).resolves.toEqual({ ok: true, applications: [] });
+    await expect(first).resolves.toEqual({
+      ok: true,
+      applications: [],
+      configuration: "current",
+    });
+    await expect(second).resolves.toEqual({
+      ok: true,
+      applications: [],
+      configuration: "current",
+    });
     expect(polls).toBe(3);
   });
 
@@ -391,7 +564,11 @@ describe("daemon", () => {
     ).resolves.toEqual({ ok: false, reason: "poll-in-progress" });
 
     releasePoll!();
-    await expect(poll).resolves.toEqual({ ok: true, applications: [] });
+    await expect(poll).resolves.toEqual({
+      ok: true,
+      applications: [],
+      configuration: "current",
+    });
   });
 
   it("rejects malformed requests", async () => {
@@ -579,6 +756,23 @@ describe("daemon", () => {
       };
       expect(written.Piploy.Applications).toEqual([newApplication]);
       expect(liveSettings.Applications.map((one) => one.Name)).toEqual(["app"]);
+
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          Piploy: {
+            RootDirectory: path.dirname(configPath),
+            Applications: [newApplication],
+            MinutesBetweenBackgroundPolls: 5,
+          },
+        }),
+      );
+      await expect(
+        sendRequest(daemon.socketPath, { command: "status" }),
+      ).resolves.toMatchObject({
+        ok: true,
+        status: { configuration: "restart-required" },
+      });
     });
 
     it("rejects an application the schema does not accept", async () => {
@@ -752,7 +946,10 @@ describe("daemon", () => {
       await expect(isListening(mcpPort)).resolves.toBe(false);
       await expect(
         sendRequest(daemon.socketPath, { command: "status" }),
-      ).resolves.toEqual({ ok: true, status: { applications: [] } });
+      ).resolves.toEqual({
+        ok: true,
+        status: { applications: [], configuration: "current" },
+      });
       expect(messages).toContain(
         "warn No Tailscale address found. MCP server not started",
       );

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -6,15 +6,18 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  ConfigurationChangedError,
   getApplicationDataDirectory,
   getApplicationRepoDirectory,
   getApplicationRootDirectory,
   getDataDirectory,
   getVolumeDirectory,
+  loadConfiguration,
   loadSettings,
   parseHostEnvironmentReference,
   parseSettings,
   registerApplication,
+  readConfigurationRevision,
   resolveBundleDirectory,
   resolveConfigPath,
 } from "../../src/settings.js";
@@ -296,12 +299,59 @@ describe("parseSettings", () => {
       EnvironmentVariables: { TOKEN: "${hostEnv:CONTAINER_TOKEN}" },
     };
 
-    registerApplication(configPath, rawApplication);
+    const loaded = loadConfiguration(configPath);
+    registerApplication(configPath, rawApplication, loaded.revision);
 
     const persisted = JSON.parse(await readFile(configPath, "utf8")) as {
       Piploy: { Applications: unknown[] };
     };
     expect(persisted.Piploy.Applications).toEqual([rawApplication]);
+  });
+
+  it("rejects registration when the file no longer matches the loaded revision", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "piploy-settings-"));
+    const configPath = path.join(directory, "piploy.json");
+    const initial = {
+      Piploy: { RootDirectory: "/root", Applications: [] as unknown[] },
+    };
+    await writeFile(configPath, JSON.stringify(initial));
+    const loaded = loadConfiguration(configPath);
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        Piploy: {
+          ...initial.Piploy,
+          MinutesBetweenBackgroundPolls: 5,
+        },
+      }),
+    );
+
+    expect(() =>
+      registerApplication(configPath, validApplication, loaded.revision),
+    ).toThrow(ConfigurationChangedError);
+    const persisted = JSON.parse(await readFile(configPath, "utf8")) as {
+      Piploy: { Applications: unknown[] };
+    };
+    expect(persisted.Piploy.Applications).toEqual([]);
+  });
+
+  it("returns the revision of the exact bytes written by registration", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "piploy-settings-"));
+    const configPath = path.join(directory, "piploy.json");
+    await writeFile(
+      configPath,
+      JSON.stringify({ Piploy: { RootDirectory: "/root", Applications: [] } }),
+    );
+    const loaded = loadConfiguration(configPath);
+
+    const registered = registerApplication(
+      configPath,
+      validApplication,
+      loaded.revision,
+    );
+
+    expect(registered.application).toEqual(validApplication);
+    expect(registered.revision).toBe(readConfigurationRevision(configPath));
   });
 
   it.each(["", "/outside", "../outside", "services/../../outside"])(


### PR DESCRIPTION
## Summary

- track the exact `piploy.json` revision loaded into daemon or inline command settings
- report configuration drift in status and prevent stale daemon or inline Poll results
- keep status and Poll recovery available when an edited file is invalid
- preserve safe live `register` updates by advancing Application state and file revision together
- document the restart requirement and cover startup, registration, malformed-file, secret-output, and mid-command races

## Validation

- `corepack pnpm lint`
- `corepack pnpm test` (13 files, 236 tests)
- `corepack pnpm build`

Closes #135