### PR TITLE
Select Application images by build settings and exact ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,3 +350,25 @@ will remain in systemd's restart loop until it is rolled back manually.
 ## TODO
 
 - Git commit hook + minimal web server on the Pi to receive the hook so Piploy does not have to poll.
+
+## Image reuse and upgrades
+
+Piploy identifies a build by a versioned hash of the configured repository URL,
+exact Git commit, normalized Dockerfile path, and effective build context.
+Omitting `BuildContextPath` still uses the Dockerfile's parent directory.
+Equivalent normalized paths reuse the same image. Runtime settings such as
+ports, Volumes, and environment variables do not change build identity.
+
+Each Poll selects an image with matching build metadata and passes its exact
+Docker image ID to container creation. Container reuse and concurrent-create
+adoption require that ID as well as the commit and runtime configuration.
+Compatibility tags remain available, but a commit tag alone cannot establish
+image reuse. Both Dockerode and opt-in Buildx follow this contract.
+
+The first Poll after upgrading may rebuild legacy images that lack build
+identity metadata and briefly interrupt Applications during normal container
+replacement. No configuration migration is required. A failed or postponed
+build leaves the current container running. Cleanup protects images referenced
+by containers, including after a replacement build moves the latest tag.
+Downgrading restores the older Bundle's incomplete reuse behavior and does
+not retain this fix.

--- a/docs/adr/0002-module-seams-and-test-split.md
+++ b/docs/adr/0002-module-seams-and-test-split.md
@@ -3,7 +3,8 @@
 ## Decision
 
 `dockerPlan.ts` contains the pure Docker decision policy. Given image or
-container state, a Git commit, and a runtime-configuration hash, `planImage` and `planContainer` select
+container state, a versioned build identity, an exact image ID, a Git commit,
+and a runtime-configuration hash, `planImage` and `planContainer` select
 `reuse`, `build`, `start`, or `recreate`; unit tests exercise these functions
 with plain values. `docker.ts` is the I/O adapter around dockerode and applies
 that policy while also handling cleanup.
@@ -55,3 +56,17 @@ and Application-image cleanup. Builder state is separate from Application
 images. Normal cleanup preserves every image referenced by a container and
 never invokes a global prune. A successful build does not imply successful
 container replacement.
+
+Build identity hashes the configured repository URL verbatim, exact commit,
+normalized Dockerfile path, and effective context. URL aliases are deliberately
+not combined, because different configured URLs may identify different sources.
+The serialized identity carries a version, and only its hash is stored in image
+labels and tags. Runtime-only settings remain in the container hash. Omitted
+context retains the Dockerfile-parent default. Both builders use this policy.
+
+Image reuse requires matching identity metadata. The build's unique tag locates
+and validates its result, so another build moving a compatibility tag cannot
+select the wrong result. The orchestrator carries the selected image ID into
+container creation. Ordinary reuse and concurrent-create adoption compare that
+ID alongside existing runtime checks. Legacy commit tags alone are cache misses.
+See [upgrade behavior](../../README.md#image-reuse-and-upgrades).

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -19,6 +19,7 @@ import {
   containerPortBindingHostIps,
   containerRestartPolicy,
   getBuildContextPathFromSetting,
+  getBuildIdentity,
   getContainerConfigHash,
   getDockerfilePathFromSetting,
   planContainer,
@@ -35,6 +36,7 @@ import { getApplicationRepoDirectory, getVolumeDirectory } from "./settings.js";
 const piploy = "piploy";
 const imageAppLabelName = `${piploy}_appName`;
 const imageCommitLabelName = `${piploy}_gitTipCommit`;
+const imageBuildIdentityLabelName = `${piploy}_buildIdentity`;
 const containerConfigLabelName = `${piploy}_configHash`;
 const testMarkerLabelName = `${piploy}_isCreatedByTest`;
 
@@ -88,6 +90,7 @@ export interface PiployDockerService {
   ensureContainerRunning(
     application: Application,
     commit: GitCommit,
+    imageId: string,
   ): Promise<EnsureContainerResult>;
   getDockerStatus(application: Application): Promise<DockerStatus>;
   /** Resolves to `undefined` when the Application has no container at all. */
@@ -151,6 +154,7 @@ function asDockerContainer(
 ): DockerContainer {
   return {
     id: container.Id,
+    imageId: container.ImageID,
     state: container.State,
     gitTipCommit: container.Labels[imageCommitLabelName],
     configHash: container.Labels[containerConfigLabelName],
@@ -456,9 +460,25 @@ export function createDockerService(
     signal?: AbortSignal,
   ): Promise<EnsureImageResult> {
     const commitTag = getImageVersionTagCommit(application.Name, commit);
-    const existingImage = await findImage(commitTag);
+    const buildIdentity = getBuildIdentity(
+      application.GitRepositoryUrl,
+      commit.hash,
+      application.DockerfilePath,
+      application.BuildContextPath,
+    );
+    const identityTag = getImageVersionTag(
+      application.Name,
+      `b_${buildIdentity}`,
+    );
+    const existingImage = await findImage(identityTag);
     const imagePlan = planImage(
-      existingImage ? { id: existingImage.Id } : undefined,
+      existingImage
+        ? {
+            id: existingImage.Id,
+            buildIdentity: existingImage.Labels?.[imageBuildIdentityLabelName],
+          }
+        : undefined,
+      buildIdentity,
     );
     if (imagePlan.action === "reuse") {
       return { wasCreated: false, imageId: imagePlan.imageId };
@@ -478,6 +498,7 @@ export function createDockerService(
     }
 
     const uniqueId = crypto.randomUUID();
+    const uniqueTag = getImageVersionTagUniqueId(application.Name, uniqueId);
     logger.info(`Building docker image for commit ${commit.hash}`);
     const started = Date.now();
     const options: PiployImageBuildOptions = {
@@ -485,12 +506,14 @@ export function createDockerService(
       t: [
         getImageVersionTagLatest(application.Name),
         commitTag,
-        getImageVersionTagUniqueId(application.Name, uniqueId),
+        uniqueTag,
+        identityTag,
       ],
       labels: {
         [`${piploy}_buildDate`]: new Date().toISOString(),
         [imageAppLabelName]: application.Name,
         [imageCommitLabelName]: commit.hash,
+        [imageBuildIdentityLabelName]: buildIdentity,
         [`${piploy}_uniqueId`]: uniqueId,
         ...(settings.IsTestRun ? { [testMarkerLabelName]: "true" } : {}),
       },
@@ -519,8 +542,11 @@ export function createDockerService(
       throw error;
     }
 
-    const builtImage = await findImage(commitTag);
-    if (!builtImage) {
+    const builtImage = await findImage(uniqueTag);
+    if (
+      !builtImage ||
+      builtImage.Labels?.[imageBuildIdentityLabelName] !== buildIdentity
+    ) {
       throw new Error(`Failed to create image for ${application.Name}`);
     }
     logger.info(
@@ -532,6 +558,7 @@ export function createDockerService(
   async function ensureContainerRunning(
     application: Application,
     commit: GitCommit,
+    imageId: string,
   ): Promise<EnsureContainerResult> {
     const containerName = getContainerName(application);
     const existingContainer = await findContainer(containerName);
@@ -551,6 +578,7 @@ export function createDockerService(
       existingContainer ? asDockerContainer(existingContainer) : undefined,
       commit.hash,
       configHash,
+      imageId,
     );
 
     if (containerPlan.action === "reuse") {
@@ -626,7 +654,7 @@ export function createDockerService(
     let createdContainer: Dockerode.Container;
     try {
       createdContainer = await docker.createContainer({
-        Image: getImageVersionTagCommit(application.Name, commit),
+        Image: imageId,
         name: containerName,
         Env: environment,
         ExposedPorts: exposedPorts,
@@ -660,6 +688,7 @@ export function createDockerService(
         racedContainer ? asDockerContainer(racedContainer) : undefined,
         commit.hash,
         configHash,
+        imageId,
       );
       if (racedPlan.action === "fail") throw error;
 

--- a/src/dockerPlan.ts
+++ b/src/dockerPlan.ts
@@ -3,10 +3,12 @@ import path from "node:path";
 
 export interface DockerImage {
   id: string;
+  buildIdentity?: string;
 }
 
 export interface DockerContainer {
   id: string;
+  imageId: string;
   state: string;
   gitTipCommit?: string;
   configHash?: string;
@@ -74,8 +76,36 @@ export const containerRestartPolicy = { Name: "unless-stopped" } as const;
 /** Every published application port stays reachable only from this Pi. */
 export const containerPortBindingHostIps = ["127.0.0.1", "::1"] as const;
 
-export function planImage(existingImage?: DockerImage): ImagePlan {
-  return existingImage
+export function getBuildIdentity(
+  repository: string,
+  commit: string,
+  dockerfileSetting: string,
+  contextSetting?: string,
+): string {
+  const dockerfile = getDockerfilePathFromSetting(dockerfileSetting);
+  const identity = {
+    version: 1,
+    repository,
+    commit,
+    dockerfile: path.posix.join(
+      dockerfile.contextDirectory,
+      dockerfile.dockerfileName,
+    ),
+    context:
+      contextSetting === undefined
+        ? path.posix
+            .normalize(dockerfile.contextDirectory || ".")
+            .replace(/\/$/, "")
+        : getBuildContextPathFromSetting(contextSetting).replace(/\/$/, ""),
+  };
+  return `v1_${createHash("sha256").update(JSON.stringify(identity)).digest("hex")}`;
+}
+
+export function planImage(
+  existingImage: DockerImage | undefined,
+  buildIdentity: string,
+): ImagePlan {
+  return existingImage?.buildIdentity === buildIdentity
     ? { action: "reuse", imageId: existingImage.id }
     : { action: "build" };
 }
@@ -84,6 +114,7 @@ export function planContainer(
   existingContainer: DockerContainer | undefined,
   gitTipCommit: string,
   configHash: string,
+  imageId: string,
 ): ContainerPlan {
   if (!existingContainer) {
     return { action: "recreate" };
@@ -91,7 +122,8 @@ export function planContainer(
 
   if (
     existingContainer.gitTipCommit === gitTipCommit &&
-    existingContainer.configHash === configHash
+    existingContainer.configHash === configHash &&
+    existingContainer.imageId === imageId
   ) {
     if (
       existingContainer.state === "running" ||
@@ -112,20 +144,22 @@ export function planContainer(
  * name-conflict create failure. Unlike planContainer, an unusable state here
  * does not mean "recreate": the caller has already lost the create race, so
  * removing this container would only invite another conflict. A container
- * whose labels match the requested commit and config is exactly the one this
- * call wanted, and is started (a race winner is not yet running the instant
- * after Docker registers its name) unless it already is. A mismatch, or no
+ * whose image ID and labels match the requested image, commit and config is
+ * the one this call wanted. A race winner may not be running yet, so it is
+ * started unless already running. A mismatch, or no
  * container at all, means the name conflict was real, not benign.
  */
 export function planRacedContainer(
   existingContainer: DockerContainer | undefined,
   gitTipCommit: string,
   configHash: string,
+  imageId: string,
 ): RacedContainerPlan {
   if (
     !existingContainer ||
     existingContainer.gitTipCommit !== gitTipCommit ||
-    existingContainer.configHash !== configHash
+    existingContainer.configHash !== configHash ||
+    existingContainer.imageId !== imageId
   ) {
     return { action: "fail" };
   }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -16,10 +16,11 @@ export interface OrchestratorDeps {
     application: Application,
     commit: { hash: string },
     signal?: AbortSignal,
-  ): Promise<void>;
+  ): Promise<{ imageId: string }>;
   ensureContainerRunning(
     application: Application,
     commit: { hash: string },
+    imageId: string,
   ): Promise<void>;
   cleanupInactive(applications: Application[]): Promise<void>;
 }
@@ -61,10 +62,10 @@ export function createOrchestratorDeps(
       ensureLocalRepository(settings, application, logger),
     getLatestCommit: (application) => getLatestCommit(settings, application),
     async ensureImageExists(application, commit, signal) {
-      await docker.ensureImageExists(application, commit, signal);
+      return docker.ensureImageExists(application, commit, signal);
     },
-    async ensureContainerRunning(application, commit) {
-      await docker.ensureContainerRunning(application, commit);
+    async ensureContainerRunning(application, commit, imageId) {
+      await docker.ensureContainerRunning(application, commit, imageId);
     },
     cleanupInactive: (applications) => docker.cleanupInactive(applications),
   };
@@ -94,10 +95,14 @@ export function createOrchestrator(
           const commit = await deps.getLatestCommit(application);
           stage = "build";
           signal?.throwIfAborted();
-          await deps.ensureImageExists(application, commit, signal);
+          const image = await deps.ensureImageExists(
+            application,
+            commit,
+            signal,
+          );
           signal?.throwIfAborted();
           stage = "start";
-          await deps.ensureContainerRunning(application, commit);
+          await deps.ensureContainerRunning(application, commit, image.imageId);
           results.push({ application: application.Name, ok: true });
         } catch (error) {
           const gitError =

--- a/test/integration/buildx.test.ts
+++ b/test/integration/buildx.test.ts
@@ -1,3 +1,4 @@
+import { verifyBuildIdentity } from "./helpers/buildIdentity.js";
 import { Readable } from "node:stream";
 import { promisify } from "node:util";
 import { mkdtemp, mkdir, writeFile, readFile, rm } from "node:fs/promises";
@@ -171,7 +172,11 @@ it("reuses dependencies on source changes and reversion, and invalidates them on
 it("postpones low-space builds, permits same-commit reuse, and builds after capacity is available", async () => {
   const previous = { hash: crypto.randomUUID() };
   const image = await service.ensureImageExists(application, previous);
-  const started = await service.ensureContainerRunning(application, previous);
+  const started = await service.ensureContainerRunning(
+    application,
+    previous,
+    image.imageId,
+  );
   const limited = createDockerService(
     {
       ...settings,
@@ -186,14 +191,23 @@ it("postpones low-space builds, permits same-commit reuse, and builds after capa
     wasCreated: false,
     imageId: image.imageId,
   });
-  const next = { hash: crypto.randomUUID() };
-  await expect(
-    limited.ensureImageExists(application, next),
-  ).rejects.toBeInstanceOf(BuildPostponedError);
+  const next = previous;
+  await writeFile(
+    path.join(repo, "Replacement"),
+    await readFile(path.join(repo, "Dockerfile")),
+  );
+  const changed = { ...application, DockerfilePath: "Replacement" };
+  await expect(limited.ensureImageExists(changed, next)).rejects.toBeInstanceOf(
+    BuildPostponedError,
+  );
   expect(
     (await engine.getContainer(started.containerId).inspect()).State.Running,
   ).toBe(true);
-  expect((await service.ensureImageExists(application, next)).wasCreated).toBe(
+  await limited.cleanupInactive([application]);
+  expect((await engine.getImage(image.imageId).inspect()).Id).toBe(
+    image.imageId,
+  );
+  expect((await service.ensureImageExists(changed, next)).wasCreated).toBe(
     true,
   );
 }, 240000);
@@ -445,4 +459,8 @@ it("runs Buildx through the installed single-file bundle during a real Poll", as
   } finally {
     await remote.close();
   }
+}, 240000);
+
+it("uses build identity and exact image IDs through Poll", async () => {
+  await verifyBuildIdentity(settings, logger);
 }, 240000);

--- a/test/integration/docker.test.ts
+++ b/test/integration/docker.test.ts
@@ -1,5 +1,6 @@
+import { verifyBuildIdentity } from "./helpers/buildIdentity.js";
 import { existsSync } from "node:fs";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, writeFile, copyFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -130,10 +131,11 @@ describe("docker adapter", () => {
       'FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc\nRUN printf \'%s\\n\' \'#!/bin/sh\' \'printf "HTTP/1.1 200 OK\\\\r\\\\nContent-Length: 14\\\\r\\\\n\\\\r\\\\nloopback-only\\\\n"\' > /response && chmod +x /response\nCMD ["nc", "-lk", "-p", "8080", "-e", "/response"]\n',
     );
 
-    await docker.ensureImageExists(portApplication, commit);
+    const portImage = await docker.ensureImageExists(portApplication, commit);
     const started = await docker.ensureContainerRunning(
       portApplication,
       commit,
+      portImage.imageId,
     );
     const inspect = await new Dockerode()
       .getContainer(started.containerId)
@@ -186,7 +188,11 @@ describe("docker adapter", () => {
       imageId: built.imageId,
     });
 
-    const started = await docker.ensureContainerRunning(application, commit);
+    const started = await docker.ensureContainerRunning(
+      application,
+      commit,
+      built.imageId,
+    );
     expect(started).toMatchObject({ wasCreated: true, wasStarted: true });
     expect(
       existsSync(
@@ -222,7 +228,9 @@ describe("docker adapter", () => {
         ],
       }),
     );
-    expect(await docker.ensureContainerRunning(application, commit)).toEqual({
+    expect(
+      await docker.ensureContainerRunning(application, commit, built.imageId),
+    ).toEqual({
       wasCreated: false,
       wasStarted: false,
       containerId: started.containerId,
@@ -242,13 +250,17 @@ describe("docker adapter", () => {
     // Reuse and start make no host-environment read, while a failed recreate
     // checks before removing the current container.
     delete process.env[hostEnvironmentName];
-    expect(await docker.ensureContainerRunning(application, commit)).toEqual({
+    expect(
+      await docker.ensureContainerRunning(application, commit, built.imageId),
+    ).toEqual({
       wasCreated: false,
       wasStarted: false,
       containerId: started.containerId,
     });
     await new Dockerode().getContainer(started.containerId).stop();
-    expect(await docker.ensureContainerRunning(application, commit)).toEqual({
+    expect(
+      await docker.ensureContainerRunning(application, commit, built.imageId),
+    ).toEqual({
       wasCreated: false,
       wasStarted: true,
       containerId: started.containerId,
@@ -260,7 +272,11 @@ describe("docker adapter", () => {
     );
     expect(replacementImage.imageId).not.toBe(built.imageId);
     await expect(
-      docker.ensureContainerRunning(application, replacementCommit),
+      docker.ensureContainerRunning(
+        application,
+        replacementCommit,
+        replacementImage.imageId,
+      ),
     ).rejects.toThrow(
       `Host environment variable '${hostEnvironmentName}' is not set`,
     );
@@ -298,8 +314,15 @@ describe("docker adapter", () => {
       'FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc\nCMD ["sh", "-c", "echo crashing-on-boot >&2; exit 3"]\n',
     );
 
-    await docker.ensureImageExists(crashingApplication, crashingCommit);
-    await docker.ensureContainerRunning(crashingApplication, crashingCommit);
+    const crashImage = await docker.ensureImageExists(
+      crashingApplication,
+      crashingCommit,
+    );
+    await docker.ensureContainerRunning(
+      crashingApplication,
+      crashingCommit,
+      crashImage.imageId,
+    );
 
     // The restart policy keeps the container alive as a slot, so it is seen
     // either mid-restart or between attempts. Both carry the last exit code.
@@ -348,15 +371,23 @@ describe("docker adapter", () => {
       );
     }
 
-    await docker.ensureImageExists(shortApplication, shortCommit);
-    await docker.ensureImageExists(longApplication, longCommit);
+    const shortImage = await docker.ensureImageExists(
+      shortApplication,
+      shortCommit,
+    );
+    const longImage = await docker.ensureImageExists(
+      longApplication,
+      longCommit,
+    );
     const longStarted = await docker.ensureContainerRunning(
       longApplication,
       longCommit,
+      longImage.imageId,
     );
     const shortStarted = await docker.ensureContainerRunning(
       shortApplication,
       shortCommit,
+      shortImage.imageId,
     );
 
     const shortRecreated = await docker.ensureContainerRunning(
@@ -365,6 +396,7 @@ describe("docker adapter", () => {
         EnvironmentVariables: { VERSION: "updated" },
       },
       shortCommit,
+      shortImage.imageId,
     );
 
     expect(shortRecreated.containerId).not.toBe(shortStarted.containerId);
@@ -472,14 +504,22 @@ describe("docker adapter", () => {
     );
 
     const raceCommit = { hash: crypto.randomUUID().replaceAll("-", "") };
-    await docker.ensureImageExists(raceApplication, raceCommit);
+    let raceImage = await docker.ensureImageExists(raceApplication, raceCommit);
 
     // Two pollers racing to create the SAME version: the loser must detect
     // that the winner already created exactly the container it wanted, and
     // adopt it instead of failing.
     const sameVersionResults = await Promise.all([
-      docker.ensureContainerRunning(raceApplication, raceCommit),
-      docker.ensureContainerRunning(raceApplication, raceCommit),
+      docker.ensureContainerRunning(
+        raceApplication,
+        raceCommit,
+        raceImage.imageId,
+      ),
+      docker.ensureContainerRunning(
+        raceApplication,
+        raceCommit,
+        raceImage.imageId,
+      ),
     ]);
     expect(sameVersionResults[0].containerId).toBe(
       sameVersionResults[1].containerId,
@@ -488,16 +528,31 @@ describe("docker adapter", () => {
 
     await docker.cleanupTestCreated();
 
-    // Two pollers racing to create DIFFERENT versions: the loser must not
+    // Two pollers racing to create DIFFERENT images at the same commit: the loser must not
     // silently adopt the winner's container, since that would leave the
     // wrong version running while reporting success.
-    const otherCommit = { hash: crypto.randomUUID().replaceAll("-", "") };
-    await docker.ensureImageExists(raceApplication, raceCommit);
-    await docker.ensureImageExists(raceApplication, otherCommit);
+    const otherCommit = raceCommit;
+    await copyFile(
+      path.join(repoDirectory, "Dockerfile"),
+      path.join(repoDirectory, "Otherfile"),
+    );
+    raceImage = await docker.ensureImageExists(raceApplication, raceCommit);
+    const otherImage = await docker.ensureImageExists(
+      { ...raceApplication, DockerfilePath: "Otherfile" },
+      otherCommit,
+    );
 
     const mismatchedResults = await Promise.allSettled([
-      docker.ensureContainerRunning(raceApplication, raceCommit),
-      docker.ensureContainerRunning(raceApplication, otherCommit),
+      docker.ensureContainerRunning(
+        raceApplication,
+        raceCommit,
+        raceImage.imageId,
+      ),
+      docker.ensureContainerRunning(
+        raceApplication,
+        otherCommit,
+        otherImage.imageId,
+      ),
     ]);
     expect(
       mismatchedResults.filter((r) => r.status === "fulfilled"),
@@ -517,17 +572,32 @@ describe("docker adapter", () => {
     // failure, and both must land on the same replacement container.
     const upgradeFromCommit = { hash: crypto.randomUUID().replaceAll("-", "") };
     const upgradeToCommit = { hash: crypto.randomUUID().replaceAll("-", "") };
-    await docker.ensureImageExists(raceApplication, upgradeFromCommit);
-    await docker.ensureImageExists(raceApplication, upgradeToCommit);
+    const upgradeFromImage = await docker.ensureImageExists(
+      raceApplication,
+      upgradeFromCommit,
+    );
+    const upgradeToImage = await docker.ensureImageExists(
+      raceApplication,
+      upgradeToCommit,
+    );
     const upgradeFromResult = await docker.ensureContainerRunning(
       raceApplication,
       upgradeFromCommit,
+      upgradeFromImage.imageId,
     );
     expect(upgradeFromResult.wasCreated).toBe(true);
 
     const upgradeResults = await Promise.all([
-      docker.ensureContainerRunning(raceApplication, upgradeToCommit),
-      docker.ensureContainerRunning(raceApplication, upgradeToCommit),
+      docker.ensureContainerRunning(
+        raceApplication,
+        upgradeToCommit,
+        upgradeToImage.imageId,
+      ),
+      docker.ensureContainerRunning(
+        raceApplication,
+        upgradeToCommit,
+        upgradeToImage.imageId,
+      ),
     ]);
     expect(upgradeResults[0].containerId).toBe(upgradeResults[1].containerId);
     expect(upgradeResults[0].containerId).not.toBe(
@@ -537,3 +607,7 @@ describe("docker adapter", () => {
     await docker.cleanupTestCreated();
   });
 });
+
+it("uses build identity and exact image IDs through Poll", async () => {
+  await verifyBuildIdentity(settings, logger);
+}, 240000);

--- a/test/integration/helpers/buildIdentity.ts
+++ b/test/integration/helpers/buildIdentity.ts
@@ -1,0 +1,196 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import Dockerode from "dockerode";
+import { pack } from "tar-fs";
+import { expect, vi } from "vitest";
+
+import {
+  createDockerService,
+  type EnsureImageResult,
+} from "../../../src/docker.js";
+import { getBuildIdentity } from "../../../src/dockerPlan.js";
+import { createOrchestrator } from "../../../src/orchestrator.js";
+import type { Logger } from "../../../src/logger.js";
+import type { Application, PiploySettings } from "../../../src/settings.js";
+
+/** Exercises the same Poll contract against either real builder. */
+export async function verifyBuildIdentity(
+  settings: PiploySettings,
+  logger: Logger,
+): Promise<void> {
+  const application: Application = {
+    Name: `identity${crypto.randomUUID().replaceAll("-", "")}`,
+    GitRepositoryUrl: "https://example.invalid/identity.git",
+    DockerfilePath: "nested/One",
+  };
+  const configured = {
+    ...settings,
+    Applications: [...settings.Applications, application],
+  };
+  const service = createDockerService(configured, logger);
+  const engine = new Dockerode();
+  const commit = { hash: "a".repeat(40) };
+  const repo = path.join(settings.RootDirectory, application.Name, "repo");
+  await mkdir(path.join(repo, "nested"), { recursive: true });
+  const base =
+    "alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc";
+  for (const [file, marker] of [
+    ["One", "one"],
+    ["Two", "two"],
+  ]) {
+    await writeFile(
+      path.join(repo, "nested", file!),
+      `FROM ${base}\nCOPY marker /marker\nCMD ["sh", "-c", "echo ${marker}; cat /marker; exec sleep 3600"]\n`,
+    );
+  }
+  await writeFile(
+    path.join(repo, "nested", "Broken"),
+    `FROM ${base}\nCOPY missing /missing\n`,
+  );
+  await writeFile(path.join(repo, "nested", "marker"), "nested-output\n");
+  await writeFile(path.join(repo, "marker"), "root-output\n");
+
+  // A pre-upgrade image has only the old ownership metadata and commit tag.
+  const commitTag = `piploy/${application.Name}:g_${commit.hash}`;
+  const legacyStream = await engine.buildImage(
+    pack(path.join(repo, "nested")),
+    {
+      dockerfile: "One",
+      t: commitTag,
+      labels: {
+        piploy_appName: application.Name,
+        piploy_gitTipCommit: commit.hash,
+        piploy_isCreatedByTest: "true",
+      },
+    },
+  );
+  await new Promise<void>((resolve, reject) => {
+    engine.modem.followProgress(legacyStream, (error) =>
+      error ? reject(error) : resolve(),
+    );
+  });
+  const legacy = await engine.getImage(commitTag).inspect();
+  await engine
+    .getImage(legacy.Id)
+    .tag({ repo: `piploy/${application.Name}`, tag: "v_legacy" });
+  let selected: EnsureImageResult | undefined;
+  let running: string | undefined;
+  const poll = async () => {
+    const result = await createOrchestrator(
+      { ...configured, Applications: [application] },
+      logger,
+      {
+        ensureLocalRepository: async () => {},
+        getLatestCommit: async () => commit,
+        ensureImageExists: async (current, tip, signal) => {
+          selected = await service.ensureImageExists(current, tip, signal);
+          return selected;
+        },
+        ensureContainerRunning: async (current, tip, imageId) => {
+          running = (
+            await service.ensureContainerRunning(current, tip, imageId)
+          ).containerId;
+        },
+        cleanupInactive: () => service.cleanupInactive(configured.Applications),
+      },
+    ).poll();
+    return result;
+  };
+  const output = async (expected: string) => {
+    await vi.waitFor(async () => {
+      const logs = (await service.getContainerLogs(application, 10))?.text;
+      for (const line of expected.split("\n")) {
+        expect(logs).toContain(` ${line}\n`);
+      }
+    });
+    expect((await engine.getContainer(running!).inspect()).Image).toBe(
+      selected!.imageId,
+    );
+  };
+
+  expect(await poll()).toEqual([{ application: application.Name, ok: true }]);
+  expect(selected!.wasCreated).toBe(true);
+  expect(selected!.imageId).not.toBe(legacy.Id);
+  await output("one\nnested-output");
+  const firstImage = selected!.imageId;
+  const firstContainer = running;
+  expect(await poll()).toMatchObject([{ ok: true }]);
+  expect(selected).toEqual({ wasCreated: false, imageId: firstImage });
+  expect(running).toBe(firstContainer);
+  application.DockerfilePath = " /nested\\.\\One ";
+  application.BuildContextPath = "./nested//";
+  expect(await poll()).toMatchObject([{ ok: true }]);
+  expect(selected).toEqual({ wasCreated: false, imageId: firstImage });
+  expect(running).toBe(firstContainer);
+
+  application.EnvironmentVariables = { RUNTIME_ONLY: "changed" };
+  expect(await poll()).toMatchObject([{ ok: true }]);
+  expect(selected).toEqual({ wasCreated: false, imageId: firstImage });
+  expect(running).not.toBe(firstContainer);
+  expect((await engine.getContainer(running!).inspect()).Config.Env).toContain(
+    "RUNTIME_ONLY=changed",
+  );
+
+  application.DockerfilePath = "nested/Two";
+  expect(await poll()).toMatchObject([{ ok: true }]);
+  expect(selected!.wasCreated).toBe(true);
+  expect(selected!.imageId).not.toBe(firstImage);
+  await output("two\nnested-output");
+  const nestedImage = selected!.imageId;
+  const nestedContainer = running!;
+  await expect(engine.getImage(firstImage).inspect()).rejects.toThrow();
+
+  application.BuildContextPath = ".";
+  const rootImage = await service.ensureImageExists(application, commit);
+  expect(rootImage.wasCreated).toBe(true);
+  expect(rootImage.imageId).not.toBe(nestedImage);
+  await service.cleanupInactive(configured.Applications);
+  expect((await engine.getImage(nestedImage).inspect()).Id).toBe(nestedImage);
+  expect(
+    (await engine.getContainer(nestedContainer).inspect()).State.Running,
+  ).toBe(true);
+
+  // Moving compatibility tags must not change the image passed to creation.
+  await engine
+    .getImage(nestedImage)
+    .tag({ repo: `piploy/${application.Name}`, tag: `g_${commit.hash}` });
+  await engine
+    .getImage(nestedImage)
+    .tag({ repo: `piploy/${application.Name}`, tag: "latest" });
+  running = (
+    await service.ensureContainerRunning(application, commit, rootImage.imageId)
+  ).containerId;
+  expect(running).not.toBe(nestedContainer);
+  selected = rootImage;
+  await output("two\nroot-output");
+  expect(await poll()).toMatchObject([{ ok: true }]);
+  expect(selected).toEqual({ wasCreated: false, imageId: rootImage.imageId });
+  const rootContainer = running;
+
+  application.DockerfilePath = "nested/Broken";
+  expect(await poll()).toMatchObject([{ ok: false, stage: "build" }]);
+  expect(
+    (await engine.getContainer(rootContainer!).inspect()).State.Running,
+  ).toBe(true);
+  expect((await engine.getImage(rootImage.imageId).inspect()).Id).toBe(
+    rootImage.imageId,
+  );
+
+  // An identity tag is insufficient when its image metadata does not match.
+  application.DockerfilePath = "nested/Two";
+  const identity = getBuildIdentity(
+    application.GitRepositoryUrl,
+    commit.hash,
+    application.DockerfilePath,
+    application.BuildContextPath,
+  );
+  await engine
+    .getImage(nestedImage)
+    .tag({ repo: `piploy/${application.Name}`, tag: `b_${identity}` });
+  expect(await poll()).toMatchObject([{ ok: true }]);
+  expect(selected!.wasCreated).toBe(true);
+  await output("two\nroot-output");
+  await engine.getContainer(running!).remove({ force: true });
+  await service.cleanupInactive(settings.Applications);
+}

--- a/test/unit/dockerPlan.test.ts
+++ b/test/unit/dockerPlan.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   getContainerConfigHash,
+  getBuildIdentity,
   getBuildContextPathFromSetting,
   getDockerfilePathFromSetting,
   planContainer,
@@ -17,14 +18,19 @@ const digest = "a".repeat(64);
 
 describe("planImage", () => {
   it("reuses an image already built for the commit", () => {
-    expect(planImage({ id: "sha256:existing" })).toEqual({
+    expect(
+      planImage(
+        { id: "sha256:existing", buildIdentity: "v1_expected" },
+        "v1_expected",
+      ),
+    ).toEqual({
       action: "reuse",
       imageId: "sha256:existing",
     });
   });
 
   it("builds when the commit image does not exist", () => {
-    expect(planImage()).toEqual({ action: "build" });
+    expect(planImage(undefined, "v1_expected")).toEqual({ action: "build" });
   });
 });
 
@@ -34,17 +40,29 @@ describe("planContainer", () => {
   it.each([
     [undefined, { action: "recreate" }],
     [
-      { id: "container", state: "running", gitTipCommit: "other" },
+      {
+        id: "container",
+        imageId: "sha256:selected",
+        state: "running",
+        gitTipCommit: "other",
+      },
       { action: "recreate", existingContainerId: "container" },
     ],
     [
-      { id: "container", state: "created", gitTipCommit: "commit" },
+      {
+        id: "container",
+        imageId: "sha256:selected",
+        state: "created",
+        gitTipCommit: "commit",
+      },
       { action: "recreate", existingContainerId: "container" },
     ],
   ] as const)(
     "recreates when the current container is not usable",
     (container, expected) => {
-      expect(planContainer(container, "commit", configHash)).toEqual(expected);
+      expect(
+        planContainer(container, "commit", configHash, "sha256:selected"),
+      ).toEqual(expected);
     },
   );
 
@@ -53,12 +71,14 @@ describe("planContainer", () => {
       planContainer(
         {
           id: "container",
+          imageId: "sha256:selected",
           state: "running",
           gitTipCommit: "commit",
           configHash,
         },
         "commit",
         configHash,
+        "sha256:selected",
       ),
     ).toEqual({ action: "reuse", containerId: "container" });
   });
@@ -68,12 +88,14 @@ describe("planContainer", () => {
       planContainer(
         {
           id: "container",
+          imageId: "sha256:selected",
           state: "restarting",
           gitTipCommit: "commit",
           configHash,
         },
         "commit",
         configHash,
+        "sha256:selected",
       ),
     ).toEqual({ action: "reuse", containerId: "container" });
   });
@@ -83,12 +105,14 @@ describe("planContainer", () => {
       planContainer(
         {
           id: "container",
+          imageId: "sha256:selected",
           state: "exited",
           gitTipCommit: "commit",
           configHash,
         },
         "commit",
         configHash,
+        "sha256:selected",
       ),
     ).toEqual({ action: "start", containerId: "container" });
   });
@@ -98,6 +122,7 @@ describe("planContainer", () => {
       planContainer(
         {
           id: "container",
+          imageId: "sha256:selected",
           state: "running",
           gitTipCommit: "commit",
           configHash: getContainerConfigHash({
@@ -108,6 +133,7 @@ describe("planContainer", () => {
         getContainerConfigHash({
           portMappings: [{ hostPort: 9090, containerPort: 80 }],
         }),
+        "sha256:selected",
       ),
     ).toEqual({ action: "recreate", existingContainerId: "container" });
   });
@@ -173,12 +199,14 @@ describe("planContainer", () => {
       planContainer(
         {
           id: "container",
+          imageId: "sha256:selected",
           state: "running",
           gitTipCommit: "commit",
           configHash: legacyMappedHash,
         },
         "commit",
         getContainerConfigHash({ portMappings: mappings }),
+        "sha256:selected",
       ),
     ).toEqual({ action: "recreate", existingContainerId: "container" });
   });
@@ -225,7 +253,9 @@ describe("planRacedContainer", () => {
   const configHash = getContainerConfigHash({});
 
   it("fails when no container won the race", () => {
-    expect(planRacedContainer(undefined, "commit", configHash)).toEqual({
+    expect(
+      planRacedContainer(undefined, "commit", configHash, "sha256:selected"),
+    ).toEqual({
       action: "fail",
     });
   });
@@ -235,12 +265,14 @@ describe("planRacedContainer", () => {
       planRacedContainer(
         {
           id: "container",
+          imageId: "sha256:selected",
           state: "running",
           gitTipCommit: "other",
           configHash,
         },
         "commit",
         configHash,
+        "sha256:selected",
       ),
     ).toEqual({ action: "fail" });
   });
@@ -250,6 +282,7 @@ describe("planRacedContainer", () => {
       planRacedContainer(
         {
           id: "container",
+          imageId: "sha256:selected",
           state: "running",
           gitTipCommit: "commit",
           configHash: getContainerConfigHash({
@@ -258,6 +291,7 @@ describe("planRacedContainer", () => {
         },
         "commit",
         configHash,
+        "sha256:selected",
       ),
     ).toEqual({ action: "fail" });
   });
@@ -267,12 +301,14 @@ describe("planRacedContainer", () => {
       planRacedContainer(
         {
           id: "container",
+          imageId: "sha256:selected",
           state: "running",
           gitTipCommit: "commit",
           configHash,
         },
         "commit",
         configHash,
+        "sha256:selected",
       ),
     ).toEqual({ action: "adopt", containerId: "container" });
   });
@@ -282,12 +318,14 @@ describe("planRacedContainer", () => {
       planRacedContainer(
         {
           id: "container",
+          imageId: "sha256:selected",
           state: "restarting",
           gitTipCommit: "commit",
           configHash,
         },
         "commit",
         configHash,
+        "sha256:selected",
       ),
     ).toEqual({ action: "adopt", containerId: "container" });
   });
@@ -297,9 +335,16 @@ describe("planRacedContainer", () => {
     (state) => {
       expect(
         planRacedContainer(
-          { id: "container", state, gitTipCommit: "commit", configHash },
+          {
+            id: "container",
+            imageId: "sha256:selected",
+            state,
+            gitTipCommit: "commit",
+            configHash,
+          },
           "commit",
           configHash,
+          "sha256:selected",
         ),
       ).toEqual({ action: "start", containerId: "container" });
     },
@@ -499,3 +544,59 @@ describe("validateDockerfileImageReferences", () => {
     },
   );
 });
+
+describe("build identity", () => {
+  const identity = (
+    dockerfile = "nested/Dockerfile",
+    context?: string,
+    repository = "https://example.test/project.git",
+    commit = "abc123",
+  ) => getBuildIdentity(repository, commit, dockerfile, context);
+
+  it("normalizes equivalent paths and preserves the omitted parent context", () => {
+    expect(identity()).toMatch(/^v1_[a-f0-9]{64}$/);
+    expect(identity(" /nested\\.\\Dockerfile ")).toBe(identity());
+    expect(identity("nested//Dockerfile")).toBe(identity());
+    expect(identity("nested/Dockerfile", "./nested//")).toBe(identity());
+    expect(identity("Dockerfile")).toBe(identity("./Dockerfile", "."));
+    expect(identity("nested/Dockerfile", ".")).not.toBe(identity());
+  });
+
+  it("distinguishes Dockerfile, repository and exact commit", () => {
+    expect(identity("nested/Otherfile")).not.toBe(identity());
+    expect(
+      identity(undefined, undefined, "https://example.test/other.git"),
+    ).not.toBe(identity());
+    expect(identity(undefined, undefined, undefined, "abc1234")).not.toBe(
+      identity(),
+    );
+  });
+
+  it.each([undefined, "", "v0_old", "v1_other"])(
+    "rejects absent or mismatched image metadata %s",
+    (buildIdentity) => {
+      expect(
+        planImage({ id: "sha256:legacy", buildIdentity }, identity()),
+      ).toEqual({ action: "build" });
+    },
+  );
+});
+
+it.each(["running", "restarting", "exited", "created"])(
+  "does not reuse or adopt a different image in state %s",
+  (state) => {
+    const container = {
+      id: "container",
+      imageId: "sha256:other",
+      state,
+      gitTipCommit: "commit",
+      configHash: "config",
+    };
+    expect(
+      planContainer(container, "commit", "config", "sha256:selected"),
+    ).toEqual({ action: "recreate", existingContainerId: "container" });
+    expect(
+      planRacedContainer(container, "commit", "config", "sha256:selected"),
+    ).toEqual({ action: "fail" });
+  },
+);

--- a/test/unit/orchestrator.test.ts
+++ b/test/unit/orchestrator.test.ts
@@ -43,7 +43,7 @@ function createDeps(): OrchestratorDeps {
   return {
     ensureLocalRepository: vi.fn(),
     getLatestCommit: vi.fn(async () => ({ hash: "abc123" })),
-    ensureImageExists: vi.fn(),
+    ensureImageExists: vi.fn(async () => ({ imageId: "sha256:selected" })),
     ensureContainerRunning: vi.fn(),
     cleanupInactive: vi.fn(),
   };
@@ -62,10 +62,13 @@ describe("orchestrator", () => {
     });
     deps.ensureImageExists = vi.fn(async (application, commit) => {
       calls.push(`image:${application.Name}:${commit.hash}`);
+      return { imageId: `sha256:${application.Name}` };
     });
-    deps.ensureContainerRunning = vi.fn(async (application, commit) => {
-      calls.push(`container:${application.Name}:${commit.hash}`);
-    });
+    deps.ensureContainerRunning = vi.fn(
+      async (application, commit, imageId) => {
+        calls.push(`container:${application.Name}:${commit.hash}:${imageId}`);
+      },
+    );
     deps.cleanupInactive = vi.fn(
       async (configuredApplications: Application[]) => {
         calls.push(
@@ -80,11 +83,11 @@ describe("orchestrator", () => {
       "repository:first",
       "commit:first",
       "image:first:first",
-      "container:first:first",
+      "container:first:first:sha256:first",
       "repository:second",
       "commit:second",
       "image:second:second",
-      "container:second:second",
+      "container:second:second:sha256:second",
       "cleanup:first,second",
     ]);
   });
@@ -96,14 +99,19 @@ describe("orchestrator", () => {
     logger.error = (message) => errors.push(message);
     deps.ensureImageExists = vi.fn(async (application) => {
       if (application.Name === "first") throw new Error("build failed");
+      return { imageId: "sha256:selected" };
     });
 
     const results = await createOrchestrator(settings, logger, deps).poll();
 
     expect(deps.ensureContainerRunning).toHaveBeenCalledTimes(1);
-    expect(deps.ensureContainerRunning).toHaveBeenCalledWith(applications[1], {
-      hash: "abc123",
-    });
+    expect(deps.ensureContainerRunning).toHaveBeenCalledWith(
+      applications[1],
+      {
+        hash: "abc123",
+      },
+      "sha256:selected",
+    );
     expect(deps.cleanupInactive).toHaveBeenCalledWith(applications);
     expect(errors).toEqual(["build failed"]);
     expect(results).toEqual([
@@ -225,7 +233,7 @@ it("retries a postponed build on the next Poll without starting a replacement ea
   deps.ensureImageExists = vi
     .fn()
     .mockRejectedValueOnce(new BuildPostponedError("low storage"))
-    .mockResolvedValue(undefined);
+    .mockResolvedValue({ imageId: "sha256:selected" });
   const orchestrator = createOrchestrator(
     { ...settings, Applications: [applications[0]!] },
     createLogger(),
@@ -245,6 +253,7 @@ it("passes cancellation to builds and skips replacement and cleanup after shutdo
   deps.ensureImageExists = vi.fn(async (_application, _commit, signal) => {
     expect(signal).toBe(controller.signal);
     controller.abort();
+    return { imageId: "sha256:selected" };
   });
   await createOrchestrator(settings, createLogger(), deps).poll(
     controller.signal,


### PR DESCRIPTION
Changing an Application's Dockerfile or effective build context at the same Git commit now selects a new image. Image reuse requires matching versioned build metadata, and Poll passes the selected image ID into container creation and concurrent-create checks. Runtime-only changes reuse the image. Existing tags, configuration, and both build backends remain supported.

The first Poll after upgrading may rebuild legacy images and briefly interrupt Applications during normal replacement. No configuration migration is required. Failed or postponed builds retain the current container, and cleanup protects its image after tags move. Downgrading restores the older Bundle's incomplete reuse behavior.

Validation: lint, all 263 unit tests, and bundle verification passed. The full integration run passed 54 tests; two new assertions were corrected for timestamped logs, and both shared identity scenarios then passed against real Dockerode and Buildx builders. Coverage includes fixed-commit Dockerfile/context changes, equivalent paths, runtime-only changes, legacy images, moved tags, same-commit image races, build failures/postponements, and cleanup.

Closes #144

Co authored by GPT-6 - default in Codex
