### PR TITLE
Build Application images with opt-in Buildx and protected cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,3 +279,12 @@ will remain in systemd's restart loop until it is rolled back manually.
 ## TODO
 
 - Git commit hook + minimal web server on the Pi to receive the hook so Piploy does not have to poll.
+
+## Optional Buildx builds
+
+Buildx is disabled by default, including after automatic bundle updates.
+See the [Buildx rollout and recovery runbook](docs/buildx-rollout.md) before
+activation. It covers supported versions, explicit setup, cache retention,
+Docker storage checks, verified image recovery archives, and rollback with
+automatic updates paused. Production activation is a separately approved
+operation.

--- a/docs/adr/0001-config-validation-and-logging.md
+++ b/docs/adr/0001-config-validation-and-logging.md
@@ -89,3 +89,16 @@ is intentionally not ISO 8601 week numbering.
 Configuration errors fail at startup instead of surfacing later during a
 Poll. Log files are compact and directly readable, but changing the log
 format or retention policy requires an explicit compatibility decision.
+
+The optional `Buildx` object enables the dedicated builder only when `Enabled`
+is true. Retention and storage settings are validated at startup and require
+a restart. Defaults protect cache used in the last 720 hours, target 8 GiB of
+cache, and require 5 GiB free before a new build. A storage postponement is a
+build-stage Poll result with code `buildPostponed`; a later Poll retries it.
+Existing-image reuse precedes builder and storage checks. See the
+[Buildx rollout runbook](../buildx-rollout.md).
+
+Opt-in Buildx progress uses timestamped info-level lines so operators can see
+Dockerfile execution and cache reuse with the normal installed logger. Legacy
+Dockerode progress retains its debug level. Build summaries include total
+duration and follow verification of the expected image in the Engine store.

--- a/docs/adr/0002-module-seams-and-test-split.md
+++ b/docs/adr/0002-module-seams-and-test-split.md
@@ -48,3 +48,10 @@ containers on a developer machine out of test cleanup.
 Unit tests focus on deterministic policy and sequencing. Integration tests
 cover behavior whose correctness depends on Git or Docker rather than on a
 substitute implementation.
+
+`buildx.ts` owns the opt-in Docker CLI builder operations. `docker.ts` retains
+Dockerfile validation, context creation, image identity, container operations,
+and Application-image cleanup. Builder state is separate from Application
+images. Normal cleanup preserves every image referenced by a container and
+never invokes a global prune. A successful build does not imply successful
+container replacement.

--- a/docs/adr/0004-supply-chain-controls.md
+++ b/docs/adr/0004-supply-chain-controls.md
@@ -40,3 +40,11 @@ Piploy never advances a digest automatically. The policy establishes image
 identity and limits registries, but any publisher can create a repository on
 GitHub Container Registry. It does not sandbox Dockerfile build commands or
 verify image signatures or provenance.
+
+## BuildKit infrastructure image
+
+Piploy's opt-in Buildx adapter may use the single upstream
+`docker.io/moby/buildkit` image pinned by digest in `src/buildx.ts`. This is a
+narrow exception for the builder and its read-only filesystem measurement
+container. It does not expand the Application Dockerfile allowlist. Changes
+to the digest require a reviewed commit and ARM64 manifest verification.

--- a/docs/adr/0005-application-state-and-volume-model.md
+++ b/docs/adr/0005-application-state-and-volume-model.md
@@ -40,3 +40,10 @@ directory derived next to `piploy.json` — the same rule that already locates
 - Files in a Volume are owned by whatever user the container runs as. An
   Application whose Dockerfile sets no `USER` writes root-owned files that the
   service user cannot read without `sudo`.
+
+The opt-in Buildx adapter has one infrastructure exception to the mount rule:
+a short-lived read-only measurement container binds the verified Engine storage
+directory to measure its free space, including when the Engine is remote.
+This never changes Application mounts or grants Application Dockerfiles access
+to those directories. Its Docker cache volume and private builder metadata
+survive `wipeall`; Application data remains untouched.

--- a/docs/buildx-rollout.md
+++ b/docs/buildx-rollout.md
@@ -1,0 +1,349 @@
+# Buildx rollout and recovery
+
+This runbook supports the human-owned rollout in issue #140. Merging the code
+does not activate Buildx. Automatic bundle updates leave it disabled unless
+`Piploy.Buildx.Enabled` is explicitly true.
+
+Before production access, an assisting agent must read the environment's
+private production instructions. Keep service identities, paths, endpoints,
+configuration contents, and credentials in a private working record. For each
+production mutation, show the exact resolved command, its effect, failure
+risk, and rollback, then obtain approval for that one action. Machine-level
+package installation always requires approval. Do not run this document as a
+single script.
+
+## Supported components
+
+Use Linux Docker Engine and CLI 29 or newer, Buildx 0.36 or newer, and the
+pinned BuildKit 0.32.0 multi-platform image below. Its index includes native
+`linux/arm64` and `linux/amd64` images. Piploy checks the Engine identity,
+versions, owned builder metadata/container, and effective GC policy before
+using the builder. The CLI uses Dockerode's Engine endpoint explicitly;
+it never selects a different Docker context or changes the default builder.
+
+```text
+docker.io/moby/buildkit:v0.32.0@sha256:1f8167fcb0eca5b7126353d35299386945cbb8949cc516c592a49f80cfce4fa2
+```
+
+ARM64 manifest:
+`sha256:518fe61c1c400205c50541fd57bbb6eb11549027737fb8c76ac56af48e42c181`.
+This infrastructure image has the narrow exception recorded in ADR-0004.
+Application Dockerfile image rules remain unchanged.
+
+## Read-only checks
+
+Run as the daemon's service account, with its Docker environment. First
+resolve the installed bundle, configuration, systemd unit, and Engine endpoint
+from private instructions. In the command examples, set `piploy_bundle`,
+`piploy_config`, `piploy_unit`, and `piploy_engine` to those verified values.
+Do not assume that an operator's interactive Docker context matches them.
+Set `export PIPLOY_CONFIG="$piploy_config"` in this operator shell so every
+bundle command reads the same configuration as the daemon.
+
+```bash
+uname -m
+node "$piploy_bundle" --version
+docker --host "$piploy_engine" version
+docker --host "$piploy_engine" buildx version
+docker --host "$piploy_engine" info --format '{{.ID}} {{.Driver}} {{json .DriverStatus}} {{.DockerRootDir}}'
+docker --host "$piploy_engine" buildx ls
+node "$piploy_bundle" status
+systemctl status "$piploy_unit"
+```
+
+Confirm there is no in-flight Poll or self-update. Record health and current
+image/container identities for every Application. Inventory legacy cache with
+`docker --host "$piploy_engine" system df -v` and read-only image listings.
+Piploy will not import or prune unidentified legacy cache. If manual maintenance
+is needed, prepare exact resource targets and obtain separate approval.
+
+Measure the filesystem containing the Engine's `DockerRootDir` on the Engine
+host, not the CLI host. On a Pi using `overlay2`, run `df -h` against that
+reported directory. For containerd image storage, also find the actual
+containerd data directory from its service arguments/configuration and measure
+that filesystem. Docker's `data-root` does not relocate containerd data.
+With Docker Desktop, these paths belong to the VM.
+
+Piploy measures via a short-lived, network-disabled, read-only container using
+the pinned image and a read-only bind of the Engine storage directory. This
+infrastructure operation does not alter Application Volume configuration.
+The measured minimum covers Docker's data directory and the helper's root
+filesystem, which resides on the Engine's image snapshot storage. This also
+covers the usual containerd image store when it uses a different filesystem
+from Docker's data directory. Builder bootstrap/image download also needs space; budget
+for it before activation. A 5 GiB preflight threshold cannot guarantee that an
+arbitrary build fits. Build/export failures leave the current Application in
+place and never trigger deletion to recover disk space.
+
+## Installation if required
+
+The Pi evidence collected for this change showed Engine/CLI 29.7.0, Buildx
+0.36.0, ARM64, `overlay2`, and 34 GiB available. Recheck at rollout time.
+These versions do not require an upgrade for this feature.
+
+If prerequisites are missing, follow Docker's official
+[Raspberry Pi OS/Debian installation instructions](https://docs.docker.com/engine/install/debian/).
+First inspect the configured package sources and available versions:
+
+```bash
+apt-cache policy docker-ce docker-ce-cli docker-buildx-plugin
+apt-cache madison docker-ce docker-ce-cli docker-buildx-plugin
+```
+
+Prepare a version-pinned install command using the actual package versions
+from that output, for example `sudo apt-get install docker-ce-cli=VERSION
+ docker-buildx-plugin=VERSION`. Show the fully resolved command before approval.
+An Engine upgrade may restart Docker and affect running Applications; plan it
+separately with a health baseline and package downgrade/recovery procedure.
+If Docker's repository is absent, prepare each repository/key setup command
+from the official instructions for the detected OS, and approve each write
+separately. Piploy never installs packages itself.
+
+## Preserve recovery before activation
+
+Choose a recovery directory outside Piploy's root directory, Docker cleanup,
+and normal release backup names. Resolve it as `piploy_recovery`. Preserve a
+separately named known-good bundle and configuration there; `.prev` alone is
+insufficient because another self-update can replace it. Approve each copy.
+Record checksums and verify the copied bundle's version.
+
+Expand each copy command and approve it separately:
+
+```bash
+cp --preserve=mode "$piploy_bundle" "$piploy_recovery/known-good-piploy.cjs"
+cp --preserve=mode "$piploy_config" "$piploy_recovery/known-good-piploy.json"
+```
+
+Then record `sha256sum` of both copies and compare with the originals. Check
+`PIPLOY_CONFIG="$piploy_recovery/known-good-piploy.json" node
+"$piploy_recovery/known-good-piploy.cjs" --version`.
+
+Before updating a representative Application, resolve `previous_image` from
+the running container's inspected `.Image` value, and preserve its container
+configuration privately. Prepare an exact `docker create` command from the
+current container's ports, bind mounts, environment references, restart policy,
+name, and image. Do not publish environment values. Check the Application's
+health endpoint and record its expected response.
+
+Account for the uncompressed image size, archive space, builder download,
+new image, and cache growth. The archive must leave the configured minimum
+free space plus room for the planned build. Prefer a separate recovery disk.
+An image ID or extra tag is not a recovery archive.
+
+The following are separately approved writes:
+
+```bash
+docker --host "$piploy_engine" image save --output "$piploy_recovery/application-image.tar" "$previous_image"
+sha256sum "$piploy_recovery/application-image.tar" > "$piploy_recovery/application-image.tar.sha256"
+```
+
+Read-only verification:
+
+```bash
+sha256sum --check "$piploy_recovery/application-image.tar.sha256"
+tar -tf "$piploy_recovery/application-image.tar"
+```
+
+Confirm the archive contains a manifest/index and the image configuration and
+layers. On an isolated recovery Engine, approve an `image load --input` of the
+archive and verify that `image inspect "$previous_image"` succeeds. Prepare
+that same load command for production recovery before the representative
+update. Keep the archive through the full observation period. Deleting it
+requires separate approval.
+
+## Activate
+
+Stop the daemon with a separately approved `systemctl stop "$piploy_unit"`.
+Existing Application containers keep running under Docker. This pauses Polls
+and automatic self-update while configuration and builder setup are reviewed.
+Back up the private `.piploy-buildx` directory next to the configuration if it
+already exists. It contains builder ownership and configuration metadata.
+
+Prepare this addition inside the existing `Piploy` object, preserving all
+other settings. Approve the exact configuration edit before writing it:
+
+```json
+"Buildx": {
+  "Enabled": true,
+  "CacheRetentionHours": 720,
+  "CacheTargetBytes": 8589934592,
+  "MinimumFreeBytes": 5368709120
+}
+```
+
+These settings require a restart. The cache target is a soft target, not a
+quota. Running an Application does not refresh its intermediate cache's last
+use; only builds using those records do. Both automatic GC and explicit prune
+have the same last-use protection, with one GC policy and no broader fallback.
+Eligible old cache is reclaimed least recently used first. Recent cache may
+therefore exceed the target, and new builds may be postponed until capacity is
+available. Existing-image reuse and running Applications continue.
+
+Before the first Poll, prepare and approve the exact builder setup operations
+using the values generated by `src/buildx.ts` in the reviewed release. The
+normal builder name is `piploy-` plus the first 24 hex characters of SHA-256 of
+`absolute configuration path + :normal`. Its Buildx metadata directory is
+`.piploy-buildx/normal` next to that configuration. Test builders use `:test`,
+`piploy-test-`, and `.piploy-buildx/test` instead. Set `BUILDX_CONFIG` to the
+normal metadata directory for every inspection or maintenance command.
+
+Creation uses `buildx create --name NAME --driver docker-container`, the pinned
+image, `env.PIPLOY_BUILDER_OWNER=OWNER`, `env.PIPLOY_BUILDER_POLICY=HASH`, and
+`--buildkitd-config FILE`, followed by the explicit Engine endpoint. OWNER is
+the same 24-character hash used in the name; HASH is SHA-256 of the exact TOML
+below, including final newline and indentation. Generate that file with the
+reviewed `buildkitConfiguration` function, not a hand-reformatted copy.
+Approve the config-file write, builder creation, and `buildx inspect NAME
+--bootstrap` separately. Bootstrap pulls the pinned image and creates a
+privileged BuildKit container with a persistent Docker volume. Review disk
+cost and privilege implications before approval.
+
+```toml
+[worker.oci]
+  gc = true
+[[worker.oci.gcpolicy]]
+  all = true
+  keepDuration = "2592000s"
+  reservedSpace = 0
+  maxUsedSpace = 8589934592
+  minFreeSpace = 5368709120
+[worker.containerd]
+  enabled = false
+```
+
+Resolve these local variables read-only before proposing setup commands:
+
+```bash
+piploy_config="$(node -e 'process.stdout.write(require("node:path").resolve(process.argv[1]))' "$piploy_config")"
+piploy_owner="$(node -e 'const c=require("node:crypto");process.stdout.write(c.createHash("sha256").update(process.argv[1]).update(":normal").digest("hex").slice(0,24))' "$piploy_config")"
+piploy_builder="piploy-$piploy_owner"
+export BUILDX_CONFIG="$(dirname "$piploy_config")/.piploy-buildx/normal"
+piploy_builder_config="$BUILDX_CONFIG/buildkitd.toml"
+piploy_buildkit_image='docker.io/moby/buildkit:v0.32.0@sha256:1f8167fcb0eca5b7126353d35299386945cbb8949cc516c592a49f80cfce4fa2'
+```
+
+Approve `mkdir -p -m 700 "$BUILDX_CONFIG"` separately. Then approve writing the
+exact TOML above to `"$piploy_builder_config"` with mode 600, using a here-document
+that retains its two-space indentation and final newline. Compute its hash:
+
+```bash
+piploy_policy="$(sha256sum "$piploy_builder_config" | cut -d ' ' -f 1)"
+```
+
+Before builder creation, inspect `buildx_buildkit_${piploy_builder}0_state` if
+it exists. Its `piploy_builderOwner` label must equal `$piploy_owner`, its driver
+must be `local`, and its options must be empty. Never add an ownership label
+to an unidentified existing volume. If absent, expand and separately approve:
+
+```bash
+docker --host "$piploy_engine" volume create --driver local --label "piploy_builderOwner=$piploy_owner" "buildx_buildkit_${piploy_builder}0_state"
+```
+
+Expand and show each of these commands for separate approval:
+
+```bash
+docker --host "$piploy_engine" buildx create --name "$piploy_builder" --driver docker-container --driver-opt "image=$piploy_buildkit_image" --driver-opt "env.PIPLOY_BUILDER_OWNER=$piploy_owner" --driver-opt "env.PIPLOY_BUILDER_POLICY=$piploy_policy" --buildkitd-config "$piploy_builder_config" "$piploy_engine"
+docker --host "$piploy_engine" buildx inspect "$piploy_builder" --bootstrap
+```
+
+Verify metadata, container image and ownership markers, Engine endpoint, and
+`GCPolicy` through `buildx ls --format '{{json .}}'`. It must show exactly one
+policy, `all=true`, 30-day `keepDuration`, 8 GiB `maxUsedSpace`, 5 GiB
+`minFreeSpace`, and zero reserved space. Inspect the generated container and
+its persistent state volume. Never adopt or remove a matching name whose
+ownership is unverified. A settings change recreates a verified owned builder
+with `buildx rm --keep-state` before applying the new policy. Approve those
+exact operations as part of any production retention change.
+
+With recovery ready and builder verified, approve restarting the daemon.
+Startup queues a Poll, so this action also authorizes its identified Application
+updates. If a representative update needs a manual Poll, approve that exact
+command and expected commit separately. Buildx progress is timestamped at info level.
+
+## Verify and observe
+
+Check Application health, status, the loaded commit image in the same Engine,
+Buildx progress, total build duration, and container replacement separately.
+Record elapsed times without claiming a speedup from incomparable builds.
+Repeat normal status/cache/free-space checks after at least one later normal
+Poll. Restart the daemon only with approval and verify that the owned builder
+and cache persist. Verify the operator's default builder/context is unchanged.
+Use the local integration evidence for low-space and destructive cache tests;
+do not force disk exhaustion or cache deletion on production.
+
+## Interrupted builder recreation
+
+The cache volume carries ownership independently of the Buildx metadata. If
+creation or a retention change is interrupted after `buildx rm --keep-state`,
+Piploy verifies that label, the local driver, and empty volume options on the
+next Poll, then recreates the builder using the retained cache. No cache
+migration or deletion is needed. A missing CLI must be repaired before retry.
+
+For production recovery, keep the daemon stopped while inspecting:
+
+```bash
+docker --host "$piploy_engine" volume inspect "buildx_buildkit_${piploy_builder}0_state"
+docker --host "$piploy_engine" buildx ls --format '{{json .}}'
+```
+
+If metadata and container are absent but the volume ownership checks match,
+prepare the exact create and bootstrap commands from Activate, using the
+approved configuration. Approve each separately, verify the effective policy,
+and only then approve the next Poll. If the label does not match, or a container
+exists without metadata, stop and restore the saved metadata after checking
+its Engine, image, owner, and configuration. Do not adopt the volume by name,
+relabel it, or delete it to make the error disappear.
+
+## Disable or recover
+
+If prerequisites, retention, storage, or Application health are wrong, pause
+Piploy with an approved service stop. Preserve diagnostics before changing
+anything else. Disabling Buildx means an approved edit setting `Enabled` to
+false, then an approved restart. The bundle continues using Dockerode's legacy
+build path. Disabling does not remove cache or roll back Application commits.
+The dedicated builder's already-configured automatic GC continues while its
+container runs; optionally stop the verified builder container with separate
+approval to pause it. Builder deletion is never necessary for recovery.
+
+For bundle recovery, keep the service stopped, approve restoration of the
+separately saved bundle and configuration, and verify their checksums/version.
+Keep the service stopped to prevent automatic self-update from undoing rollback.
+For temporary Application checks use a separately approved manual CLI Poll
+only after correcting the failed commit; manual Poll does not self-update.
+Do not restart the automatic daemon until the release/commit problem is fixed
+or the owner approves another plan. Restoring ordinary service operation also
+restores timer-driven automatic self-update; verify that this is intentional.
+
+If an Application needs recovery, keep Polls paused throughout:
+
+1. Verify the archive checksum again.
+2. Approve loading the archive into the correct Engine.
+3. Inspect the recovered image by the recorded image ID.
+4. Approve removal of only the failed replacement container, if present.
+5. Approve the prepared container-create command using the recovered image,
+   preserved Application data mounts and original runtime settings.
+6. Approve starting that container, then check its health.
+
+A restored bundle/configuration does not itself restore an Application. Keep
+Piploy paused until the failed source commit is corrected or the owner approves
+another recovery plan, otherwise the next Poll will immediately reapply it.
+Never use `wipeall`, global image/system/volume pruning, or Application-data
+deletion as a recovery step.
+
+`wipeall` retains its existing meaning: remove Piploy Application containers,
+images, and root-directory contents while preserving Application data. It does
+not delete the dedicated BuildKit builder, its metadata, or cache volume.
+Removed Applications still receive explicit container/image cleanup during
+Poll. Obsolete unreferenced Application images are removed separately from
+cache. Unrelated containers and their referenced images are protected.
+
+Record sanitized rollout evidence in #140. A rollback leaves that issue open.
+Retain recovery copies and archives through observation; approve any later
+archive or verified-builder deletion separately.
+
+## Upstream references
+
+- [Dedicated builder and persistence](https://docs.docker.com/build/builders/drivers/docker-container/)
+- [BuildKit configuration](https://docs.docker.com/build/buildkit/toml-configuration/)
+- [Prune age filters and storage targets](https://docs.docker.com/reference/cli/docker/buildx/prune/)
+- [Docker and containerd data directories](https://docs.docker.com/engine/daemon/)

--- a/src/buildx.ts
+++ b/src/buildx.ts
@@ -1,0 +1,454 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+import type Dockerode from "dockerode";
+
+import type { Logger } from "./logger.js";
+import type { PiploySettings } from "./settings.js";
+import { resolveConfigPath } from "./settings.js";
+
+export const buildkitImage =
+  "docker.io/moby/buildkit:v0.32.0@sha256:1f8167fcb0eca5b7126353d35299386945cbb8949cc516c592a49f80cfce4fa2";
+
+export class BuildPostponedError extends Error {
+  readonly code = "buildPostponed";
+  constructor(reason: string) {
+    super(
+      `Build postponed: ${reason}. Check Docker storage and Buildx prerequisites; Piploy will retry on a later Poll.`,
+    );
+    this.name = "BuildPostponedError";
+  }
+}
+
+export function buildkitConfiguration(
+  retentionHours: number,
+  targetBytes: number,
+  minimumFreeBytes: number,
+): string {
+  return `[worker.oci]\n  gc = true\n[[worker.oci.gcpolicy]]\n  all = true\n  keepDuration = "${retentionHours * 3600}s"\n  reservedSpace = 0\n  maxUsedSpace = ${targetBytes}\n  minFreeSpace = ${minimumFreeBytes}\n[worker.containerd]\n  enabled = false\n`;
+}
+
+export function parseAvailableBytes(output: string): number {
+  const lines = output.trim().split("\n");
+  const available = lines
+    .slice(1)
+    .map((line) => Number(line.trim().split(/\s+/)[3]) * 1024);
+  if (
+    available.length < 1 ||
+    available.some((value) => !Number.isSafeInteger(value) || value < 0)
+  ) {
+    throw new Error("Docker storage free-space measurement was invalid");
+  }
+  return Math.min(...available);
+}
+
+interface CommandOptions {
+  input?: NodeJS.ReadableStream;
+  signal?: AbortSignal;
+  progress?: boolean;
+}
+
+export function createBuildx(
+  settings: PiploySettings,
+  docker: Dockerode,
+  logger: Logger,
+) {
+  const policy = settings.Buildx!;
+  const owner = createHash("sha256")
+    .update(path.resolve(resolveConfigPath()))
+    .update(settings.IsTestRun ? ":test" : ":normal")
+    .digest("hex")
+    .slice(0, 24);
+  const name = `piploy-${settings.IsTestRun ? "test-" : ""}${owner}`;
+  const directory = path.join(
+    path.dirname(path.resolve(resolveConfigPath())),
+    ".piploy-buildx",
+    settings.IsTestRun ? "test" : "normal",
+  );
+  const configuration =
+    (settings.IsTestRun ? "debug = true\n" : "") +
+    buildkitConfiguration(
+      policy.CacheRetentionHours,
+      policy.CacheTargetBytes,
+      policy.MinimumFreeBytes,
+    );
+  const policyHash = createHash("sha256").update(configuration).digest("hex");
+  const containerName = `buildx_buildkit_${name}0`;
+  const stateVolumeName = `${containerName}_state`;
+  let endpoint: string | undefined;
+
+  async function command(
+    args: string[],
+    options: CommandOptions = {},
+  ): Promise<string> {
+    options.signal?.throwIfAborted();
+    return new Promise((resolve, reject) => {
+      const child = spawn(
+        "docker",
+        endpoint ? ["--host", endpoint, ...args] : args,
+        {
+          shell: false,
+          env: {
+            ...process.env,
+            DOCKER_CONTEXT: undefined,
+            BUILDX_BUILDER: undefined,
+            BUILDX_CONFIG: directory,
+          },
+          stdio: ["pipe", "pipe", "pipe"],
+        },
+      );
+      let output = "";
+      let pending = "";
+      let inputError: unknown;
+      let killTimer: ReturnType<typeof setTimeout> | undefined;
+      const abort = () => {
+        child.kill("SIGTERM");
+        killTimer ??= setTimeout(() => child.kill("SIGKILL"), 5000);
+        killTimer.unref();
+      };
+      const timeout = options.progress ? undefined : setTimeout(abort, 120000);
+      timeout?.unref();
+      options.signal?.addEventListener("abort", abort, { once: true });
+      const onData = (data: Buffer) => {
+        output = (output + data.toString()).slice(-1024 * 1024);
+        if (options.progress) {
+          pending += data.toString();
+          const lines = pending.split(/\r?\n/);
+          pending = lines.pop() ?? "";
+          for (const line of lines) if (line) logger.info(`Buildx ${line}`);
+          if (pending.length > 16384) {
+            logger.info(`Buildx ${pending.slice(0, 16384)}`);
+            pending = "";
+          }
+        }
+      };
+      child.stdout.on("data", onData);
+      child.stderr.on("data", onData);
+      child.once("error", () => {
+        clearTimeout(timeout);
+        clearTimeout(killTimer);
+        options.signal?.removeEventListener("abort", abort);
+        reject(
+          new Error(
+            "Cannot execute Docker CLI. Install the supported Docker CLI and Buildx plugin before enabling Buildx.",
+          ),
+        );
+      });
+      child.once("close", (code) => {
+        clearTimeout(timeout);
+        clearTimeout(killTimer);
+        options.signal?.removeEventListener("abort", abort);
+        if (pending) logger.info(`Buildx ${pending}`);
+        if (options.signal?.aborted)
+          reject(new Error("Buildx operation cancelled"));
+        else if (code !== 0 || inputError)
+          reject(
+            new Error(
+              `Buildx ${args.slice(0, args[0] === "buildx" ? 2 : 1).join(" ")} operation failed (exit ${String(code)}). ${options.progress ? "Check timestamped build progress for Dockerfile, export, or disk errors." : args[0] === "run" ? "Docker storage measurement failed; check Engine storage access and capacity." : "Check Docker CLI/Buildx prerequisites and the owned builder using docs/buildx-rollout.md."}`,
+            ),
+          );
+        else resolve(output);
+      });
+      if (options.input) {
+        void pipeline(options.input as Readable, child.stdin).catch(
+          (error: unknown) => {
+            inputError = error;
+            abort();
+          },
+        );
+      } else child.stdin.end();
+    });
+  }
+
+  async function preflight(signal?: AbortSignal): Promise<void> {
+    const run = (args: string[]) => command(args, { signal });
+    // Dockerode resolves DOCKER_HOST itself. An explicit endpoint prevents CLI
+    // context selection from redirecting builds to another Engine.
+    const modem = docker.modem as unknown as {
+      getSocketPath(): Promise<string> | undefined;
+    };
+    const socketPath = await modem.getSocketPath();
+    if (socketPath) endpoint = `unix://${socketPath}`;
+    else if (process.env.DOCKER_HOST) endpoint = process.env.DOCKER_HOST;
+    else throw new Error("Buildx requires an explicit Docker Engine endpoint");
+    const info = await docker.info();
+    const cliInfo = JSON.parse(await run(["info", "--format", "{{json .}}"]));
+    if (!info.ID || cliInfo.ID !== info.ID)
+      throw new Error("Docker CLI and Dockerode must address the same Engine");
+    const version = JSON.parse(
+      await run(["version", "--format", "{{json .}}"]),
+    );
+    const buildxVersion = await run(["buildx", "version"]);
+    const cliMajor = Number(
+      /^(\d+)\./.exec(String(version.Client?.Version))?.[1],
+    );
+    const engineMajor = Number(
+      /^(\d+)\./.exec(String(version.Server?.Version))?.[1],
+    );
+    const buildxMatch = /\bv(\d+)\.(\d+)\./.exec(buildxVersion);
+    if (
+      !(cliMajor >= 29) ||
+      !(engineMajor >= 29) ||
+      !buildxMatch ||
+      !(Number(buildxMatch[1]) > 0 || Number(buildxMatch[2]) >= 36)
+    ) {
+      throw new Error(
+        "Buildx requires Docker Engine/CLI 29 or newer and Buildx 0.36 or newer. Install compatible versions before activation.",
+      );
+    }
+    if (info.OSType !== "linux")
+      throw new Error("Piploy Buildx requires a Linux Docker Engine");
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+  }
+
+  async function verifyContainer(expectedPolicy = policyHash): Promise<void> {
+    const container = await docker.getContainer(containerName).inspect();
+    if (
+      !container.Mounts.some(
+        (mount) =>
+          mount.Name === stateVolumeName &&
+          mount.Destination === "/var/lib/buildkit",
+      ) ||
+      container.Config.Image !== buildkitImage ||
+      !container.Config.Env?.includes(`PIPLOY_BUILDER_OWNER=${owner}`) ||
+      !container.Config.Env?.includes(`PIPLOY_BUILDER_POLICY=${expectedPolicy}`)
+    ) {
+      throw new Error(
+        "Piploy builder ownership or retention configuration differs. Follow the runbook to inspect and recreate the owned builder with cache preserved.",
+      );
+    }
+  }
+
+  async function ensureBuilder(signal?: AbortSignal): Promise<void> {
+    const run = (args: string[]) => command(args, { signal });
+    await preflight(signal);
+    const containers = await docker.listContainers({ all: true });
+    const exists = containers.some((container) =>
+      container.Names.includes(`/${containerName}`),
+    );
+    const volume = (await docker.listVolumes()).Volumes?.find(
+      (candidate) => candidate.Name === stateVolumeName,
+    );
+    if (
+      volume &&
+      (volume.Labels?.piploy_builderOwner !== owner ||
+        volume.Driver !== "local" ||
+        Object.keys(volume.Options ?? {}).length !== 0)
+    ) {
+      throw new Error(
+        "An unidentified Piploy cache volume already exists. Inspect its ownership using the runbook; Piploy will not adopt it.",
+      );
+    }
+    if (exists && !volume)
+      throw new Error(
+        "Piploy builder has no owned cache volume; inspect the builder before recovery",
+      );
+    // Private Buildx metadata avoids changing the operator's default builder.
+    const inspected = (await run(["buildx", "ls", "--format", "{{json .}}"]))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line))
+      .find((builder) => builder.Name === name);
+    let create = !inspected;
+    if (inspected) {
+      const previousPolicy =
+        inspected.Nodes?.[0]?.DriverOpts?.["env.PIPLOY_BUILDER_POLICY"];
+      if (
+        inspected.Driver !== "docker-container" ||
+        inspected.Nodes?.length !== 1 ||
+        inspected.Nodes[0].Endpoint !== endpoint ||
+        inspected.Nodes[0].DriverOpts?.["env.PIPLOY_BUILDER_OWNER"] !== owner ||
+        inspected.Nodes[0].DriverOpts?.image !== buildkitImage ||
+        typeof previousPolicy !== "string" ||
+        !/^[a-f0-9]{64}$/.test(previousPolicy)
+      ) {
+        throw new Error(
+          "Piploy builder ownership or Engine differs. Inspect it using the runbook before making changes.",
+        );
+      }
+      if (exists) await verifyContainer(previousPolicy);
+      if (previousPolicy !== policyHash) {
+        await run(["buildx", "rm", "--keep-state", name]);
+        logger.info(
+          "Recreating owned Buildx builder with restart-applied retention; persistent cache retained",
+        );
+        create = true;
+      }
+    } else {
+      if (exists)
+        throw new Error(
+          "Piploy builder container exists without its Buildx metadata. Restore the metadata before building.",
+        );
+      if (volume)
+        logger.info(
+          "Resuming owned Buildx builder creation with retained cache",
+        );
+    }
+    if (!volume) {
+      signal?.throwIfAborted();
+      // The label survives buildx rm --keep-state, so a later Poll can safely
+      // resume an interrupted creation without trusting the volume name alone.
+      await docker.createVolume({
+        Name: stateVolumeName,
+        Driver: "local",
+        Labels: { piploy_builderOwner: owner },
+      });
+    }
+    const verifiedVolume = await docker.getVolume(stateVolumeName).inspect();
+    if (
+      verifiedVolume.Labels?.piploy_builderOwner !== owner ||
+      verifiedVolume.Driver !== "local" ||
+      Object.keys(verifiedVolume.Options ?? {}).length !== 0
+    ) {
+      throw new Error(
+        "Piploy cache volume ownership changed before builder creation; inspect it before retrying",
+      );
+    }
+    if (create) {
+      const configPath = path.join(directory, "buildkitd.toml");
+      writeFileSync(configPath, configuration, { mode: 0o600 });
+      await run([
+        "buildx",
+        "create",
+        "--name",
+        name,
+        "--driver",
+        "docker-container",
+        "--driver-opt",
+        `image=${buildkitImage}`,
+        "--driver-opt",
+        `env.PIPLOY_BUILDER_OWNER=${owner}`,
+        "--driver-opt",
+        `env.PIPLOY_BUILDER_POLICY=${policyHash}`,
+        "--buildkitd-config",
+        configPath,
+        endpoint!,
+      ]);
+    }
+    await run(["buildx", "inspect", name, "--bootstrap"]);
+    await verifyContainer();
+    const running = (await run(["buildx", "ls", "--format", "{{json .}}"]))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line))
+      .find((builder) => builder.Name === name);
+    const policies = running?.Nodes?.[0]?.GCPolicy;
+    if (
+      running?.Nodes?.[0]?.Version !== "v0.32.0" ||
+      policies?.length !== 1 ||
+      policies[0].all !== true ||
+      policies[0].keepDuration !== policy.CacheRetentionHours * 3600 * 1e9 ||
+      policies[0].maxUsedSpace !== policy.CacheTargetBytes ||
+      policies[0].minFreeSpace !== policy.MinimumFreeBytes ||
+      policies[0].reservedSpace !== 0
+    ) {
+      throw new Error(
+        "Piploy BuildKit version or effective GC policy differs; stop the owned builder and restore the runbook configuration",
+      );
+    }
+  }
+
+  async function cleanup(signal?: AbortSignal): Promise<void> {
+    const run = (args: string[]) => command(args, { signal });
+    await ensureBuilder(signal);
+    const result = await run([
+      "buildx",
+      "prune",
+      "--builder",
+      name,
+      "--force",
+      "--all",
+      "--filter",
+      `until=${policy.CacheRetentionHours * 3600}s`,
+      "--max-used-space",
+      String(policy.CacheTargetBytes),
+      "--min-free-space",
+      String(policy.MinimumFreeBytes),
+      "--reserved-space",
+      "0",
+    ]);
+    logger.info(`Buildx cache cleanup: ${result.trim()}`);
+  }
+
+  async function availableBytes(signal?: AbortSignal): Promise<number> {
+    const run = (args: string[]) => command(args, { signal });
+    const info = await docker.info();
+    const storagePath = info.DockerRootDir as string;
+    if (!storagePath?.startsWith("/") || /[,\n]/.test(storagePath))
+      throw new Error("Cannot identify Docker storage filesystem");
+    // The helper's root filesystem measures the Engine's image snapshot
+    // storage, which can differ from DockerRootDir with containerd.
+    const output = await run([
+      "run",
+      "--rm",
+      "--network",
+      "none",
+      "--read-only",
+      "--mount",
+      `type=bind,src=${storagePath},dst=/storage,readonly`,
+      "--entrypoint",
+      "df",
+      buildkitImage,
+      "-Pk",
+      "/storage",
+      "/",
+    ]);
+    return parseAvailableBytes(output);
+  }
+
+  async function build(
+    input: NodeJS.ReadableStream,
+    dockerfile: string,
+    tags: string[],
+    labels: Record<string, string>,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    try {
+      signal?.throwIfAborted();
+      await ensureBuilder(signal);
+      let free = await availableBytes(signal);
+      if (free < policy.MinimumFreeBytes) {
+        await cleanup(signal);
+        free = await availableBytes(signal);
+      }
+      logger.info(
+        `Buildx Docker storage available=${free} minimum=${policy.MinimumFreeBytes} bytes`,
+      );
+      if (free < policy.MinimumFreeBytes)
+        throw new Error(
+          `Docker storage has ${free} free bytes, below ${policy.MinimumFreeBytes}; protected cache will not be deleted`,
+        );
+    } catch (error) {
+      (input as Readable).destroy();
+      if (signal?.aborted) throw error;
+      throw new BuildPostponedError(
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+    const args = [
+      "buildx",
+      "build",
+      "--builder",
+      name,
+      "--load",
+      "--progress",
+      "plain",
+      "--file",
+      dockerfile,
+    ];
+    for (const tag of tags) args.push("--tag", tag);
+    for (const [key, value] of Object.entries(labels))
+      args.push("--label", `${key}=${value}`);
+    args.push("-");
+    await command(args, { input, signal, progress: true });
+  }
+
+  logger.info(
+    `Buildx enabled: retention=${policy.CacheRetentionHours}h cacheTarget=${policy.CacheTargetBytes} minimumFree=${policy.MinimumFreeBytes} bytes; settings apply after restart`,
+  );
+  return { build, cleanup, availableBytes, name, directory };
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -141,7 +141,7 @@ export async function getApplicationStatus(
 }
 
 export interface DaemonDeps {
-  poll(): Promise<PollApplicationResult[]>;
+  poll(signal?: AbortSignal): Promise<PollApplicationResult[]>;
   getStatus(): Promise<ApplicationStatusSnapshot>;
   getLogs(application: string, tail?: number): Promise<ApplicationLogsResult>;
   checkGitHubRepositoryAccess(
@@ -258,7 +258,7 @@ export function createDaemonDeps(
   }
 
   return {
-    poll: () => orchestrator.poll(),
+    poll: (signal) => orchestrator.poll(signal),
     getStatus: async () => ({
       applications: await Promise.all(
         settings.Applications.map((application) =>
@@ -411,6 +411,8 @@ export async function startDaemon(
   let workerRunning = false;
   let stopping = false;
   let pollInProgress = false;
+  const pollCancellation = new AbortController();
+  let activePoll: Promise<PollApplicationResult[]> | undefined;
   let shutdownPromise: Promise<void> | undefined;
   let mcpServer: McpServerHandle | undefined;
 
@@ -429,9 +431,22 @@ export async function startDaemon(
   function shutdown(): Promise<void> {
     if (shutdownPromise) return shutdownPromise;
     stopping = true;
+    pollCancellation.abort();
     clearInterval(timer);
     for (const socket of sockets) socket.destroy();
     shutdownPromise = Promise.all([
+      activePoll === undefined
+        ? undefined
+        : new Promise<void>((resolve) => {
+            // Git transport is not cancellable; shutdown still has a finite bound.
+            const timeout = setTimeout(resolve, 6000);
+            void activePoll!
+              .catch((error: unknown) => logError(logger, error))
+              .finally(() => {
+                clearTimeout(timeout);
+                resolve();
+              });
+          }),
       close(server),
       // A stuck MCP server must not hold up the shutdown a client just asked
       // for, and must not be what fails it. The socket teardown is the one
@@ -517,13 +532,15 @@ export async function startDaemon(
           }
           pollInProgress = true;
           try {
-            const applications = await deps.poll();
+            activePoll = deps.poll(pollCancellation.signal);
+            const applications = await activePoll;
             if (!isConfigurationCurrent()) {
               return configurationChangedResponse();
             }
             return { ok: true, applications, configuration: "current" };
           } finally {
             pollInProgress = false;
+            activePoll = undefined;
           }
       }
     } catch (error) {

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -12,6 +12,7 @@ import DockerIgnore from "@balena/dockerignore";
 import Dockerode from "dockerode";
 import { pack } from "tar-fs";
 
+import { createBuildx } from "./buildx.js";
 import { decodeContainerLog, limitLogBytes } from "./containerLogs.js";
 import {
   containerLogConfig,
@@ -82,6 +83,7 @@ export interface PiployDockerService {
   ensureImageExists(
     application: Application,
     commit: GitCommit,
+    signal?: AbortSignal,
   ): Promise<EnsureImageResult>;
   ensureContainerRunning(
     application: Application,
@@ -402,6 +404,9 @@ export function createDockerService(
   logger: Logger,
 ): PiployDockerService {
   const docker = new Dockerode();
+  const buildx = settings.Buildx?.Enabled
+    ? createBuildx(settings, docker, logger)
+    : undefined;
 
   async function findImage(
     reference: string,
@@ -448,6 +453,7 @@ export function createDockerService(
   async function ensureImageExists(
     application: Application,
     commit: GitCommit,
+    signal?: AbortSignal,
   ): Promise<EnsureImageResult> {
     const commitTag = getImageVersionTagCommit(application.Name, commit);
     const existingImage = await findImage(commitTag);
@@ -473,32 +479,53 @@ export function createDockerService(
 
     const uniqueId = crypto.randomUUID();
     logger.info(`Building docker image for commit ${commit.hash}`);
-    const buildStream = await buildImage(
-      docker,
-      createBuildContext(buildPaths),
-      {
-        dockerfile: buildPaths.dockerfilePath,
-        t: [
-          getImageVersionTagLatest(application.Name),
-          commitTag,
-          getImageVersionTagUniqueId(application.Name, uniqueId),
-        ],
-        labels: {
-          [`${piploy}_buildDate`]: new Date().toISOString(),
-          [imageAppLabelName]: application.Name,
-          [imageCommitLabelName]: commit.hash,
-          [`${piploy}_uniqueId`]: uniqueId,
-          ...(settings.IsTestRun ? { [testMarkerLabelName]: "true" } : {}),
-        },
+    const started = Date.now();
+    const options: PiployImageBuildOptions = {
+      dockerfile: buildPaths.dockerfilePath,
+      t: [
+        getImageVersionTagLatest(application.Name),
+        commitTag,
+        getImageVersionTagUniqueId(application.Name, uniqueId),
+      ],
+      labels: {
+        [`${piploy}_buildDate`]: new Date().toISOString(),
+        [imageAppLabelName]: application.Name,
+        [imageCommitLabelName]: commit.hash,
+        [`${piploy}_uniqueId`]: uniqueId,
+        ...(settings.IsTestRun ? { [testMarkerLabelName]: "true" } : {}),
       },
-    );
-    await followBuildProgress(docker, buildStream, logger);
-    logger.info(`Built docker image for commit ${commit.hash}`);
+    };
+    try {
+      if (buildx) {
+        await buildx.build(
+          createBuildContext(buildPaths),
+          buildPaths.dockerfilePath,
+          options.t,
+          options.labels!,
+          signal,
+        );
+      } else {
+        const buildStream = await buildImage(
+          docker,
+          createBuildContext(buildPaths),
+          options,
+        );
+        await followBuildProgress(docker, buildStream, logger);
+      }
+    } catch (error) {
+      logger.warn(
+        `Image build did not complete; duration=${Date.now() - started}ms; current Application retained`,
+      );
+      throw error;
+    }
 
     const builtImage = await findImage(commitTag);
     if (!builtImage) {
       throw new Error(`Failed to create image for ${application.Name}`);
     }
+    logger.info(
+      `Built docker image for commit ${commit.hash}; duration=${Date.now() - started}ms`,
+    );
     return { wasCreated: true, imageId: builtImage.Id };
   }
 
@@ -748,6 +775,8 @@ export function createDockerService(
   ): Promise<Dockerode.ImageInfo[]> {
     const labelFilters = [imageAppLabelName];
     if (additionalLabel) labelFilters.push(additionalLabel);
+    else if (settings.IsTestRun)
+      labelFilters.push(`${testMarkerLabelName}=true`);
     return (
       await docker.listImages({
         all: true,
@@ -773,19 +802,58 @@ export function createDockerService(
     for (const image of images) {
       await docker.getImage(image.Id).remove({ force: true });
     }
-    await docker.pruneImages({ filters: { dangling: ["true"] } });
   }
 
   async function cleanupInactive(applications: Application[]): Promise<void> {
+    const declaredNames = new Set(
+      applications.map((application) => application.Name),
+    );
+    const containers = await docker.listContainers({ all: true });
+    for (const container of containers) {
+      const appName = container.Labels[imageAppLabelName];
+      if (
+        appName &&
+        !declaredNames.has(appName) &&
+        (container.Labels[testMarkerLabelName] === "true") ===
+          (settings.IsTestRun === true)
+      ) {
+        await docker.getContainer(container.Id).remove({ force: true });
+      }
+    }
+    // References protect a serving image even after its latest tag moves to a
+    // replacement whose container cannot be created.
+    const referencedImages = new Set(
+      (await docker.listContainers({ all: true })).map(
+        (container) => container.ImageID,
+      ),
+    );
     const latestTags = new Set(
       applications.map((application) =>
         getImageVersionTagLatest(application.Name),
       ),
     );
-    const inactiveImages = (await getPiployImages()).filter(
-      (image) => !image.RepoTags?.some((tag) => latestTags.has(tag)),
-    );
-    await stopContainersAndDeleteImages(inactiveImages);
+    for (const image of await getPiployImages()) {
+      if (
+        (image.Labels[testMarkerLabelName] === "true") !==
+        (settings.IsTestRun === true)
+      )
+        continue;
+      if (
+        referencedImages.has(image.Id) ||
+        image.RepoTags?.some((tag) => latestTags.has(tag))
+      )
+        continue;
+      await docker.getImage(image.Id).remove({ force: true });
+    }
+    if (buildx) {
+      try {
+        await buildx.cleanup();
+      } catch (error) {
+        logger.warn(
+          `Buildx cache cleanup postponed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
   }
 
   async function cleanupAll(): Promise<void> {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,3 +1,4 @@
+import { BuildPostponedError } from "./buildx.js";
 import { createDockerService, PortAlreadyInUseError } from "./docker.js";
 import {
   ensureLocalRepository,
@@ -14,6 +15,7 @@ export interface OrchestratorDeps {
   ensureImageExists(
     application: Application,
     commit: { hash: string },
+    signal?: AbortSignal,
   ): Promise<void>;
   ensureContainerRunning(
     application: Application,
@@ -23,7 +25,7 @@ export interface OrchestratorDeps {
 }
 
 export interface Orchestrator {
-  poll(): Promise<PollApplicationResult[]>;
+  poll(signal?: AbortSignal): Promise<PollApplicationResult[]>;
 }
 
 export type PollApplicationResult =
@@ -33,7 +35,7 @@ export type PollApplicationResult =
       ok: false;
       stage: PollFailureStage;
       message: string;
-      code?: "portAlreadyInUse";
+      code?: "portAlreadyInUse" | "buildPostponed";
       gitError?: GitDiagnostic;
     };
 
@@ -58,8 +60,8 @@ export function createOrchestratorDeps(
     ensureLocalRepository: (application) =>
       ensureLocalRepository(settings, application, logger),
     getLatestCommit: (application) => getLatestCommit(settings, application),
-    async ensureImageExists(application, commit) {
-      await docker.ensureImageExists(application, commit);
+    async ensureImageExists(application, commit, signal) {
+      await docker.ensureImageExists(application, commit, signal);
     },
     async ensureContainerRunning(application, commit) {
       await docker.ensureContainerRunning(application, commit);
@@ -73,13 +75,14 @@ export function createOrchestrator(
   logger: Logger,
   deps: OrchestratorDeps = createOrchestratorDeps(settings, logger),
 ): Orchestrator {
-  async function poll(): Promise<PollApplicationResult[]> {
+  async function poll(signal?: AbortSignal): Promise<PollApplicationResult[]> {
     const pollLogger = logger.child({ operation: "poll" });
     pollLogger.info("Polling applications");
     const results: PollApplicationResult[] = [];
 
     try {
       for (const application of settings.Applications) {
+        if (signal?.aborted) break;
         const applicationLogger = pollLogger.child({
           application: application.Name,
         });
@@ -90,7 +93,9 @@ export function createOrchestrator(
           await deps.ensureLocalRepository(application);
           const commit = await deps.getLatestCommit(application);
           stage = "build";
-          await deps.ensureImageExists(application, commit);
+          signal?.throwIfAborted();
+          await deps.ensureImageExists(application, commit, signal);
+          signal?.throwIfAborted();
           stage = "start";
           await deps.ensureContainerRunning(application, commit);
           results.push({ application: application.Name, ok: true });
@@ -104,7 +109,8 @@ export function createOrchestrator(
             stage,
             message: gitError?.message ?? errorMessage(error),
             ...(gitError === undefined ? {} : { gitError }),
-            ...(error instanceof PortAlreadyInUseError
+            ...(error instanceof PortAlreadyInUseError ||
+            error instanceof BuildPostponedError
               ? { code: error.code }
               : {}),
           });
@@ -112,7 +118,7 @@ export function createOrchestrator(
       }
     } finally {
       pollLogger.info("Cleaning up unused images");
-      await deps.cleanupInactive(settings.Applications);
+      if (!signal?.aborted) await deps.cleanupInactive(settings.Applications);
     }
 
     return results;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -118,6 +118,28 @@ const PiploySettingsSchema = z.object({
   Applications: z.array(ApplicationSchema),
   GitHubOwnerCredentials: GitHubOwnerCredentialsSchema.optional(),
   IsTestRun: z.boolean().optional(),
+  Buildx: z
+    .object({
+      Enabled: z.boolean().default(false),
+      CacheRetentionHours: z
+        .number()
+        .min(1 / 3600)
+        .max(876000)
+        .default(720),
+      CacheTargetBytes: z
+        .number()
+        .int()
+        .positive()
+        .safe()
+        .default(8 * 1024 ** 3),
+      MinimumFreeBytes: z
+        .number()
+        .int()
+        .positive()
+        .safe()
+        .default(5 * 1024 ** 3),
+    })
+    .optional(),
 });
 
 const ConfigFileSchema = z.object({

--- a/test/integration/buildx.test.ts
+++ b/test/integration/buildx.test.ts
@@ -1,0 +1,448 @@
+import { Readable } from "node:stream";
+import { promisify } from "node:util";
+import { mkdtemp, mkdir, writeFile, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execFile, execFileSync } from "node:child_process";
+
+import Dockerode from "dockerode";
+import { afterAll, expect, it, vi } from "vitest";
+
+import { createDockerService } from "../../src/docker.js";
+import {
+  BuildPostponedError,
+  buildkitImage,
+  createBuildx,
+} from "../../src/buildx.js";
+import { startGitFixtureRemote } from "./helpers/gitFixture.js";
+import { parseSettings } from "../../src/settings.js";
+import type { Logger } from "../../src/logger.js";
+
+const temporary = await mkdtemp(path.join(os.tmpdir(), "piploy-buildx-"));
+const previousConfig = process.env.PIPLOY_CONFIG;
+process.env.PIPLOY_CONFIG = path.join(temporary, "piploy.json");
+const messages: string[] = [];
+let progress: ((message: string) => void) | undefined;
+const logger: Logger = {
+  debug: (m) => {
+    messages.push(m);
+    progress?.(m);
+  },
+  info: (m) => {
+    messages.push(m);
+    progress?.(m);
+  },
+  warn: (m) => messages.push(m),
+  error: (m) => messages.push(m),
+  child: () => logger,
+};
+const application = {
+  Name: `buildx${crypto.randomUUID().replaceAll("-", "")}`,
+  GitRepositoryUrl: "https://example.invalid/test",
+  DockerfilePath: "Dockerfile",
+};
+const settings = parseSettings({
+  Piploy: {
+    RootDirectory: path.join(temporary, "root"),
+    Applications: [application],
+    IsTestRun: true,
+    Buildx: {
+      Enabled: true,
+      MinimumFreeBytes: 1,
+    },
+  },
+});
+const engine = new Dockerode();
+const service = createDockerService(settings, logger);
+const builder = createBuildx(settings, engine, logger);
+const unrelatedBuilder = `unrelated-${crypto.randomUUID()}`;
+let unrelatedCreated = false;
+const repo = path.join(settings.RootDirectory, application.Name, "repo");
+await mkdir(repo, { recursive: true });
+
+function cli(args: string[]): string {
+  return execFileSync("docker", args, {
+    encoding: "utf8",
+    env: { ...process.env, BUILDX_CONFIG: builder.directory },
+    timeout: 120000,
+  });
+}
+
+afterAll(async () => {
+  await service.cleanupTestCreated();
+  if (unrelatedCreated) cli(["buildx", "rm", unrelatedBuilder]);
+  const container = await engine
+    .getContainer(`buildx_buildkit_${builder.name}0`)
+    .inspect()
+    .catch(() => undefined);
+  if (
+    container?.Config.Env?.some((value) =>
+      value.startsWith("PIPLOY_BUILDER_OWNER="),
+    )
+  )
+    cli(["buildx", "rm", builder.name]);
+  if (previousConfig === undefined) delete process.env.PIPLOY_CONFIG;
+  else process.env.PIPLOY_CONFIG = previousConfig;
+  await rm(temporary, { recursive: true, force: true });
+});
+
+it("builds and reuses persistent cache across commit tags and Poll cleanup", async () => {
+  await writeFile(
+    path.join(repo, "Dockerfile"),
+    'FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc AS dependencies\nCOPY dependency /dependency\nRUN echo dependency-marker && cp /dependency /installed\nFROM dependencies AS application\nCOPY source /source\nRUN echo source-marker && cat /source > /result\nCMD ["sleep", "3600"]\n',
+  );
+  await writeFile(path.join(repo, "dependency"), "one");
+  await writeFile(path.join(repo, "source"), "one");
+  const first = { hash: crypto.randomUUID() };
+  const image = await service.ensureImageExists(application, first);
+  expect(image.wasCreated).toBe(true);
+  console.info(
+    "Cache fixture cold:",
+    messages.find((line) => line.includes("Built docker image")),
+  );
+  expect(await service.ensureImageExists(application, first)).toEqual({
+    wasCreated: false,
+    imageId: image.imageId,
+  });
+  await service.cleanupInactive([application]);
+  messages.length = 0;
+  await service.ensureImageExists(application, { hash: crypto.randomUUID() });
+  expect(messages.join("\n")).toContain("CACHED");
+  console.info(
+    "Cache fixture unchanged:",
+    messages.find((line) => line.includes("Built docker image")),
+  );
+  expect(await builder.availableBytes()).toBeGreaterThan(0);
+}, 240000);
+
+it("resumes interrupted builder recreation using the owned retained volume", async () => {
+  const volumeName = `buildx_buildkit_${builder.name}0_state`;
+  const before = await engine.getVolume(volumeName).inspect();
+  expect(before.Labels.piploy_builderOwner).toBeDefined();
+  // Reproduce process termination after rm succeeds but before create runs.
+  cli(["buildx", "rm", "--keep-state", builder.name]);
+  const previousPath = process.env.PATH;
+  try {
+    process.env.PATH = temporary;
+    await expect(
+      service.ensureImageExists(application, { hash: crypto.randomUUID() }),
+    ).rejects.toThrow("Cannot execute Docker CLI");
+  } finally {
+    process.env.PATH = previousPath;
+  }
+  messages.length = 0;
+  const resumed = createDockerService(settings, logger);
+  await resumed.ensureImageExists(application, { hash: crypto.randomUUID() });
+  expect(cached("dependency-marker")).toBe(true);
+  expect(cached("source-marker")).toBe(true);
+  const after = await engine.getVolume(volumeName).inspect();
+  expect(before).toHaveProperty("CreatedAt");
+  expect(after).toEqual(before);
+}, 240000);
+
+function cached(marker: string): boolean {
+  const instruction = messages.find((line) =>
+    line.includes(`RUN echo ${marker}`),
+  );
+  const step = instruction?.match(/#\d+/)?.[0];
+  return !!step && messages.some((line) => line.includes(`${step} CACHED`));
+}
+
+it("reuses dependencies on source changes and reversion, and invalidates them on dependency changes", async () => {
+  for (const [file, value, dependenciesCached, sourceCached] of [
+    ["source", "two", true, false],
+    ["source", "one", true, true],
+    ["dependency", "two", false, false],
+  ] as const) {
+    await writeFile(path.join(repo, file), value);
+    await service.cleanupInactive([application]);
+    messages.length = 0;
+    await service.ensureImageExists(application, { hash: crypto.randomUUID() });
+    expect(cached("dependency-marker")).toBe(dependenciesCached);
+    expect(cached("source-marker")).toBe(sourceCached);
+    console.info(
+      `Cache fixture ${file}=${value}:`,
+      messages.find((line) => line.includes("Built docker image")),
+    );
+    expect(messages.some((line) => /duration=\d+ms/.test(line))).toBe(true);
+  }
+}, 240000);
+
+it("postpones low-space builds, permits same-commit reuse, and builds after capacity is available", async () => {
+  const previous = { hash: crypto.randomUUID() };
+  const image = await service.ensureImageExists(application, previous);
+  const started = await service.ensureContainerRunning(application, previous);
+  const limited = createDockerService(
+    {
+      ...settings,
+      Buildx: {
+        ...settings.Buildx!,
+        MinimumFreeBytes: Number.MAX_SAFE_INTEGER,
+      },
+    },
+    logger,
+  );
+  expect(await limited.ensureImageExists(application, previous)).toEqual({
+    wasCreated: false,
+    imageId: image.imageId,
+  });
+  const next = { hash: crypto.randomUUID() };
+  await expect(
+    limited.ensureImageExists(application, next),
+  ).rejects.toBeInstanceOf(BuildPostponedError);
+  expect(
+    (await engine.getContainer(started.containerId).inspect()).State.Running,
+  ).toBe(true);
+  expect((await service.ensureImageExists(application, next)).wasCreated).toBe(
+    true,
+  );
+}, 240000);
+
+it("postpones a build when the Engine storage filesystem cannot be measured", async () => {
+  const actualInfo = await engine.info();
+  const measurementFailure = vi.spyOn(engine, "info").mockResolvedValue({
+    ...actualInfo,
+    DockerRootDir: `/nonexistent-${crypto.randomUUID()}`,
+  });
+  try {
+    await expect(
+      builder.build(Readable.from([]), "Dockerfile", [], {}),
+    ).rejects.toBeInstanceOf(BuildPostponedError);
+  } finally {
+    measurementFailure.mockRestore();
+  }
+});
+
+it("propagates Dockerfile failures and cancellation without replacing the serving container", async () => {
+  const before = await service.getDockerStatus(application);
+  await writeFile(
+    path.join(repo, "Dockerfile"),
+    "FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc\nRUN exit 42\n",
+  );
+  await expect(
+    service.ensureImageExists(application, { hash: crypto.randomUUID() }),
+  ).rejects.toThrow("operation failed");
+  await writeFile(
+    path.join(repo, "Dockerfile"),
+    "FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc\nRUN sleep 300\n",
+  );
+  const controller = new AbortController();
+  progress = (message) => {
+    if (message.includes("RUN sleep 300")) controller.abort();
+  };
+  try {
+    await expect(
+      service.ensureImageExists(
+        application,
+        { hash: crypto.randomUUID() },
+        controller.signal,
+      ),
+    ).rejects.toThrow("cancelled");
+  } finally {
+    progress = undefined;
+  }
+  expect(
+    (await service.getDockerStatus(application)).runningContainerHash,
+  ).toBe(before.runningContainerHash);
+}, 240000);
+
+it("protects recent cache under GC pressure and reclaims old cache with an explicit age filter", async () => {
+  await writeFile(
+    path.join(repo, "Dockerfile"),
+    "FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc\nRUN echo retention-marker > /retention\n",
+  );
+  const protectedSettings = {
+    ...settings,
+    Buildx: { ...settings.Buildx!, CacheTargetBytes: 1 },
+  };
+  const protectedService = createDockerService(protectedSettings, logger);
+  const protectedBuilder = createBuildx(protectedSettings, engine, logger);
+  await protectedService.ensureImageExists(application, {
+    hash: crypto.randomUUID(),
+  });
+  const records = () =>
+    cli(["buildx", "du", "--builder", builder.name, "--format", "{{json .}}"])
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            ID: string;
+            Description: string;
+            Reclaimable: boolean;
+          },
+      );
+  const protectedIds = records()
+    .filter((record) => record.Reclaimable)
+    .map((record) => record.ID);
+  expect(protectedIds.length).toBeGreaterThan(0);
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+  await protectedBuilder.cleanup();
+  expect(records().map((record) => record.ID)).toEqual(
+    expect.arrayContaining(protectedIds),
+  );
+  const shortSettings = {
+    ...settings,
+    Buildx: {
+      ...settings.Buildx!,
+      CacheRetentionHours: 1 / 3600,
+      CacheTargetBytes: 1,
+    },
+  };
+  const shortBuilder = createBuildx(shortSettings, engine, logger);
+  await shortBuilder.cleanup();
+  expect(records().map((record) => record.ID)).not.toEqual(
+    expect.arrayContaining(protectedIds),
+  );
+  expect((await service.getDockerStatus(application)).container?.state).toBe(
+    "running",
+  );
+}, 240000);
+
+it("reclaims eligible cache through automatic GC without removing Engine images", async () => {
+  const automaticSettings = {
+    ...settings,
+    Buildx: {
+      ...settings.Buildx!,
+      CacheRetentionHours: 1 / 3600,
+      CacheTargetBytes: 1,
+    },
+  };
+  const automaticService = createDockerService(automaticSettings, logger);
+  await writeFile(
+    path.join(repo, "Dockerfile"),
+    "FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc\nRUN echo automatic-marker > /automatic\n",
+  );
+  const image = await automaticService.ensureImageExists(application, {
+    hash: crypto.randomUUID(),
+  });
+  const records = () =>
+    cli(["buildx", "du", "--builder", builder.name, "--format", "{{json .}}"])
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as { ID: string; Reclaimable: boolean });
+  const before = records()
+    .filter((record) => record.Reclaimable)
+    .map((record) => record.ID);
+  expect(before.length).toBeGreaterThan(0);
+  await new Promise((resolve) => setTimeout(resolve, 2500));
+  await writeFile(
+    path.join(repo, "Dockerfile"),
+    "FROM scratch\nCOPY source /source\n",
+  );
+  await automaticService.ensureImageExists(application, {
+    hash: crypto.randomUUID(),
+  });
+  const deadline = Date.now() + 90000;
+  while (
+    Date.now() < deadline &&
+    before.every((id) => records().some((record) => record.ID === id))
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+  expect(
+    before.every((id) => records().some((record) => record.ID === id)),
+  ).toBe(false);
+  expect((await engine.getImage(image.imageId).inspect()).Id).toBe(
+    image.imageId,
+  );
+}, 240000);
+
+it("refuses mismatched ownership and missing CLI prerequisites without changing containers", async () => {
+  const metadataPath = path.join(builder.directory, "instances", builder.name);
+  const original = await readFile(metadataPath, "utf8");
+  const container = await engine
+    .getContainer(`buildx_buildkit_${builder.name}0`)
+    .inspect();
+  try {
+    const metadata = JSON.parse(original);
+    metadata.Nodes[0].DriverOpts["env.PIPLOY_BUILDER_OWNER"] = "someone-else";
+    await writeFile(metadataPath, JSON.stringify(metadata));
+    await expect(
+      service.ensureImageExists(application, { hash: crypto.randomUUID() }),
+    ).rejects.toThrow("ownership");
+    expect((await engine.getContainer(container.Id).inspect()).Id).toBe(
+      container.Id,
+    );
+  } finally {
+    await writeFile(metadataPath, original);
+  }
+  const previousPath = process.env.PATH;
+  try {
+    process.env.PATH = temporary;
+    await expect(
+      service.ensureImageExists(application, { hash: crypto.randomUUID() }),
+    ).rejects.toThrow("Cannot execute Docker CLI");
+  } finally {
+    process.env.PATH = previousPath;
+  }
+});
+
+it("leaves an unrelated builder and its cache intact during owned cleanup", async () => {
+  const fixture = path.join(temporary, "unrelated");
+  await mkdir(fixture);
+  await writeFile(
+    path.join(fixture, "Dockerfile"),
+    "FROM scratch\nCOPY marker /marker\n",
+  );
+  await writeFile(path.join(fixture, "marker"), "unrelated");
+  cli([
+    "buildx",
+    "create",
+    "--name",
+    unrelatedBuilder,
+    "--driver",
+    "docker-container",
+    "--driver-opt",
+    `image=${buildkitImage}`,
+  ]);
+  unrelatedCreated = true;
+  cli(["buildx", "build", "--builder", unrelatedBuilder, fixture]);
+  const before = cli([
+    "buildx",
+    "du",
+    "--builder",
+    unrelatedBuilder,
+    "--format",
+    "{{.ID}}",
+  ]);
+  await builder.cleanup();
+  expect(
+    cli(["buildx", "du", "--builder", unrelatedBuilder, "--format", "{{.ID}}"]),
+  ).toBe(before);
+}, 240000);
+
+it("runs Buildx through the installed single-file bundle during a real Poll", async () => {
+  const remote = await startGitFixtureRemote();
+  try {
+    const hash = remote.commit({
+      Dockerfile:
+        'FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc\nRUN echo bundle-marker > /marker\nCMD ["sleep", "3600"]\n',
+    });
+    const bundledApplication = {
+      ...application,
+      Name: `${application.Name}bundle`,
+      GitRepositoryUrl: remote.url,
+    };
+    await writeFile(
+      process.env.PIPLOY_CONFIG!,
+      JSON.stringify({
+        Piploy: { ...settings, Applications: [bundledApplication] },
+      }),
+    );
+    const result = await promisify(execFile)(
+      process.execPath,
+      [path.resolve("dist/piploy.cjs"), "poll"],
+      { env: process.env, timeout: 120000 },
+    );
+    expect(result.stdout).toContain("bundle-marker");
+    expect(result.stdout).toContain("Built docker image");
+    expect(
+      (await service.getDockerStatus(bundledApplication)).runningContainerHash,
+    ).toBe(hash);
+  } finally {
+    await remote.close();
+  }
+}, 240000);

--- a/test/integration/docker.test.ts
+++ b/test/integration/docker.test.ts
@@ -253,10 +253,14 @@ describe("docker adapter", () => {
       wasStarted: true,
       containerId: started.containerId,
     });
+    const replacementCommit = { hash: crypto.randomUUID().replaceAll("-", "") };
+    const replacementImage = await docker.ensureImageExists(
+      application,
+      replacementCommit,
+    );
+    expect(replacementImage.imageId).not.toBe(built.imageId);
     await expect(
-      docker.ensureContainerRunning(application, {
-        hash: crypto.randomUUID().replaceAll("-", ""),
-      }),
+      docker.ensureContainerRunning(application, replacementCommit),
     ).rejects.toThrow(
       `Host environment variable '${hostEnvironmentName}' is not set`,
     );
@@ -264,6 +268,14 @@ describe("docker adapter", () => {
       .getContainer(started.containerId)
       .inspect();
     expect(afterFailedRecreation.Id).toBe(started.containerId);
+    await docker.cleanupInactive(settings.Applications);
+    expect(
+      (await new Dockerode().getContainer(started.containerId).inspect()).State
+        .Running,
+    ).toBe(true);
+    expect((await new Dockerode().getImage(built.imageId).inspect()).Id).toBe(
+      built.imageId,
+    );
     expect(loggedMessages.join("\n")).not.toContain(hostEnvironmentSecret);
     expect(
       JSON.stringify(await docker.getDockerStatus(application)),

--- a/test/unit/buildx.test.ts
+++ b/test/unit/buildx.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildkitConfiguration,
+  parseAvailableBytes,
+} from "../../src/buildx.js";
+import { parseSettings } from "../../src/settings.js";
+
+const base = { RootDirectory: "/tmp/root", Applications: [] };
+
+describe("Buildx configuration", () => {
+  it("keeps existing installations opted out and defaults to the protected retention policy", () => {
+    expect(parseSettings({ Piploy: base }).Buildx).toBeUndefined();
+    expect(parseSettings({ Piploy: { ...base, Buildx: {} } }).Buildx).toEqual({
+      Enabled: false,
+      CacheRetentionHours: 720,
+      CacheTargetBytes: 8589934592,
+      MinimumFreeBytes: 5368709120,
+    });
+  });
+  it.each([0, -1, NaN, Infinity, Number.MAX_SAFE_INTEGER + 1, "100"])(
+    "rejects invalid storage limits %s",
+    (value) => {
+      for (const field of ["CacheTargetBytes", "MinimumFreeBytes"])
+        expect(() =>
+          parseSettings({ Piploy: { ...base, Buildx: { [field]: value } } }),
+        ).toThrow();
+    },
+  );
+  it("has one age-protected automatic GC policy and no unprotected fallback", () => {
+    const config = buildkitConfiguration(720, 8589934592, 5368709120);
+    expect(config.match(/\[\[worker.oci.gcpolicy\]\]/g)).toHaveLength(1);
+    expect(config).toContain('keepDuration = "2592000s"');
+    expect(config).toContain("maxUsedSpace = 8589934592");
+    expect(config).toContain("minFreeSpace = 5368709120");
+  });
+});
+
+describe("Docker storage measurement", () => {
+  it("reads the available column in 1024-byte units", () => {
+    expect(
+      parseAvailableBytes(
+        "Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/vda 1000 600 400 60% /storage\n",
+      ),
+    ).toBe(409600);
+  });
+  it.each([
+    "",
+    "permission denied",
+    "header\n/dev/vda 1000 600 nope 60% /storage",
+    "header\n/dev/vda 1000 600 -1 60% /storage",
+  ])("rejects unreliable output", (output) => {
+    expect(() => parseAvailableBytes(output)).toThrow();
+  });
+});
+
+it("uses the lower capacity when Docker data and image snapshots use different filesystems", () => {
+  expect(
+    parseAvailableBytes(
+      "Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/vda 1000 600 400 60% /storage\noverlay 1000 900 100 90% /\n",
+    ),
+  ).toBe(102400);
+});

--- a/test/unit/daemon.test.ts
+++ b/test/unit/daemon.test.ts
@@ -412,7 +412,10 @@ describe("daemon", () => {
           "piploy.sock",
         ),
         pollIntervalMinutes: 60,
-        deps: createDaemonDeps(accessSettings, logger),
+        deps: {
+          ...createDaemonDeps(accessSettings, logger),
+          poll: async () => [],
+        },
         ...noTailscale,
       });
       daemons.push(daemon);
@@ -983,6 +986,28 @@ describe("daemon", () => {
 
       expect(events).toEqual(["poll", "poll"]);
     });
+  });
+
+  it("cancels and awaits an active Poll when the daemon stops", async () => {
+    let receivedSignal: AbortSignal | undefined;
+    let completed = false;
+    const daemon = await start({
+      getLogs: noLogs,
+      poll: async (signal) => {
+        receivedSignal = signal;
+        await new Promise<void>((resolve) =>
+          signal!.addEventListener("abort", () => resolve(), { once: true }),
+        );
+        completed = true;
+        return [];
+      },
+      getStatus: async () => ({ applications: [] }),
+      attemptSelfUpdate: async () => "up-to-date",
+    });
+    await vi.waitFor(() => expect(receivedSignal).toBeDefined());
+    await daemon.stop();
+    expect(receivedSignal!.aborted).toBe(true);
+    expect(completed).toBe(true);
   });
 
   describe("isDaemonListening", () => {

--- a/test/unit/orchestrator.test.ts
+++ b/test/unit/orchestrator.test.ts
@@ -1,3 +1,4 @@
+import { BuildPostponedError } from "../../src/buildx.js";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -217,4 +218,38 @@ describe("orchestrator", () => {
       { application: "second", ok: true },
     ]);
   });
+});
+
+it("retries a postponed build on the next Poll without starting a replacement early", async () => {
+  const deps = createDeps();
+  deps.ensureImageExists = vi
+    .fn()
+    .mockRejectedValueOnce(new BuildPostponedError("low storage"))
+    .mockResolvedValue(undefined);
+  const orchestrator = createOrchestrator(
+    { ...settings, Applications: [applications[0]!] },
+    createLogger(),
+    deps,
+  );
+  expect(await orchestrator.poll()).toMatchObject([
+    { ok: false, stage: "build", code: "buildPostponed" },
+  ]);
+  expect(deps.ensureContainerRunning).not.toHaveBeenCalled();
+  expect(await orchestrator.poll()).toMatchObject([{ ok: true }]);
+  expect(deps.ensureContainerRunning).toHaveBeenCalledTimes(1);
+});
+
+it("passes cancellation to builds and skips replacement and cleanup after shutdown", async () => {
+  const deps = createDeps();
+  const controller = new AbortController();
+  deps.ensureImageExists = vi.fn(async (_application, _commit, signal) => {
+    expect(signal).toBe(controller.signal);
+    controller.abort();
+  });
+  await createOrchestrator(settings, createLogger(), deps).poll(
+    controller.signal,
+  );
+  expect(deps.ensureImageExists).toHaveBeenCalledTimes(1);
+  expect(deps.ensureContainerRunning).not.toHaveBeenCalled();
+  expect(deps.cleanupInactive).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
Adds opt-in Buildx Application builds with a dedicated, verified builder, persistent cache, and storage checks before new builds. Defaults protect cache used within 30 days, target 8 GiB, and postpone new builds below 5 GiB free. Existing installations continue using Dockerode until explicit activation.

Application-image cleanup preserves serving containers and their images when replacement fails. The rollout runbook covers setup, verified image recovery archives, and rollback with Polls and automatic updates paused. The approved infrastructure exception pins upstream BuildKit 0.32.0 by digest without expanding Application Dockerfile rules.

Validation passed:

- `pnpm lint`
- `pnpm test`: 253 tests
- `pnpm build`, including clean-install bundle checks
- `pnpm test:integration`: 54 real integration tests, including cache reuse/invalidation, explicit and automatic GC, low-space retry, cancellation, interrupted builder recreation, unrelated-resource preservation, and a Poll through the built bundle

Docker integration ran on AMD64. The owner supplied compatible ARM64 Pi prerequisite checks; production activation and observation remain in #140.

Closes #139

Co authored by GPT-6 - default in Codex
