### PR TITLE
Allow digest-pinned GHCR images

### DIFF
--- a/docs/adr/0004-supply-chain-controls.md
+++ b/docs/adr/0004-supply-chain-controls.md
@@ -18,12 +18,15 @@ pnpm audit report alongside the bundled daemon.
 Before calling Docker to build an application image, Piploy validates the
 resolved Dockerfile text. Every external `FROM` and `COPY --from` reference
 must be pinned to a SHA-256 digest and be either a Docker Official Image
-(`docker.io/library/*`, including short names) or a Microsoft .NET image
-(`mcr.microsoft.com/dotnet/*`). Piploy supports running .NET applications,
-so the Microsoft .NET namespace is an explicit application-image allowlist.
-`scratch` and earlier Docker build stages are not external references and
-remain valid. The validator collects every violation and prevents Docker from
-being called when one is found.
+(`docker.io/library/*`, including short names), a GitHub Container Registry
+image (`ghcr.io/*`), or a Microsoft .NET image
+(`mcr.microsoft.com/dotnet/*`). GitHub Container Registry is allowed so
+applications can use project-owned build images while retaining immutable
+image references. Piploy supports running .NET applications, so the Microsoft
+.NET namespace remains an explicit application-image allowlist. `scratch` and
+earlier Docker build stages are not external references and remain valid. The
+validator collects every violation and prevents Docker from being called when
+one is found.
 
 ## Consequences
 
@@ -34,5 +37,6 @@ quarantine.
 
 Application Dockerfiles must update base-image digests in reviewed commits.
 Piploy never advances a digest automatically. The policy establishes image
-identity and allowlisted publishers; it does not sandbox Dockerfile build
-commands or verify image signatures/provenance.
+identity and limits registries, but any publisher can create a repository on
+GitHub Container Registry. It does not sandbox Dockerfile build commands or
+verify image signatures or provenance.

--- a/docs/agents/registering-an-application.md
+++ b/docs/agents/registering-an-application.md
@@ -48,10 +48,10 @@ Before proposing a change, inspect the application repository and confirm:
 
 Also read the Dockerfile's `FROM` and external `COPY --from` references.
 Piploy accepts only SHA-256-digest-pinned Docker Official Images
-(`docker.io/library/*`, including short names) and Microsoft .NET images
-(`mcr.microsoft.com/dotnet/*`). `scratch` and earlier build stages are valid;
-other external references are rejected. Piploy does not advance image digests
-for the Application.
+(`docker.io/library/*`, including short names), GitHub Container Registry images
+(`ghcr.io/*`), and Microsoft .NET images (`mcr.microsoft.com/dotnet/*`).
+`scratch` and earlier build stages are valid; other external references are
+rejected. Piploy does not advance image digests for the Application.
 
 ## Application payload reference
 

--- a/src/dockerPlan.ts
+++ b/src/dockerPlan.ts
@@ -340,6 +340,7 @@ function validateExternalReference(
     });
   } else if (
     normalized?.startsWith("docker.io/library/") ||
+    /^ghcr\.io\/.+@sha256:[a-f\d]{64}$/i.test(reference) ||
     /^mcr\.microsoft\.com\/dotnet\/.+@sha256:[a-f\d]{64}$/i.test(reference)
   ) {
     return;
@@ -347,7 +348,7 @@ function validateExternalReference(
     violations.push({
       reference,
       reason:
-        "must be a Docker Official Image or mcr.microsoft.com/dotnet image",
+        "must be a Docker Official Image, ghcr.io image, or mcr.microsoft.com/dotnet image",
     });
   }
 }

--- a/test/unit/dockerPlan.test.ts
+++ b/test/unit/dockerPlan.test.ts
@@ -389,12 +389,13 @@ describe("getBuildContextPathFromSetting", () => {
 });
 
 describe("validateDockerfileImageReferences", () => {
-  it("accepts digest-pinned official and Microsoft .NET images", () => {
+  it("accepts digest-pinned images from allowed registries", () => {
     expect(
       validateDockerfileImageReferences(`
         FROM --platform=linux/arm64 node:current-slim@sha256:${digest} AS build
         FROM library/nginx:latest@sha256:${digest}
         FROM docker.io/library/alpine@sha256:${digest}
+        FROM ghcr.io/voidzero-dev/vite-plus:0.3.0@sha256:${digest}
         FROM mcr.microsoft.com/dotnet/core/sdk:3.1@sha256:${digest}
       `),
     ).toEqual([]);
@@ -426,7 +427,8 @@ describe("validateDockerfileImageReferences", () => {
         ARG NODE_IMAGE=node:latest
         FROM node:latest
         COPY --from=docker.io/someone/tool@sha256:${digest} /tool /tool
-        FROM ghcr.io/example/image@sha256:${digest}
+        FROM ghcr.io/example/image:latest
+        FROM quay.io/example/image@sha256:${digest}
         FROM \${NODE_IMAGE}
       `),
     ).toEqual([
@@ -437,12 +439,16 @@ describe("validateDockerfileImageReferences", () => {
       {
         reference: `docker.io/someone/tool@sha256:${digest}`,
         reason:
-          "must be a Docker Official Image or mcr.microsoft.com/dotnet image",
+          "must be a Docker Official Image, ghcr.io image, or mcr.microsoft.com/dotnet image",
       },
       {
-        reference: `ghcr.io/example/image@sha256:${digest}`,
+        reference: "ghcr.io/example/image:latest",
+        reason: "must be pinned with an @sha256 digest",
+      },
+      {
+        reference: `quay.io/example/image@sha256:${digest}`,
         reason:
-          "must be a Docker Official Image or mcr.microsoft.com/dotnet image",
+          "must be a Docker Official Image, ghcr.io image, or mcr.microsoft.com/dotnet image",
       },
       {
         reference: "${NODE_IMAGE}",


### PR DESCRIPTION
## Summary

- allow external `ghcr.io` image references when pinned with a full SHA-256 digest
- continue rejecting unpinned GHCR images and images from other unapproved registries
- document that a digest fixes image identity but does not establish publisher trust on GHCR

## Validation

- `pnpm lint`
- `pnpm test` (236 tests)
- `pnpm build`